### PR TITLE
fix: correct Claude credential wrapper filename and envelope, seed onboarding

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,9 @@
       "Read(//usr/local/bin/**)",
       "Bash(python3 *)",
       "Bash(xargs ls -la)",
-      "Bash(sed -n *)"
+      "Bash(sed -n *)",
+      "Bash(dax-creds get *)",
+      "Bash(echo \"--- exit: $? ---\")"
     ]
   },
   "disabledMcpjsonServers": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,15 @@ functions in `dax.py`.
 - **`dax-preview` GitHub-style UI**: directory listings now use a rounded file table with hover; README.md renders below the listing in a boxed panel with a book icon; a sticky left-side file tree with SVG icons, collapsible folders, and sessionStorage persistence appears on all pages (directory, .md, .json, .yaml). Folder names in the tree navigate; chevron toggles expand/collapse. Heavy dirs (.git, node_modules, etc.) are skipped. Page width auto-expands by 256px to keep content area at the configured width.
 - **GitHub host keys baked in**: all three key types (RSA, ECDSA, ed25519) written to `/etc/ssh/ssh_known_hosts` at image build time — no more `ssh-keyscan` on first use.
 
+## Backlog
+
+- **`save_config` destroys `~/.dax.yaml` comments and key order** — `dax_creds/init.py:26`
+  loads via `yaml.safe_load` and rewrites with `yaml.dump`, so comments (which
+  aren't in the parsed dict) vanish and keys get alphabetized by the default
+  `sort_keys=True`. Triggered by `dax creds add`, `dax creds update`, and
+  `dax init`. Fix: switch to `ruamel.yaml` round-trip mode; stopgap is
+  `sort_keys=False` plus a `.dax.yaml.bak` before each write.
+
 ## Notes
 
 - `safe.directory` is already set in `~/.gitconfig` — no need for `-c safe.directory=` flag in git commands.

--- a/dax_creds/init.py
+++ b/dax_creds/init.py
@@ -181,7 +181,7 @@ def _setup_claude_credential(cred_name, cred_def):
 
     token = provider.import_from_disk(cred_def)
     if token:
-        print(f'  [{cred_name}] importing existing token from ~/.claude/credentials.json')
+        print(f'  [{cred_name}] importing existing token from ~/.claude/.credentials.json')
         provider.store(cred_name, token)
         print(f'  [{cred_name}] done.')
         return

--- a/dax_creds/providers/claude.py
+++ b/dax_creds/providers/claude.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 try:
@@ -10,16 +11,42 @@ except ImportError:
 _KEYCHAIN_SERVICE = 'dax-creds'
 
 
-def _default_disk_locations():
-    home = Path.home()
-    return [
-        home / '.anthropic' / 'api_key',
-        home / '.claude' / 'credentials.json',
-    ]
+def _claude_dir():
+    return Path.home() / '.claude'
 
 
 def _default_credentials_json():
-    return Path.home() / '.claude' / 'credentials.json'
+    # Claude Code reads the dot-prefixed name. The non-dot name is ignored.
+    return _claude_dir() / '.credentials.json'
+
+
+def _legacy_credentials_json():
+    # dax wrote this name until 2026-07-27; Claude Code never read it.
+    return _claude_dir() / 'credentials.json'
+
+
+def _default_disk_locations():
+    return [
+        Path.home() / '.anthropic' / 'api_key',
+        _default_credentials_json(),
+        _legacy_credentials_json(),
+    ]
+
+
+def is_oauth_envelope(value):
+    """True if value is a Claude Code credentials blob Claude Code can refresh.
+
+    A bare access token is rejected: it authenticates until expiry and then
+    fails with no way to recover, which is worse than failing immediately.
+    """
+    try:
+        data = json.loads(value)
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    oauth = data.get('claudeAiOauth')
+    return isinstance(oauth, dict) and bool(oauth.get('refreshToken'))
 
 
 class ClaudeProvider:
@@ -35,18 +62,20 @@ class ClaudeProvider:
         return self._keyring.get_password(_KEYCHAIN_SERVICE, credential_name) is not None
 
     def import_from_disk(self, credential_def, credentials_file=None):
-        path = Path(credentials_file) if credentials_file else _default_credentials_json()
-        if not path.exists():
-            return None
-        try:
-            import json
-            with open(path) as f:
-                data = json.load(f)
-            if 'claudeAiOauth' not in data:
-                return None
-            return json.dumps(data)
-        except Exception:
-            return None
+        if credentials_file is not None:
+            candidates = [Path(credentials_file)]
+        else:
+            candidates = [_default_credentials_json(), _legacy_credentials_json()]
+        for path in candidates:
+            if not path.exists():
+                continue
+            try:
+                blob = path.read_text()
+            except OSError:
+                continue
+            if is_oauth_envelope(blob):
+                return json.dumps(json.loads(blob))
+        return None
 
     def has_disk_copy(self, credential_def, disk_locations=None):
         locations = disk_locations if disk_locations is not None else _default_disk_locations()
@@ -54,6 +83,12 @@ class ClaudeProvider:
 
     def store(self, credential_name, token):
         self._require_keyring()
+        if not is_oauth_envelope(token):
+            raise ValueError(
+                'refusing to store a Claude credential that is not a full '
+                'credentials blob with a refreshToken — Claude Code could not '
+                'refresh it. Expected {"claudeAiOauth": {..., "refreshToken": ...}}'
+            )
         self._keyring.set_password(_KEYCHAIN_SERVICE, credential_name, token)
 
     def get_token(self, credential_name):

--- a/dax_creds/wrappers/claude
+++ b/dax_creds/wrappers/claude
@@ -1,9 +1,57 @@
 #!/bin/bash
+# Fetch Claude OAuth credentials from the dax-creds daemon and write them where
+# Claude Code reads them: ~/.claude/.credentials.json (dot-prefixed).
+#
+# Failures are reported, never swallowed. A silent failure here went unnoticed
+# for a month because auth was quietly riding a host bind mount instead.
+
+# Claude Code reads its state from CLAUDE_CONFIG_DIR when that is set and from
+# ~/.claude otherwise. The two layouts disagree about .claude.json: it lives
+# *inside* CLAUDE_CONFIG_DIR, but at ~/.claude.json — not ~/.claude/.claude.json
+# — in the default layout. Getting this wrong is silent, which is how the
+# original credential-path bug survived a month.
+_dax_cfg_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+if [ -n "$CLAUDE_CONFIG_DIR" ]; then
+    _dax_state_file="$CLAUDE_CONFIG_DIR/.claude.json"
+else
+    _dax_state_file="$HOME/.claude.json"
+fi
+
 if [ -n "$DAX_CREDS_SOCK" ] && [ -n "$DAX_CREDS_CLAUDE" ]; then
-    _creds=$(dax-creds get "$DAX_CREDS_CLAUDE" 2>/dev/null)
-    if [ -n "$_creds" ]; then
-        mkdir -p ~/.claude
-        printf '%s' "$_creds" > ~/.claude/credentials.json
+    if _creds=$(dax-creds get "$DAX_CREDS_CLAUDE"); then
+        case "$_creds" in
+            *'"claudeAiOauth"'*)
+                mkdir -p "$_dax_cfg_dir"
+                ( umask 077; printf '%s' "$_creds" > "$_dax_cfg_dir/.credentials.json" )
+                ;;
+            *)
+                echo "dax: credential '$DAX_CREDS_CLAUDE' is not a Claude credentials blob" >&2
+                echo "dax: got ${#_creds} bytes, expected {\"claudeAiOauth\": {...}}" >&2
+                echo "dax: re-import on the host with:" >&2
+                echo "dax:   dax creds remove $DAX_CREDS_CLAUDE" >&2
+                echo "dax:   dax creds add    # then enter '$DAX_CREDS_CLAUDE' at the prompt" >&2
+                ;;
+        esac
+    else
+        echo "dax: could not fetch credential '$DAX_CREDS_CLAUDE' from dax-creds" >&2
     fi
 fi
-exec /usr/bin/claude-real "$@"
+
+# Without .claude.json, Claude Code runs its first-run wizard, and that wizard
+# prompts for a login method *before* anything reads .credentials.json — so a
+# perfectly good credential sits unused while the user is sent to a browser.
+# Seeding the onboarding flag is what makes the credential actually get used.
+#
+# Create-if-absent only. Claude Code owns this file and grows it to ~32KB on the
+# first run; rewriting it on every launch would destroy accumulated per-tenant
+# project state, permissions, and history.
+#
+# Only the onboarding flag is seeded. Folder trust is deliberately not set here:
+# accepting it silently activates .claude/settings.local.json permissions, which
+# is the user's call to make, not the wrapper's.
+if [ ! -e "$_dax_state_file" ]; then
+    mkdir -p "$(dirname "$_dax_state_file")"
+    ( umask 077; printf '%s' '{"hasCompletedOnboarding": true}' > "$_dax_state_file" )
+fi
+
+exec "${DAX_CLAUDE_REAL:-/usr/bin/claude-real}" "$@"

--- a/tests/manual/interactive_launch_probe.py
+++ b/tests/manual/interactive_launch_probe.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Probe Claude Code's *interactive* launch path against an isolated config dir.
+
+Why this exists
+---------------
+`claude auth status` and `claude -p` both read .credentials.json directly and
+report success against a config directory that would prompt for login the moment
+it is started interactively. Every automated test we have lives in that blind
+spot, which is how "the credential is not landing" was diagnosed for a day when
+the credential was landing fine and Claude Code was simply running its first-run
+wizard instead of looking at it.
+
+This probe drives the real launch path under a pty and classifies the outcome.
+
+Not a pytest. It needs a real credential and network access, so it is a manual
+diagnostic. The unit-level guarantees live in tests/test_dax_creds_claude_wrapper.py.
+
+Usage
+-----
+    # Does a bare credential authenticate interactively? (expect FAIL)
+    python3 tests/manual/interactive_launch_probe.py
+
+    # Does seeding the onboarding flag fix it? (expect PASS)
+    python3 tests/manual/interactive_launch_probe.py --seed
+
+    # Probe a config dir that already exists, without copying anything in
+    python3 tests/manual/interactive_launch_probe.py --config-dir ~/.claude --in-place
+
+The temporary config directory holds a real OAuth token and is deleted on exit
+unless --keep is passed.
+"""
+import argparse
+import json
+import os
+import pty
+import re
+import select
+import shutil
+import sys
+import tempfile
+import time
+
+ANSI_CSI = re.compile(r'\x1b\[[0-9;?]*[a-zA-Z]')
+ANSI_OSC = re.compile(r'\x1b\][^\x07]*\x07')
+
+# Anything matching this is a token; never let it reach stdout.
+SECRET = re.compile(r'sk-ant-\w+-[A-Za-z0-9_-]+')
+
+LOGIN_MARKERS = ('Select login method', 'Opening browser to sign in',
+                 'oauth/authorize')
+READY_MARKERS = ('Welcome back', 'for shortcuts')
+ONBOARDING_MARKERS = ('Choose the text style', "Let's get started")
+TRUST_MARKERS = ('trust this folder', 'has not been trusted')
+
+
+def clean(raw):
+    text = raw.decode('utf-8', 'replace')
+    text = ANSI_OSC.sub('', text)
+    text = ANSI_CSI.sub('', text)
+    return SECRET.sub('<redacted>', text)
+
+
+def squash(text):
+    """Collapse blank lines; the TUI emits a lot of them."""
+    return '\n'.join(line for line in text.splitlines() if line.strip())
+
+
+def launch(config_dir, claude_bin, enters, settle, workdir):
+    env = dict(os.environ)
+    # Strip the parent session's markers, or Claude Code treats this as a child
+    # session and takes a different path than a real user launch.
+    for key in ('CLAUDECODE', 'CLAUDE_CODE_ENTRYPOINT', 'CLAUDE_CODE_SESSION_ID',
+                'CLAUDE_CODE_CHILD_SESSION', 'ANTHROPIC_API_KEY'):
+        env.pop(key, None)
+    env['CLAUDE_CONFIG_DIR'] = str(config_dir)
+    env['TERM'] = 'xterm-256color'
+
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.chdir(workdir)
+        os.execve(claude_bin, ['claude'], env)
+
+    def drain(seconds):
+        buf = b''
+        end = time.time() + seconds
+        while time.time() < end:
+            ready, _, _ = select.select([fd], [], [], 0.5)
+            if ready:
+                try:
+                    chunk = os.read(fd, 65536)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                buf += chunk
+        return buf
+
+    screens = [('boot', clean(drain(settle)))]
+    for i in range(enters):
+        os.write(fd, b'\r')
+        time.sleep(0.5)
+        screens.append((f'after-enter-{i + 1}', clean(drain(settle))))
+
+    try:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+    return screens
+
+
+def classify(screens):
+    # The TUI positions individual characters with ANSI codes, so stripping
+    # those codes also strips the spaces between words: "Choose the text style"
+    # arrives as "Choosethetextstyle". Match with all whitespace removed on both
+    # sides rather than trying to reconstruct it.
+    squeeze = lambda s: re.sub(r'\s+', '', s)
+    transcript = squeeze('\n'.join(text for _, text in screens))
+    hit = lambda markers: any(squeeze(m) in transcript for m in markers)
+    return {
+        'login': hit(LOGIN_MARKERS),
+        'ready': hit(READY_MARKERS),
+        'onboarding': hit(ONBOARDING_MARKERS),
+        'trust': hit(TRUST_MARKERS),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--creds', default=os.path.expanduser('~/.claude/.credentials.json'),
+                    help='credential file to copy into the probe config dir')
+    ap.add_argument('--seed', action='store_true',
+                    help='also write {"hasCompletedOnboarding": true}')
+    ap.add_argument('--config-dir', help='use this dir instead of a temp one')
+    ap.add_argument('--in-place', action='store_true',
+                    help='do not copy credentials in; probe --config-dir as-is')
+    ap.add_argument('--claude-bin', default='/usr/bin/claude-real',
+                    help='real Claude binary, bypassing the dax wrapper')
+    ap.add_argument('--workdir', default=os.path.expanduser('~'),
+                    help='cwd for the probed session')
+    ap.add_argument('--enters', type=int, default=2,
+                    help='Enter keypresses to advance the wizard')
+    ap.add_argument('--settle', type=float, default=8.0,
+                    help='seconds to wait for each screen')
+    ap.add_argument('--keep', action='store_true',
+                    help='do not delete the temp config dir (it holds a token)')
+    ap.add_argument('--show', action='store_true', help='print captured screens')
+    args = ap.parse_args()
+
+    if not os.path.exists(args.claude_bin):
+        sys.exit(f'no such binary: {args.claude_bin}')
+
+    temp = None
+    if args.config_dir:
+        config_dir = os.path.expanduser(args.config_dir)
+        os.makedirs(config_dir, exist_ok=True)
+    else:
+        temp = tempfile.mkdtemp(prefix='claude-probe-')
+        config_dir = temp
+
+    try:
+        if not args.in_place:
+            if not os.path.exists(args.creds):
+                sys.exit(f'no credential file at {args.creds}')
+            shutil.copy(args.creds, os.path.join(config_dir, '.credentials.json'))
+            os.chmod(os.path.join(config_dir, '.credentials.json'), 0o600)
+        if args.seed:
+            with open(os.path.join(config_dir, '.claude.json'), 'w') as fh:
+                json.dump({'hasCompletedOnboarding': True}, fh)
+
+        screens = launch(config_dir, args.claude_bin, args.enters,
+                         args.settle, args.workdir)
+
+        if args.show:
+            for name, text in screens:
+                print(f'\n=============== {name} ===============')
+                print(squash(text)[-2000:])
+
+        saw = classify(screens)
+        print('\n--- observed ---')
+        for key in ('onboarding', 'login', 'trust', 'ready'):
+            print(f'  {key:11} {saw[key]}')
+
+        if saw['login']:
+            print('\nFAIL: reached a login prompt with a valid credential present.')
+            print('      Almost always a missing .claude.json, not a bad credential.')
+            return 1
+        if saw['ready']:
+            print('\nPASS: reached the prompt without a login screen.')
+            return 0
+        print('\nINCONCLUSIVE: neither a login screen nor a ready prompt was seen.')
+        print('      Re-run with --show, and raise --settle on a slow start.')
+        return 2
+    finally:
+        if temp and not args.keep:
+            shutil.rmtree(temp, ignore_errors=True)
+        elif temp:
+            print(f'\nkept (contains a real token): {temp}')
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_dax_creds_claude.py
+++ b/tests/test_dax_creds_claude.py
@@ -1,5 +1,15 @@
+import json
 import pytest
-from dax_creds.providers.claude import ClaudeProvider
+from dax_creds.providers.claude import (
+    ClaudeProvider,
+    is_oauth_envelope,
+    _default_credentials_json,
+    _legacy_credentials_json,
+)
+
+ENVELOPE = {'claudeAiOauth': {'accessToken': 'sk-ant-oat01-abc',
+                              'refreshToken': 'sk-ant-ort01-xyz'}}
+ENVELOPE_JSON = json.dumps(ENVELOPE)
 
 
 class FakeKeyring:
@@ -25,11 +35,27 @@ def test_check_returns_false_when_key_not_in_keychain():
     assert provider.check({}, 'claude-work') is False
 
 
-def test_store_saves_to_keychain():
+def test_store_saves_full_envelope_to_keychain():
     kr = FakeKeyring()
     provider = ClaudeProvider(keyring=kr)
-    provider.store('claude-work', 'sk-ant-api03-abc')
-    assert kr.get_password('dax-creds', 'claude-work') == 'sk-ant-api03-abc'
+    provider.store('claude-work', ENVELOPE_JSON)
+    assert kr.get_password('dax-creds', 'claude-work') == ENVELOPE_JSON
+
+
+def test_store_rejects_bare_access_token():
+    kr = FakeKeyring()
+    provider = ClaudeProvider(keyring=kr)
+    with pytest.raises(ValueError):
+        provider.store('claude-work', 'sk-ant-oat01-' + 'a' * 90)
+    assert kr.get_password('dax-creds', 'claude-work') is None
+
+
+def test_store_rejects_envelope_without_refresh_token():
+    kr = FakeKeyring()
+    provider = ClaudeProvider(keyring=kr)
+    with pytest.raises(ValueError):
+        provider.store('claude-work', json.dumps({'claudeAiOauth': {'accessToken': 'x'}}))
+    assert kr.get_password('dax-creds', 'claude-work') is None
 
 
 def test_get_token_returns_from_keychain():
@@ -39,13 +65,25 @@ def test_get_token_returns_from_keychain():
 
 
 def test_import_from_disk_returns_full_credentials_json(tmp_path):
-    import json
     creds = tmp_path / 'credentials.json'
-    payload = {'claudeAiOauth': {'accessToken': 'sk-ant-oat01-abc', 'refreshToken': 'sk-ant-ort01-xyz'}}
-    creds.write_text(json.dumps(payload))
+    creds.write_text(ENVELOPE_JSON)
     provider = ClaudeProvider(keyring=FakeKeyring())
     result = provider.import_from_disk({}, credentials_file=creds)
-    assert json.loads(result) == payload
+    assert json.loads(result) == ENVELOPE
+
+
+def test_import_from_disk_returns_none_for_bare_token(tmp_path):
+    creds = tmp_path / 'credentials.json'
+    creds.write_text('sk-ant-oat01-' + 'a' * 90)
+    provider = ClaudeProvider(keyring=FakeKeyring())
+    assert provider.import_from_disk({}, credentials_file=creds) is None
+
+
+def test_import_from_disk_returns_none_without_refresh_token(tmp_path):
+    creds = tmp_path / 'credentials.json'
+    creds.write_text(json.dumps({'claudeAiOauth': {'accessToken': 'sk-ant-oat01-abc'}}))
+    provider = ClaudeProvider(keyring=FakeKeyring())
+    assert provider.import_from_disk({}, credentials_file=creds) is None
 
 
 def test_import_from_disk_returns_none_when_file_missing(tmp_path):
@@ -93,3 +131,83 @@ def test_has_disk_copy_returns_true_when_any_location_has_content(tmp_path):
     present.write_text('{"claudeAiOauth": {}}')
     provider = ClaudeProvider(keyring=FakeKeyring())
     assert provider.has_disk_copy({}, disk_locations=[empty, present]) is True
+
+
+# --- default paths -----------------------------------------------------------
+# These exercise the defaults rather than injected paths. The original bug —
+# dax writing and reading 'credentials.json' where Claude Code reads
+# '.credentials.json' — survived because every test passed an explicit path.
+
+def test_default_credentials_path_is_dot_prefixed():
+    assert _default_credentials_json().name == '.credentials.json'
+
+
+def test_default_disk_locations_include_dot_prefixed_name(monkeypatch, tmp_path):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    from dax_creds.providers.claude import _default_disk_locations
+    names = [p.name for p in _default_disk_locations()]
+    assert '.credentials.json' in names
+
+
+def test_import_from_disk_reads_dot_prefixed_file_by_default(monkeypatch, tmp_path):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    claude_dir = tmp_path / '.claude'
+    claude_dir.mkdir()
+    (claude_dir / '.credentials.json').write_text(ENVELOPE_JSON)
+    provider = ClaudeProvider(keyring=FakeKeyring())
+    assert json.loads(provider.import_from_disk({})) == ENVELOPE
+
+
+def test_import_from_disk_falls_back_to_legacy_name(monkeypatch, tmp_path):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    claude_dir = tmp_path / '.claude'
+    claude_dir.mkdir()
+    (claude_dir / 'credentials.json').write_text(ENVELOPE_JSON)
+    provider = ClaudeProvider(keyring=FakeKeyring())
+    assert json.loads(provider.import_from_disk({})) == ENVELOPE
+
+
+def test_import_from_disk_prefers_dot_prefixed_over_legacy(monkeypatch, tmp_path):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    claude_dir = tmp_path / '.claude'
+    claude_dir.mkdir()
+    (claude_dir / '.credentials.json').write_text(ENVELOPE_JSON)
+    (claude_dir / 'credentials.json').write_text(
+        json.dumps({'claudeAiOauth': {'accessToken': 'stale', 'refreshToken': 'stale'}}))
+    provider = ClaudeProvider(keyring=FakeKeyring())
+    result = json.loads(provider.import_from_disk({}))
+    assert result['claudeAiOauth']['refreshToken'] == 'sk-ant-ort01-xyz'
+
+
+def test_import_from_disk_skips_unparseable_legacy_file(monkeypatch, tmp_path):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    claude_dir = tmp_path / '.claude'
+    claude_dir.mkdir()
+    (claude_dir / 'credentials.json').write_text('sk-ant-oat01-' + 'a' * 90)
+    provider = ClaudeProvider(keyring=FakeKeyring())
+    assert provider.import_from_disk({}) is None
+
+
+# --- envelope validation -----------------------------------------------------
+
+@pytest.mark.parametrize('value', [
+    'sk-ant-oat01-abc',
+    '',
+    'null',
+    '[]',
+    '{}',
+    '{"other": "data"}',
+    '{"claudeAiOauth": "not-a-dict"}',
+    '{"claudeAiOauth": {"accessToken": "x"}}',
+    '{"claudeAiOauth": {"accessToken": "x", "refreshToken": ""}}',
+])
+def test_is_oauth_envelope_rejects(value):
+    assert is_oauth_envelope(value) is False
+
+
+def test_is_oauth_envelope_accepts_full_blob():
+    assert is_oauth_envelope(ENVELOPE_JSON) is True
+
+
+def test_is_oauth_envelope_rejects_none():
+    assert is_oauth_envelope(None) is False

--- a/tests/test_dax_creds_claude_wrapper.py
+++ b/tests/test_dax_creds_claude_wrapper.py
@@ -1,0 +1,202 @@
+"""Tests for the container-side `claude` wrapper script.
+
+The wrapper had no coverage, which is how it shipped writing
+~/.claude/credentials.json when Claude Code reads ~/.claude/.credentials.json.
+"""
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+WRAPPER = Path(__file__).resolve().parent.parent / 'dax_creds' / 'wrappers' / 'claude'
+
+ENVELOPE = {'claudeAiOauth': {'accessToken': 'sk-ant-oat01-abc',
+                              'refreshToken': 'sk-ant-ort01-xyz'}}
+ENVELOPE_JSON = json.dumps(ENVELOPE)
+
+
+def _run(tmp_path, dax_creds_stdout, dax_creds_exit=0, env=None):
+    """Run the wrapper with a stubbed dax-creds and a no-op claude-real.
+
+    The wrapper is copied and chmod'd the way Dockerfile.tmpl installs it,
+    rather than executed in place — it is mode 644 in the repo.
+    """
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir(exist_ok=True)
+
+    wrapper = bin_dir / 'claude'
+    wrapper.write_text(WRAPPER.read_text())
+    wrapper.chmod(0o755)
+
+    stub = bin_dir / 'dax-creds'
+    stub.write_text('#!/bin/bash\nprintf %s {!r}\nexit {}\n'.format(
+        dax_creds_stdout, dax_creds_exit))
+    stub.chmod(0o755)
+
+    real = bin_dir / 'claude-real'
+    real.write_text('#!/bin/bash\nexit 0\n')
+    real.chmod(0o755)
+
+    home = tmp_path / 'home'
+    home.mkdir(exist_ok=True)
+
+    full_env = {
+        'PATH': f'{bin_dir}:/usr/bin:/bin',
+        'HOME': str(home),
+        'DAX_CREDS_SOCK': 'tcp:127.0.0.1:9999',
+        'DAX_CREDS_CLAUDE': 'claude-fre',
+        'DAX_CLAUDE_REAL': str(real),
+    }
+    if env:
+        full_env.update(env)
+
+    proc = subprocess.run([str(wrapper)], env=full_env, capture_output=True,
+                          text=True, timeout=30)
+    return proc, home / '.claude' / '.credentials.json'
+
+
+def test_writes_envelope_to_dot_prefixed_path(tmp_path):
+    proc, creds = _run(tmp_path, ENVELOPE_JSON)
+    assert proc.returncode == 0
+    assert json.loads(creds.read_text()) == ENVELOPE
+
+
+def test_does_not_write_legacy_non_dot_path(tmp_path):
+    proc, creds = _run(tmp_path, ENVELOPE_JSON)
+    assert not (creds.parent / 'credentials.json').exists()
+
+
+def test_credentials_file_is_owner_only(tmp_path):
+    proc, creds = _run(tmp_path, ENVELOPE_JSON)
+    mode = stat.S_IMODE(creds.stat().st_mode)
+    assert mode & (stat.S_IRWXG | stat.S_IRWXO) == 0, oct(mode)
+
+
+def test_bare_token_is_rejected_and_reported(tmp_path):
+    proc, creds = _run(tmp_path, 'sk-ant-oat01-' + 'a' * 90)
+    assert not creds.exists()
+    assert 'not a Claude credentials blob' in proc.stderr
+    assert 'dax creds remove' in proc.stderr
+
+
+def test_bare_token_still_execs_claude(tmp_path):
+    # A bad credential must not prevent Claude from starting — the user may
+    # already be authenticated or may want to log in interactively.
+    proc, _ = _run(tmp_path, 'sk-ant-oat01-abc')
+    assert proc.returncode == 0
+
+
+def test_daemon_failure_is_reported_not_swallowed(tmp_path):
+    proc, creds = _run(tmp_path, '', dax_creds_exit=1)
+    assert not creds.exists()
+    assert 'could not fetch credential' in proc.stderr
+    assert proc.returncode == 0
+
+
+def test_no_fetch_attempted_without_sock(tmp_path):
+    proc, creds = _run(tmp_path, ENVELOPE_JSON, env={'DAX_CREDS_SOCK': ''})
+    assert not creds.exists()
+    assert proc.stderr == ''
+
+
+def test_no_fetch_attempted_without_credential_name(tmp_path):
+    proc, creds = _run(tmp_path, ENVELOPE_JSON, env={'DAX_CREDS_CLAUDE': ''})
+    assert not creds.exists()
+    assert proc.stderr == ''
+
+
+# --- onboarding seed -------------------------------------------------------
+#
+# Claude Code's first-run wizard is gated on .claude.json and runs *ahead of*
+# the credential check: with no .claude.json, an interactive launch shows the
+# theme picker, then "Select login method", then opens a browser — while a valid
+# .credentials.json sits unread beside it.
+#
+# This is invisible to `claude auth status` and `claude -p`, both of which read
+# the credential directly and report success against a config that would prompt.
+# That blind spot is why the mount removal looked like a credential failure.
+# tests/manual/interactive_launch_probe.py exercises the real launch path.
+
+def test_seeds_onboarding_flag_when_state_file_absent(tmp_path):
+    _run(tmp_path, ENVELOPE_JSON)
+    state = tmp_path / 'home' / '.claude.json'
+    assert json.loads(state.read_text()) == {'hasCompletedOnboarding': True}
+
+
+def test_seed_does_not_overwrite_existing_state_file(tmp_path):
+    # Claude Code owns this file and grows it to ~32KB on first run. Rewriting
+    # it each launch would wipe per-tenant project state, permissions, history.
+    home = tmp_path / 'home'
+    home.mkdir(parents=True, exist_ok=True)
+    state = home / '.claude.json'
+    existing = {'hasCompletedOnboarding': True, 'projects': {'/w': {'x': 1}}}
+    state.write_text(json.dumps(existing))
+
+    _run(tmp_path, ENVELOPE_JSON)
+    assert json.loads(state.read_text()) == existing
+
+
+def test_seed_does_not_overwrite_empty_state_file(tmp_path):
+    # -e, not -s: a zero-byte .claude.json is still Claude Code's file to own.
+    home = tmp_path / 'home'
+    home.mkdir(parents=True, exist_ok=True)
+    state = home / '.claude.json'
+    state.write_text('')
+
+    _run(tmp_path, ENVELOPE_JSON)
+    assert state.read_text() == ''
+
+
+def test_seed_happens_even_when_no_credential_configured(tmp_path):
+    # The onboarding gate is independent of credential delivery — a container
+    # with no Claude credential should still not face the first-run wizard.
+    _run(tmp_path, ENVELOPE_JSON, env={'DAX_CREDS_SOCK': ''})
+    state = tmp_path / 'home' / '.claude.json'
+    assert json.loads(state.read_text()) == {'hasCompletedOnboarding': True}
+
+
+def test_seed_does_not_set_folder_trust(tmp_path):
+    # Accepting folder trust silently activates .claude/settings.local.json
+    # permissions. That is the user's decision, not the wrapper's.
+    _run(tmp_path, ENVELOPE_JSON)
+    seeded = json.loads((tmp_path / 'home' / '.claude.json').read_text())
+    assert 'projects' not in seeded
+
+
+def test_seed_is_owner_only(tmp_path):
+    _run(tmp_path, ENVELOPE_JSON)
+    state = tmp_path / 'home' / '.claude.json'
+    mode = stat.S_IMODE(state.stat().st_mode)
+    assert mode & (stat.S_IRWXG | stat.S_IRWXO) == 0, oct(mode)
+
+
+# --- CLAUDE_CONFIG_DIR layout ----------------------------------------------
+#
+# The two layouts disagree about where .claude.json lives: inside
+# CLAUDE_CONFIG_DIR when set, but at ~/.claude.json — not ~/.claude/.claude.json
+# — otherwise. Verified against Claude Code v2.1.220.
+
+def test_credentials_follow_claude_config_dir(tmp_path):
+    cfg = tmp_path / 'state' / 'tenants' / 'acme' / 'proj'
+    _run(tmp_path, ENVELOPE_JSON, env={'CLAUDE_CONFIG_DIR': str(cfg)})
+    assert json.loads((cfg / '.credentials.json').read_text()) == ENVELOPE
+    assert not (tmp_path / 'home' / '.claude' / '.credentials.json').exists()
+
+
+def test_state_file_is_inside_claude_config_dir(tmp_path):
+    cfg = tmp_path / 'state' / 'tenants' / 'acme' / 'proj'
+    _run(tmp_path, ENVELOPE_JSON, env={'CLAUDE_CONFIG_DIR': str(cfg)})
+    assert json.loads((cfg / '.claude.json').read_text()) == {
+        'hasCompletedOnboarding': True}
+    assert not (tmp_path / 'home' / '.claude.json').exists()
+
+
+def test_config_dir_created_when_missing(tmp_path):
+    cfg = tmp_path / 'does' / 'not' / 'exist' / 'yet'
+    proc, _ = _run(tmp_path, ENVELOPE_JSON, env={'CLAUDE_CONFIG_DIR': str(cfg)})
+    assert proc.returncode == 0
+    assert (cfg / '.credentials.json').exists()
+    assert (cfg / '.claude.json').exists()


### PR DESCRIPTION
## Summary
- The wrapper wrote `~/.claude/credentials.json` (no leading dot); Claude Code only reads the dot-prefixed `~/.claude/.credentials.json`, so container auth had been silently riding the shared `~/.claude` host mount instead of the daemon since at least 2026-06-27.
- `providers/claude.py` now reads/writes the dot-prefixed filename (old name kept as an import fallback) and validates the `{"claudeAiOauth": {..., "refreshToken": ...}}` envelope shape on both import and store, rejecting bare access tokens that can't be refreshed.
- `wrappers/claude` writes to the correct filename, honors `CLAUDE_CONFIG_DIR`, reports failures on stderr instead of swallowing them, and seeds `{"hasCompletedOnboarding": true}` into `.claude.json` when absent so Claude Code's first-run wizard doesn't intercept a valid credential with a login prompt. Folder trust is deliberately left unseeded — that gate controls whether `.claude/settings.local.json` permissions apply silently, and that's a call for the user to make, not the wrapper.
- Adds `tests/manual/interactive_launch_probe.py`, which drives an interactive launch under a pty to classify login/ready/onboarding/trust — the blind spot that let the original bug ship undetected for a month.

## Test plan
- [x] `pytest tests/test_dax_creds_claude.py tests/test_dax_creds_claude_wrapper.py` — 50 passed
- [x] Confirmed in a container: wrapper rejects a stale bare-token credential with the expected stderr message
- [x] Confirmed in a container: `dax creds remove` + `dax creds add` re-imports a full envelope from `~/.claude/.credentials.json`
- [x] `interactive_launch_probe.py --seed` reaches `Welcome back` with no login prompt; without `--seed` it correctly reports the login-prompt failure mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)