### PR TITLE
Tenant isolation: per-env Claude credentials, state trees, and substrate processes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,11 @@
       "Bash(xargs ls -la)",
       "Bash(sed -n *)",
       "Bash(dax-creds get *)",
-      "Bash(echo \"--- exit: $? ---\")"
+      "Bash(echo \"--- exit: $? ---\")",
+      "Bash(grep -nE ':\\\\s*\\(True|False|Yes|No|on|off\\)\\\\s*$' ~/.dax.yaml)",
+      "Bash(grep -cE ':\\\\s*\\(True|False\\)\\\\s*$' ~/.dax.yaml)",
+      "Bash(grep *)",
+      "Bash(python -m pytest -q)"
     ]
   },
   "disabledMcpjsonServers": [

--- a/.dax-tenant
+++ b/.dax-tenant
@@ -1,0 +1,1 @@
+personal

--- a/.dax.yaml.example
+++ b/.dax.yaml.example
@@ -9,9 +9,6 @@ features:
   - ssh
   - webpreview
 
-workdir:
-  container: work
-
 claudedir:
   mount: ~/.claude
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 dax.egg-info/
 Dockerfile
 *.crt
+docs/design/scripts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,52 @@ functions in `dax.py`.
   the resulting token to Keychain the way the github/auggie branches already
   did. Confirmed working.
 
+## Where this stands — 2026-07-31
+
+Nine commits on `feature/tenant-isolation` since `4c8fb6c`, plus uncommitted
+work from today (shared-files sync + locale fix, below). **423 tests passing.**
+Read this block first; the sections below are the detail.
+
+**Done and verified live:** per-env Claude credentials (C2-C8, all four grants
+independent and audited), decision B steps 1-3 — an env's state tree now mounts
+at `~/.claude` with `CLAUDE_CONFIG_DIR` a constant — and the shared-files sync
+(`sync_claude_shared_files`) that replaced the abandoned nested-mount attempt.
+`fabric` is running on all of it, with state confirmed surviving a full
+container destroy/recreate and its `CLAUDE.md`/`settings.json` confirmed
+byte-identical to host. `dax`, `discernment`, and `ys-augmentcode` are still on
+the shared mount, which is the intended fallback.
+
+**Immediate next actions, in order:**
+
+1. **Finish migrating `dax`** — `tools/migrate_env_state.py dax` (dry run, then
+   `--apply`), then `dax env set dax features claude_tenant_state`. The
+   `.claude.json` to seed its tree with is already on the host at
+   `~/fatsec/dax/doot` (34 keys, scoped to `/home/dfarrow/dax`, and it carries
+   `oauthAccount`/`userID`, so it also covers the wrapper's un-built account
+   seeding for this env). **Do not commit that file** — it holds account identity.
+   Copy it to `~/.local/state/dax/tenants/personal/dax/.claude.json`, then delete
+   it and the scratch `doit.txt` from the repo.
+2. ~~Restart `fabric`~~ — **done and verified 2026-07-31.** `sync_claude_shared_files`
+   correctly flagged fabric's leftover 0-byte `CLAUDE.md` as drift on first run;
+   `dax env accept-shared-files fabric` resolved it, and `wc` confirmed a
+   byte-perfect match between host and container.
+3. **Rebuild the image and restart running containers** (`dax build`, then
+   `dax run` for `fabric`/`dax`/whatever else is up) to pick up the
+   `LANG`/`LC_ALL` fix found while chasing a `less` false alarm during step 2 —
+   the image generated `en_US.UTF-8` but never activated it, so every shell
+   defaulted to POSIX/C. Not urgent, but do it opportunistically rather than
+   let it linger.
+4. **Delete the credential in `hci/hydraulic-controls-it`'s tree** — a live grant,
+   valid to 2026-08-24, for an engagement that ended and an env that no longer
+   exists. Then decide about the 393K of transcripts beside it.
+5. **`dax creds remove claude-fre`** if it is genuinely dead — registered, used by
+   nothing, and holding a fourth live grant.
+6. **Step 7 of the cred test sequence**: relaunch `claude` in a migrated env and
+   confirm `.credentials.json`'s mtime does not change. Cheap, and now meaningful.
+7. **Roll `discernment` over** once `dax` has a few days behind it.
+8. **Step 5 of decision B — the E deletions.** Still the largest item, still pure
+   deletion, and still reading as current code to anyone who looks.
+
 ## In progress
 
 - **Tenant isolation for Claude Code state** — design and status in
@@ -297,7 +343,89 @@ functions in `dax.py`.
   write-temp-plus-rename breaks on grpcfuse, and a silent write failure is worse
   than `/config` visibly not persisting inside a container.
 
-  **Migration runbook: `docs/testing/2026-07-31-migrate-env-to-state-tree.md`** —
+  **Correction, same day: the `ro` mount doesn't fail loudly.** The comment above
+  assumed a write attempt would error and make the loss visible. Tested from
+  inside a `claude_tenant_state` container: a plain `touch` + append against the
+  mounted `CLAUDE.md` returned no error at all. The write landed in a
+  container-local copy that silently detached from the host-mounted file — host
+  untouched, but the container's own view of the file is now wrong with nothing
+  to signal it. Quieter than assumed, not louder. Practical upshot for anyone
+  (Claude included) working inside one of these containers: never edit
+  `CLAUDE.md`/`settings.json`/`settings.local.json` in place, even to test. Draft
+  the intended change in conversation and have the user apply it on the host —
+  a successful-looking in-container write is not evidence the host file changed.
+
+  **Superseded, same day: the read side was broken too — mounting abandoned in
+  favor of a copy.** Confirmed live: mounting these three files read-only,
+  nested inside the tree mount, doesn't deliver the host's content at all — the
+  container sees an empty file, not the real `CLAUDE.md`. Unlike
+  `_CLAUDE_HOST_SHARED_DIRS` (`commands`/`plugins`), which nests fine, a
+  single-*file* bind mount nested inside another mount didn't take.
+
+  **`--mount` is not a fix — tested and ruled out, 2026-07-31.** A stripped-down
+  `docker run --mount type=bind,source=~/.claude/CLAUDE.md,target=...` (no
+  `dax`, no `--volume`, run straight from a Mac terminal to rule out every other
+  variable) reproduced the identical empty-file result: 54 lines on the host,
+  0 bytes in the container. `-v`/`--mount` are two CLI spellings of the same OCI
+  bind-mount spec, so this was never a `--volume`-syntax quirk — nesting a
+  single-file bind mount inside a directory that's also a bind mount doesn't
+  work under either flag. Don't revisit `--mount` for this.
+
+  **Built, same day: `sync_claude_shared_files` (`dax_creds/config.py`) copies
+  these three files into the tree at `dax run` time, with drift detection.** A
+  plain host-vs-tree diff can't tell "host moved on since last sync" (safe to
+  overwrite) apart from "something changed the tree's copy independently" (a
+  container editing it directly, now that it's a plain file, not a mount —
+  the exact risk of dropping the mount). A small manifest beside the tree
+  (`<tenant>/<project>.shared-files.json`, deliberately *not* inside the tree
+  itself, so it never shows up in the container's `~/.claude`) records the
+  hash of what was last synced in per file:
+
+  - tree copy missing → copy host, record hash (first-run seed)
+  - tree hash matches host → no-op
+  - tree hash matches the manifest but not host → host moved on → copy, update
+  - tree hash matches neither → drift → **warn and skip**, never silently
+    overwrite (`dax run` prints the file/env and the command to resolve it)
+
+  **Confirmed live against `fabric`, 2026-07-31.** `dax run` correctly flagged
+  drift on the first run — fabric's tree already held a 0-byte `CLAUDE.md`, a
+  leftover of the `--mount` repro above having targeted the same tree path —
+  and `dax env accept-shared-files fabric` resolved it.
+  `wc ~/.claude/CLAUDE.md` matched exactly (54 lines / 442 words / 2921 bytes)
+  on the host and inside the container. (A `hexdump`-without-`-C` byte-swap and
+  a locale-driven `less` "binary file" warning both looked alarming and were
+  both false alarms — the content is plain UTF-8 text.)
+
+  **Found chasing that `less` warning: the image never activates its own
+  locale.** `Dockerfile.tmpl` runs `locale-gen` for `en_US.UTF-8` but never
+  sets `LANG`/`LC_ALL`, so every shell in the container defaults to POSIX/C —
+  confirmed via `locale` inside `fabric`. `less` treats a `CLAUDE.md` full of
+  ordinary em-dashes as binary under that default. Fixed by adding
+  `ENV LANG=en_US.UTF-8` / `ENV LANGUAGE=en_US:en` / `ENV LC_ALL=en_US.UTF-8`
+  right after the `locale-gen` step. One new test
+  (`test_render_dockerfile_activates_the_generated_locale`), suite at **423**.
+  **Needs an image rebuild** (`dax build`) — unlike the sync fix above, this is
+  baked in at build time, not computed per `dax run`.
+
+  `dax env accept-shared-files <name>` force-adopts the host version and resets
+  the manifest — resolving drift is always an explicit act, never automatic.
+  `_CLAUDE_HOST_SHARED_FILES` in `dax.py` is now just
+  `dax_creds.config.CLAUDE_SHARED_FILES` re-exported for the existing tests.
+  15 new tests (`test_dax_creds_shared_files_sync.py`, the rewritten
+  "user-level files" section of `test_dax_claude_tenant_state_mount.py`, and
+  `env accept-shared-files` cases in `test_dax_env_cmds.py`); suite at **422**.
+  Manual pass, since none of this is reachable from unit tests (real
+  `~/.claude`, real state trees, a real container):
+  `docs/testing/2026-07-31-shared-files-sync-test.md`. No image rebuild
+  needed — the sync runs host-side while `dax run` assembles the docker
+  command.
+
+  **Migration: `tools/migrate_env_state.py <env>`** (dry run by default) does the
+  transcript copy, the history filter, and the credential/`.claude.json` checks.
+  It deliberately does **not** write `~/.dax.yaml` — switching the env over stays a
+  manual `dax env set` — and does not handle `.claude.json`, which has to be copied
+  out of the env's running container before shutdown since it dies with it. Runbook
+  with the reasoning: `docs/testing/2026-07-31-migrate-env-to-state-tree.md` —
   how to move an env's accumulated state into its tree rather than starting empty.
   The separability was checked, not assumed: `projects/<mangled-cwd>/` is keyed by
   container cwd so it is already per-env (transcripts + auto-memory);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,23 @@ functions in `dax.py`.
   against), so `check_claude_grants.py` remains the audit for sharing that
   already exists. 20 tests, suite at **367**.
 
-  **Also new: C7 — `dax creds add` rebuilds the definition and drops unprompted
+  **C8 built 2026-07-30 — `dax creds add` asks the provider first and never asks
+  for a per-env name.** Naming is dax's job (C2), so once the provider is one of
+  `BARE_PROVIDER_CREDS` the name is derived, not typed — which also removes the
+  way a derived credential got silently converted to an explicitly registered one
+  (no "Overwrite it?" fires, since there is no registry entry to collide with, and
+  it then stops inheriting `credential_defaults`). Flow: provider → env (cwd's env
+  offered first) → tenant *only if that env has none* → derived name printed →
+  offer to add the bare token to the env's `creds:` → write
+  `credential_defaults` only if missing → **hand off to `dax creds login`, never
+  importing a token from disk**. `_run_creds_add` returns
+  `(config, pending_login)` and `cmd_creds` runs the login when accepted. Every
+  `_setup_*` now returns whether a secret was stored, so `Credential "X" saved.`
+  stops appearing when nothing was. **`dax init`'s inline creds loop still has
+  the old shape** — safe (C6's guard holds) but still hand-named; fold it in with
+  the backlogged `dax init` tenant prompt. 18 tests, suite at **385**.
+
+  **Superseded: C7 — `dax creds add` rebuilds the definition and drops unprompted
   fields.** `_define_credential` starts from `{'provider': ...}` (`init.py:113`)
   and `_run_creds_add` assigns it wholesale (`init.py:369`), so re-running `add`
   on an existing credential silently loses anything its prompts don't ask for;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,75 @@ functions in `dax.py`.
 - **Tenant isolation for Claude Code state** — design and status in
   `docs/design/2026-07-27-tenant-isolation.md`. Replaces the shared `~/.claude`
   mount with per-tenant/project state trees selected via `CLAUDE_CONFIG_DIR`.
-  Sequencing steps 1–2 (credential wrapper fix, onboarding seed) are done and
-  merged (PR #4). Remaining: steps 3–7 — mount relocation, seed-template
-  wiring for new trees, tenant resolution in the `claude` wrapper, `dax tenant
-  set`/`dax tenants`, and the credential-span escalation check.
+  Steps 1–2 merged in PR #4. Steps 3–6 implemented, unit-tested, and
+  **confirmed on the real repos this design exists for** — `fabric`
+  (single-tenant) and `discernment` (multi-tenant, `processes/` subdirs) —
+  not just scratch projects. Discernment specifically: two concurrent `claude`
+  sessions in different tmux windows, different labeled processes, same
+  container — each isolated, each persisted its own history correctly across
+  quit/restart, zero cross-tenant leakage. That's the actual bug from this
+  doc's Problem section, fixed and observed, not just theorized. Step 7
+  dropped — see the design doc's Sequencing section for why. Nothing is live
+  by default — `claude_tenant_state` is opt-in per project via its own
+  `features:` list.
+  **Redesigned 2026-07-28**: the `unattributed` fallback is gone entirely —
+  every undeclared location now either resolves, gets interactively
+  classified before the container launches (`dax run` walks the repo root
+  and, for multi-tenant projects, every undeclared child under
+  `tenant_subdir`, refusing to launch until all are assigned), or hard-refuses
+  (only for a subdirectory discovered mid-session, since Docker can't add a
+  mount to an already-running container). `dax tenant classify` re-runs that
+  walk on demand, re-prompting even already-declared entries. A multi-tenant
+  repo's root can now also resolve as its own project/tenant (needed for
+  working on discernment's own tooling independent of any one customer
+  process). 253 tests pass. Still outstanding before trusting this as the
+  default: the shared `plugins`/`skills`/`commands`/`cache` migration from
+  `~/.claude` (scoped, not yet built — see below, and now caveated by a
+  skills-symlink discovery: discernment's own project-specific skills should
+  move to Claude Code's native project-scoped `.claude/skills/` instead of
+  being blanket-shared to every tenant), and the multi-day refresh-token
+  rotation soak (still unconfirmed; nothing tested so far ran long enough to
+  hit it). The real fabric/discernment containers have not been re-tested
+  against this latest classification-flow change yet — that needs an image
+  rebuild (`dax_creds` is a frozen, non-editable install) plus a fresh manual
+  pass.
+- **Fixed: `dax run` from inside a registered project's subdirectory silently
+  mis-scoped the container.** `cmd_run`'s project lookup (`find_project_by_dir`)
+  only matches by exact `dir:` equality; a `cd` into `discernment/processes/<name>/`
+  on the host followed by `dax run` there fell through to `run_init`,
+  auto-registering the subdirectory as a brand-new project and mounting only
+  it — repo-root content (`.git`, `.claude/skills/`) silently absent, no
+  error, and (worse) the pre-existing `.dax-tenant` there made it resolve to
+  the same tenant/state dir the correct flow would have, masking the bug
+  entirely. Fixed via `find_enclosing_project` (`dax_creds/config.py`):
+  `cmd_run` now refuses with the enclosing project's name/root instead of
+  auto-registering, whenever cwd is nested inside — not equal to — an
+  already-registered project. See `docs/design/2026-07-27-tenant-isolation.md`
+  decision 6's "Gate 0" note. 259 tests pass.
+- **Shared plugins/skills/commands/cache migration** — scoped but not yet
+  built. Plan: one-time, host-wide copy (not a symlink) from
+  `~/.claude/{plugins,skills,commands}` into
+  `~/.local/state/dax/shared/{plugins,skills,commands,cache}` the first time
+  `claude_tenant_state` runs and the shared dir doesn't exist yet, gated on
+  `claude_tenant_state` actually being active, living in `cmd_run()`'s
+  orchestration rather than inside `feature_claude_tenant_state` (which stays
+  a pure argv-builder like every other `feature_*` function). Without this,
+  a project opting in loses access to whatever plugins/commands are already
+  installed under the old `~/.claude`.
 
 ## Backlog
+
+- **`dax creds add` doesn't actually overwrite Keychain on re-add** —
+  `_setup_claude_credential`'s `if provider.check(...): return` early-exit
+  means confirming "Overwrite it?" only rewrites YAML metadata, not the
+  Keychain secret itself. Found during tenant-isolation testing when a
+  rotated credential wouldn't take; workaround is `dax creds remove` before
+  `dax creds add`. Fix: the overwrite-confirmed path needs to actually call
+  through to the provider's store, not early-return before it.
+- **`dax creds login`'s browser callback doesn't work for Claude** — same
+  class of bug as Auggie's already-known limitation. Workaround is the
+  device-flow login instead. Found during the same tenant-isolation testing
+  pass as the Keychain-overwrite bug above.
 
 - **`save_config` destroys `~/.dax.yaml` comments and key order** — `dax_creds/init.py:26`
   loads via `yaml.safe_load` and rewrites with `yaml.dump`, so comments (which
@@ -42,6 +105,28 @@ functions in `dax.py`.
   `sort_keys=True`. Triggered by `dax creds add`, `dax creds update`, and
   `dax init`. Fix: switch to `ruamel.yaml` round-trip mode; stopgap is
   `sort_keys=False` plus a `.dax.yaml.bak` before each write.
+
+- **`claude` wrapper doesn't seed `oauthAccount`/`userID`** — cosmetic only
+  (omitting it just costs a profile-fetch round trip and the org name in the
+  first banner, per `docs/design/2026-07-27-tenant-isolation.md`'s seed-key
+  table), but seeding it correctly needs real account data (`emailAddress`,
+  `organizationName`, `accountUuid`), and nothing in `dax_creds/` currently
+  sources or relays that from the host into a container. Would need a new
+  daemon action (or a new credential-envelope field) reading it out of the
+  host's own `~/.claude.json`. Not attempted as part of the tenant-isolation
+  seed-template work — out of scope for a wrapper-only change.
+
+- **Container shell lands in `$HOME`, not the project mount** — every dax
+  session starts the user at `$HOME`, requiring a manual `cd <project>`
+  before anything useful (including `claude`, once tenant isolation refuses
+  to start there anyway). No `-w`/`--workdir` docker flag exists in `dax.py`
+  today — `Dockerfile.tmpl`'s static `WORKDIR` can't know a per-project mount
+  name at build time. Fix would be a small `cmd_run()` addition using stage
+  3's already-computed `workdir_name`. Landing the shell at the mount root
+  is a strict improvement in both single- and multi-tenant cases (see
+  discussion in `docs/design/2026-07-27-tenant-isolation.md`'s history) but
+  is an ergonomic change orthogonal to the tenant-isolation bug fix itself —
+  deferred, not part of any current stage.
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,23 +319,25 @@ functions in `dax.py`.
   auto-registering, whenever cwd is nested inside — not equal to — an
   already-registered project. See `docs/design/2026-07-27-tenant-isolation.md`
   decision 6's "Gate 0" note. 259 tests pass.
-- **Shared plugins/skills/commands/cache migration** — scoped but not yet
-  built, and **reshaped by the 2026-07-29 redesign**: with the state tree now
-  mounted at `~/.claude` itself, these become *nested* mounts inside it
-  (`shared/plugins` → `~/.claude/plugins`), not a sibling path. Docker orders
-  mounts by destination depth, so the nesting resolves. `skills/` is further
-  changed — discernment's shared skills now arrive via the sidecar's second
-  mount at `~/.claude/skills/`, and project-specific skills belong in the
-  project's own `.claude/skills/`. Original plan, still broadly applicable:
-  one-time, host-wide copy (not a symlink) from
-  `~/.claude/{plugins,skills,commands}` into
-  `~/.local/state/dax/shared/{plugins,skills,commands,cache}` the first time
-  `claude_tenant_state` runs and the shared dir doesn't exist yet, gated on
-  `claude_tenant_state` actually being active, living in `cmd_run()`'s
-  orchestration rather than inside `feature_claude_tenant_state` (which stays
-  a pure argv-builder like every other `feature_*` function). Without this,
-  a project opting in loses access to whatever plugins/commands are already
-  installed under the old `~/.claude`.
+- **~~Shared plugins/skills/commands/cache migration~~ — deleted, not built
+  (decision B2, 2026-07-30).** No `shared/` tree and no seeding copy. Instead
+  mount the host's own `~/.claude/commands` and `~/.claude/plugins` **rw**,
+  nested inside the tree mount at `~/.claude` (Docker orders mounts by
+  destination depth, so the nesting resolves).
+
+  Checked against the real directories rather than assumed: `commands` holds 11
+  live commands and is the only genuine user state; `plugins` has **nothing
+  installed** — just the official marketplace catalog that Claude Code
+  auto-installs and refreshes itself, so mounting it is an optimization against
+  four redundant 6.3M clones, not state preservation. `skills` drops out
+  (discernment content, arriving via decision D's sidecar mount) and `cache`
+  drops out (derived, generic, cheap to refetch, and the only one of the four
+  where fetched content can turn account-specific).
+
+  With the list down to two, the copy step isn't worth its cost: direct mounts
+  need no seeding code, keep one source of truth, remove the divergence class
+  where a host-authored command is invisible in containers, and are *strictly
+  less* container write access than today's wholesale rw `~/.claude`.
 
 ## Backlog
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,13 +277,26 @@ functions in `dax.py`.
   expiries cannot corroborate separate mints. A grant hash changing across a
   known-good login is the evidence that does.
 
-  Note for step 7: `feature_claude_tenant_state` and the wrapper's Gate B are
-  still the **pre-redesign shape** (trees under
-  `~/.local/state/dax/tenants/<t>/<p>`, `dax-creds resolve-tenant`), so
-  decision B is not built and inject-if-absent can only be exercised under the
-  shared `~/.claude` mount, where the divergence it guards against cannot
-  arise. Don't switch on `claude_tenant_state` to test it — that exercises the
-  abandoned design.
+  **Superseded 2026-07-31: decision B steps 1-3 are built and live-verified on
+  `fabric`.** The feature now mounts the env's state tree **at** `~/.claude` with
+  `CLAUDE_CONFIG_DIR` a constant, Gate B is gone from the wrapper, and
+  `claude`/`claude_tenant_state` are mutually exclusive (`dax run` refuses). No
+  image rebuild was needed: `dax run` deliberately stops setting
+  `DAX_TENANT_STATE`, so a wrapper still carrying Gate B leaves it dormant.
+  Verified live — mount shape, credential bootstrap from Keychain, and **state
+  surviving a full container destroy/recreate**, which closes the regression where
+  `.claude.json` was discarded on every teardown. Step 5 (the E deletions) is
+  still outstanding, so the old tenant machinery remains present but unreachable
+  from the wrapper.
+
+  **Watch for orphan grants in state trees.** `fabric`'s tree held a
+  `.credentials.json` from 2026-07-28 whose grant matched no Keychain entry.
+  Inject-if-absent correctly left it alone (non-empty file), so the env would have
+  refreshed and used an untracked grant indefinitely.
+  `tests/manual/check_claude_grants.py` cannot see it — it reads Keychain only,
+  never the trees, which is where credentials now live. Extending it to scan
+  `~/.local/state/dax/tenants/*/*/.credentials.json` and flag grants that match no
+  Keychain entry (or duplicate another tree's) is **not yet built**.
 
 - **Claude credentials are per tenant/project** — named
   `claude-<tenant>-<project>`, each minted by its **own fresh login**. That is
@@ -341,6 +354,23 @@ functions in `dax.py`.
 
 ## Backlog
 
+- **Per-env features are additive only — no way to opt *out*.** Features
+  accumulate from four sources (global `features:`, the env entry, a `.dax.yaml`
+  in cwd, `-f`) and every one only adds. So an env cannot decline a globally
+  inherited feature, which is why switching one env to `claude_tenant_state`
+  takes four writes: a hand-edit to strip `claude` from the global list, plus
+  three `dax env set … features claude` calls to give it back to the envs that
+  still want it.
+
+  Fit-and-polish fix, deferred: make `claude_tenant_state` **supersede an
+  inherited `claude`** (it was designed as the replacement for that mount, not a
+  peer), printing `claude_tenant_state supersedes claude for <env>` so it is
+  never silent — while still *refusing* when both are listed explicitly on the
+  same env, where the intent is genuinely ambiguous. That reduces the four writes
+  to one and leaves the global list alone. The general form — a `-claude` removal
+  syntax any env could use — is a bigger mechanism and not worth building until
+  something needs it.
+
 - **`dax init` should prompt for `tenant`** at registration time — editing an
   existing env is now covered by `dax env set`.
 
@@ -376,6 +406,16 @@ functions in `dax.py`.
   deferred, not part of any current stage.
 
 ## Notes
+
+- **Tests must never write the real `$HOME`.** A dax container bind-mounts the
+  host's `~/.dax.yaml` **rw**, so a test that writes `$HOME/.dax.yaml` destroys
+  the live config — env definitions, credential metadata, and gmail
+  `client_id`/`client_secret` values that exist nowhere else. This happened on
+  2026-07-31: four tests called `run_env_set` (which calls `save_config`
+  unconditionally) with no `HOME` isolation, and pytest overwrote the real config
+  with fixture data. `tests/conftest.py` now redirects `HOME` for every test via
+  an autouse fixture; per-module `home` fixtures still override it. Don't remove
+  it, and pass an explicit `HOME=<tmpdir>` to ad-hoc verification scripts too.
 
 - `safe.directory` is already set in `~/.gitconfig` — no need for `-c safe.directory=` flag in git commands.
 - Files NOT to back up: credentials, `~/.claude/projects/`, `history.jsonl`, caches, sessions, auggie ephemeral data.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,14 +222,21 @@ functions in `dax.py`.
   grants. **C3's refusal path confirmed live** on a second, cancelled run — the
   "predates this login" refusal printed and Keychain was untouched.
 
-  **New: C6 — the C3 guard compares the file, not the grant.**
-  `_disk_token_for` returns the whole envelope (`providers/claude.py:77`), so a
-  Claude Code token refresh landing inside the login window makes an abandoned
-  login look successful and imports another env's grant under the new name.
-  Low probability, C3's silent-success signature. Tighter fix: before storing,
-  compare the credential's `refreshToken` hash against every other stored Claude
-  credential and refuse on collision — `check_claude_grants.py`'s logic enforced
-  at import time. Not yet built.
+  **C6 built 2026-07-30 — one grant per name, enforced at import time.** C3's
+  guard compares the on-disk *file*, not the grant, so a Claude Code token
+  refresh landing inside the login window made an abandoned login look
+  successful. Rather than tightening that proxy, the invariant is now enforced
+  directly: `grant_id()` hashes the refresh token, and
+  `ClaudeProvider.grant_collision()` refuses to store a token whose grant already
+  sits under another name (skipping the credential's own name, since re-importing
+  its own token is a no-op). `credential_names_for_provider()` supplies
+  registered **and derived** names — enumerating only the registry would let the
+  check pass by seeing nothing. Wired into both doors, which **closes the
+  outstanding `dax creds add` gap**: that path never had the before/after guard
+  at all. Claude-only by design; github/gmail/ssh are user-level, where one name
+  per credential is the intent. Inert in a container (no Keychain to compare
+  against), so `check_claude_grants.py` remains the audit for sharing that
+  already exists. 20 tests, suite at **367**.
 
   **Also new: C7 — `dax creds add` rebuilds the definition and drops unprompted
   fields.** `_define_credential` starts from `{'provider': ...}` (`init.py:113`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,23 @@ functions in `dax.py`.
   still outstanding, so the old tenant machinery remains present but unreachable
   from the wrapper.
 
+  **B2's shared list was incomplete — fixed 2026-07-31.** A tree mount replaces
+  `~/.claude` wholesale, so the *user-level* `CLAUDE.md`, `settings.json`, and
+  `settings.local.json` vanished with it. `fabric` ran a full day without your
+  global instructions, silently. `_CLAUDE_HOST_SHARED_FILES` now mounts all three
+  **read-only** — writable single-file bind mounts are exactly where
+  write-temp-plus-rename breaks on grpcfuse, and a silent write failure is worse
+  than `/config` visibly not persisting inside a container.
+
+  **Migration runbook: `docs/testing/2026-07-31-migrate-env-to-state-tree.md`** —
+  how to move an env's accumulated state into its tree rather than starting empty.
+  The separability was checked, not assumed: `projects/<mangled-cwd>/` is keyed by
+  container cwd so it is already per-env (transcripts + auto-memory);
+  `history.jsonl` carries a `project` field per line so it filters cleanly (92 of
+  2185 lines were dax); and a container's `~/.claude.json` already has just the one
+  project key, so it seeds the tree wholesale and preserves trust/`allowedTools`/
+  tips. `file-history/` is keyed by session UUID and mappable but low value.
+
   **Watch for orphan grants in state trees.** `fabric`'s tree held a
   `.credentials.json` from 2026-07-28 whose grant matched no Keychain entry.
   Inject-if-absent correctly left it alone (non-empty file), so the env would have

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,35 @@ the shared mount, which is the intended fallback.
   `~/.claude/skills/` because Claude Code only discovers skills in the
   directories it scans; a CLAUDE.md pointer registers nothing.
 
+  **Generalized and built, 2026-07-31 (stage 1 of 2): `feature_mounts`.**
+  Rather than a discernment-specific sidecar mount, any env can now list extra
+  host paths in a `mounts:` field (`dax env set <name> mounts <path>[,<path>...]`,
+  comma-split the same way `creds`/`features` are), opted into via
+  `features: [mounts]` — the same "list the data, then opt in" shape as the
+  existing `feature_ports`. Each path mounts read-write as a **sibling under
+  $HOME**, named by `dir_basename`, deliberately *not* nested inside the
+  project's own workdir mount: nesting a mount inside a mount is exactly the
+  class of bug that broke the CLAUDE.md/settings.json file mounts (see
+  `sync_claude_shared_files` above), and siblings under $HOME sidestep it
+  rather than leaning on directory-nesting (which does work) staying that way.
+  `dax env show` lists configured mounts and flags them if `mounts` isn't in
+  that env's active features. Deliberately does not yet cover the `skills/`
+  second-mount or a common process-init script — **stage 2**, backlogged
+  below, since these processes share a common initiation sequence worth
+  scripting once stage 1 is in use.
+
+  **Found live testing this against a real migrated process, same day:**
+  `dax env show`/`dax env set` worked — they read `mounts` straight off the
+  project dict — but `dax run` printed "no mounts defined" and mounted
+  nothing. `cmd_run` promotes `project['tenant']` and `project['features']`
+  into the flat `config` dict feature functions read, but `mounts` was never
+  added to that promotion, so `feature_mounts` saw an empty list regardless of
+  what was configured. One-line fix (`config['mounts'] = project.get('mounts')
+  or []`), plus an integration test *through `cmd_run`* — the earlier
+  unit tests of `feature_mounts` alone couldn't have caught this, since the
+  bug was entirely in the wiring between the two. 12 new tests total, suite at
+  **435**.
+
   `claude_tenant_state` stays opt-in for now — the 2026-07-28/29 outage forced
   a fallback to the old shared-mount model, and that escape hatch is worth
   keeping. Still outstanding: the shared `plugins`/`commands`/`cache`
@@ -498,6 +527,15 @@ the shared mount, which is the intended fallback.
   less* container write access than today's wholesale rw `~/.claude`.
 
 ## Backlog
+
+- **Discernment process migration, stage 2: a helper script for the common
+  process-init sequence.** Stage 1 (`feature_mounts`, above) is the mechanism;
+  every migrated process still needs `dax init`/`dax env set ... mounts
+  ~/discernment`/`dax env set ... features claude,mounts` by hand, and that
+  sequence is identical across processes. Worth scripting once a few processes
+  have gone through it manually. Also not yet built: mounting discernment's
+  `skills/` a second time at `~/.claude/skills/` (original decision D scope) —
+  `feature_mounts` only covers the top-level sidecar mount so far.
 
 - **Per-env features are additive only — no way to opt *out*.** Features
   accumulate from four sources (global `features:`, the env entry, a `.dax.yaml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,43 +24,265 @@ functions in `dax.py`.
 - **`dax-preview` GitHub-style UI**: directory listings now use a rounded file table with hover; README.md renders below the listing in a boxed panel with a book icon; a sticky left-side file tree with SVG icons, collapsible folders, and sessionStorage persistence appears on all pages (directory, .md, .json, .yaml). Folder names in the tree navigate; chevron toggles expand/collapse. Heavy dirs (.git, node_modules, etc.) are skipped. Page width auto-expands by 256px to keep content area at the configured width.
 - **GitHub host keys baked in**: all three key types (RSA, ECDSA, ed25519) written to `/etc/ssh/ssh_known_hosts` at image build time — no more `ssh-keyscan` on first use.
 
+- **`~/.dax.yaml` round-trip preservation**: `save_config` no longer destroys
+  comments or alphabetizes keys. `dax_creds/config.py` gained
+  `yaml_round_trip()` (ruamel, `preserve_quotes`, `width=4096` so long `dir:`
+  paths aren't wrapped); `load_dax_config` uses it but **falls back to pyyaml**
+  when ruamel is missing so reads never break, while `save_config` **refuses**
+  rather than falling back, since a pyyaml rewrite is exactly what destroys the
+  file. It also serializes fully before opening the file, so a failed dump
+  can't truncate the config, and deliberately stays an in-place write rather
+  than write-temp-plus-rename — `~/.dax.yaml` is a single-file bind mount in a
+  container, and single-file grpcfuse mounts are where atomic rename breaks.
+  Verified byte-stable against the real `~/.dax.yaml`, including the
+  commented-out `#- claude_tenant_state` toggle. `ruamel.yaml` added to
+  `pyproject.toml` and `Dockerfile.tmpl`. **Requires `pip install -e .` on the
+  host to take effect** — the host is an editable install, the container is not.
+
+- **Per-env Claude credentials by convention**: a bare `claude` in an env's
+  `creds:` list resolves to `claude-<tenant>-<project>` — dax enforces the
+  naming instead of the user hand-maintaining it (a typo'd `claud-fre` sat
+  unused in `~/.dax.yaml` for weeks). `BARE_PROVIDER_CREDS` in
+  `dax_creds/config.py` holds the providers this applies to — claude only,
+  since github/gmail/ssh are genuinely user-level. An explicitly named
+  credential always wins, keeping old configs working and leaving an escape
+  hatch for deliberately sharing one across two envs. A bare token with no
+  `tenant` set is **refused**, not silently shared — `cmd_run` exits. Derived
+  names that aren't registered yet are synthesized in memory rather than
+  written, so resolution stays a pure read and the login flow is what registers
+  them. `find_named_project_by_dir` is new (returns `(name, project)`) because
+  derived names need the registry name.
+
+- **An abandoned login no longer imports the credential already on disk**:
+  `_post_login_import` ran unconditionally after `subprocess.run()`, and its
+  claude branch reads `~/.claude/.credentials.json` — so cancelling a login
+  stored the *existing shared* credential under the new per-env name. Two
+  Keychain entries, one OAuth grant, no isolation, and it authenticated fine so
+  nothing looked wrong. Found in live testing 2026-07-30. `cmd_creds_login` now
+  snapshots the on-disk token before launching the flow (`_disk_token_for`,
+  covering github/claude/auggie) and refuses to import when it is unchanged.
+  **Still open:** `dax creds add`'s claude path has no such guard, so per-env
+  credentials must be minted with `dax creds login`, not `add`.
+
+- **Derived credentials inherit `credential_defaults`**: a synthesized
+  definition had no `browser`/`chrome_profile`, so every per-env login opened
+  the default browser instead of the right Chrome profile. A top-level
+  `credential_defaults: {claude: {browser:, chrome_profile:}}` block is merged
+  into each — the right shape, since browser choice belongs to the human
+  authenticating rather than the env. Defaults never override `provider`; an
+  explicitly registered credential ignores them.
+
+- **`dax creds list` shows derived credentials** (tagged `(derived)`), so the
+  host stops disagreeing with `dax-creds list` in the container. Its "used by"
+  column now resolves rather than matching literally — an env listing a bare
+  `claude` matched nothing before, and a superseded explicit credential wrongly
+  looked in use. `dax creds remove` can also clear a derived credential now
+  (Keychain only, no config write); previously it rejected them as unknown, so
+  a bad one could not be removed at all.
+
+- **`dax creds add` overwrite actually overwrites**: every `_setup_*_credential`
+  now takes `replace=`, set only when the user confirms "Overwrite it?". The
+  old `if provider.check(...): return` early-exit made that confirmation a lie —
+  YAML metadata was rewritten while the Keychain secret was left untouched, so
+  a rotated credential couldn't be re-imported without `dax creds remove` first.
+  When a confirmed replace finds nothing new to store, `_report_no_token` now
+  says explicitly that the old secret survived and how to clear it.
+
+- **`dax creds remove` removes from both stores**: previously it deleted only
+  the Keychain secret, leaving the definition in `~/.dax.yaml` so the credential
+  kept appearing in `dax creds list` and a fat-fingered name could never be got
+  rid of. Now also drops the config entry and saves — and **refuses** if any
+  project still references it, checked before anything is deleted so a refusal
+  leaves both stores untouched.
+
+- **`dax envs list` merged with the tenant view**: outer-joins `~/.dax.yaml`'s
+  projects against a filesystem walk of `~/.local/state/dax/tenants/`, so an env
+  orphaned from *either* direction shows up — a registry entry with no state
+  tree, or a state tree with no registry entry (deregistered or renamed, with
+  transcripts and memory still on disk). The latter was invisible to every
+  previous command and is what the deletion-grouping rationale needs. TENANT,
+  STATE, and USED columns added — tree size plus a compact relative age
+  (`now`/`3d`/`5w`/`1y`), both from a single walk, since size and recency answer
+  different halves of "is this worth keeping". USED is the newest *file* mtime,
+  not the directory's, so an in-place edit doesn't read as ancient. Markers are `*` running,
+  `!` directory missing, `?` orphan, with a legend for whichever appear. A
+  registry row claims its matching tree, so only unclaimed trees are reported —
+  and only a *declared* tenant can claim one, since without it there's no path
+  to look under. `state_trees()`/`state_tree_path()` live in
+  `dax_creds/config.py`. Supersedes `dax tenants`.
+
+- **`dax env show` / `dax env set`**: inspect or edit one environment without
+  walking `dax init`'s full wizard. Singular `env` acts on one environment,
+  matching the existing `tenant`/`tenants` split. `show` prints the registry
+  entry plus resolved container name and running state, the state-tree path and
+  whether it exists, and a warning when the entry still carries deprecated
+  `multi_tenant`/`tenant_subdir` keys. `set` takes one field —
+  `tenant`/`dir`/`image`/`creds` — with `creds` comma-separated and validated
+  against defined credentials before writing; `--help` and the unknown-field
+  error both print the full field table. `name` is optional in both, defaulting
+  to the env containing cwd and falling back to the enclosing project so it
+  works from a subdirectory. `ENV_FIELDS`/`env_field_help()` live in
+  `dax_creds/config.py`, not `init.py`, so parser construction doesn't import
+  keyring on every `dax` invocation.
+
+- **`dax creds login` browser callback works for Claude**: `claude auth login`
+  binds a callback listener *inside* the container while the browser opens on
+  the *host*, so the localhost redirect could never resolve.
+  `_force_claude_device_flow_redirect` (`dax_creds/daemon.py`) rewrites
+  `redirect_uri` to Claude's device-flow callback before the URL reaches the
+  host browser. Paired with `_post_login_import`'s claude branch, which stores
+  the resulting token to Keychain the way the github/auggie branches already
+  did. Confirmed working.
+
 ## In progress
 
 - **Tenant isolation for Claude Code state** — design and status in
-  `docs/design/2026-07-27-tenant-isolation.md`. Replaces the shared `~/.claude`
-  mount with per-tenant/project state trees selected via `CLAUDE_CONFIG_DIR`.
-  Steps 1–2 merged in PR #4. Steps 3–6 implemented, unit-tested, and
-  **confirmed on the real repos this design exists for** — `fabric`
-  (single-tenant) and `discernment` (multi-tenant, `processes/` subdirs) —
-  not just scratch projects. Discernment specifically: two concurrent `claude`
-  sessions in different tmux windows, different labeled processes, same
-  container — each isolated, each persisted its own history correctly across
-  quit/restart, zero cross-tenant leakage. That's the actual bug from this
-  doc's Problem section, fixed and observed, not just theorized. Step 7
-  dropped — see the design doc's Sequencing section for why. Nothing is live
-  by default — `claude_tenant_state` is opt-in per project via its own
-  `features:` list.
-  **Redesigned 2026-07-28**: the `unattributed` fallback is gone entirely —
-  every undeclared location now either resolves, gets interactively
-  classified before the container launches (`dax run` walks the repo root
-  and, for multi-tenant projects, every undeclared child under
-  `tenant_subdir`, refusing to launch until all are assigned), or hard-refuses
-  (only for a subdirectory discovered mid-session, since Docker can't add a
-  mount to an already-running container). `dax tenant classify` re-runs that
-  walk on demand, re-prompting even already-declared entries. A multi-tenant
-  repo's root can now also resolve as its own project/tenant (needed for
-  working on discernment's own tooling independent of any one customer
-  process). 253 tests pass. Still outstanding before trusting this as the
-  default: the shared `plugins`/`skills`/`commands`/`cache` migration from
-  `~/.claude` (scoped, not yet built — see below, and now caveated by a
-  skills-symlink discovery: discernment's own project-specific skills should
-  move to Claude Code's native project-scoped `.claude/skills/` instead of
-  being blanket-shared to every tenant), and the multi-day refresh-token
-  rotation soak (still unconfirmed; nothing tested so far ran long enough to
-  hit it). The real fabric/discernment containers have not been re-tested
-  against this latest classification-flow change yet — that needs an image
+  `docs/design/2026-07-27-tenant-isolation.md`. **Read that doc's
+  "Redesign 2026-07-29 — multi-tenant abandoned" section before touching
+  anything tenant-related.**
+
+  **The multi-tenant model is abandoned.** Each project is single-tenant;
+  `tenant` survives only as a declared grouping label on the project's
+  `~/.dax.yaml` entry, kept because it makes "end the engagement" one
+  `rm -rf` of `~/.local/state/dax/tenants/<tenant>/`. The state tree now
+  mounts directly at `~/.claude`, with `CLAUDE_CONFIG_DIR=$HOME/.claude`
+  as a **constant** — no cwd resolution — kept solely because it is what
+  relocates `.claude.json` inside the directory mount (unset, that file sits
+  at `~/.claude.json`, outside the tree, and is discarded on teardown).
+
+  **A large body of implemented, passing code is slated for deletion, not
+  extension** — `_ensure_tenants_classified`, `_prompt_tenant`,
+  `dax tenant classify`, `resolve_for_cwd`, `dax-creds resolve-tenant`,
+  Gate B in the `claude` wrapper, `.dax-tenant` files,
+  `DAX_MULTI_TENANT`/`DAX_TENANT_SUBDIR`, and ~68 tests. It still reads as
+  current. Don't build on it. `find_enclosing_project`/Gate 0 stays — that
+  is a separate bug, not tenant machinery.
+
+  Trigger: discernment is being reworked so each process becomes its own
+  repository (history split, not `git mv`), removing the only multi-tenant
+  project. Discernment then mounts as a **sidecar** — wholesale at
+  `~/discernment` (rw), with its `skills/` mounted a second time at
+  `~/.claude/skills/` because Claude Code only discovers skills in the
+  directories it scans; a CLAUDE.md pointer registers nothing.
+
+  `claude_tenant_state` stays opt-in for now — the 2026-07-28/29 outage forced
+  a fallback to the old shared-mount model, and that escape hatch is worth
+  keeping. Still outstanding: the shared `plugins`/`commands`/`cache`
+  migration (now a nested mount inside the `~/.claude` tree mount), the
+  multi-day refresh-token rotation soak, executing the deletions above, and a
+  re-test of the real fabric/discernment containers — which needs an image
   rebuild (`dax_creds` is a frozen, non-editable install) plus a fresh manual
   pass.
+
+- **Manual credential test sequence** —
+  `docs/testing/2026-07-30-cred-management-test-sequence.md`. Follow it after
+  any image rebuild or credential change. It exists because the three places the
+  real bugs lived are unreachable from the suite: the macOS Keychain, the Chrome
+  profile a login opens, and whether two credentials are the same OAuth grant.
+  Nearly every step is a **host** command — keyring is unreachable in a
+  container, so `dax creds list` there always reports `stored: no`, and
+  `~/.dax.yaml`'s host paths mean `dax env show` can't match cwd to an env.
+
+  **Container rebuild verified 2026-07-30** (step 0): 342 tests pass, installed
+  `dax_creds` byte-identical to the repo, `/usr/bin/claude` identical to
+  `dax_creds/wrappers/claude` (inject-if-absent shipped), `ruamel.yaml`
+  importable, and `DAX_CREDS_CLAUDE=claude-personal-dax` in a live container —
+  so C2's derived naming resolves end to end, from `~/.dax.yaml` through
+  `dax run` into the container env. **Host step 1 passed 2026-07-30**: editable
+  reinstall picked up ruamel 0.19.1, and `dax env set` rewrote `~/.dax.yaml`
+  byte-identically (empty diff). That is a real round-trip proof, not a
+  short-circuit — `run_env_set` saves unconditionally (`init.py:649`), so a
+  same-value set still serializes the whole file. **Step 2 passed 2026-07-30**
+  with findings — full results in the design doc's "Confirmed 2026-07-30"
+  entry. Headline: all three derived Claude credentials are already in Keychain,
+  minted *before* the C3 fix. **Step 3 passed** — 4 distinct grants, no sharing,
+  refresh expiries staggered across the days the logins happened. Note the
+  check's limit, now in its docstring: the refresh token only *proxies* grant
+  identity, so a copy is detectable until either side refreshes — run step 3
+  right after minting, where the signal is strongest.
+  Also surfaced 8 orphaned state trees, all discernment processes left by the
+  abandoned multi-tenant classification.
+
+  **Step 4 found a blocking bug (C5 in the design doc): `dax creds login`
+  refuses derived names.** `cmd_creds_login` (`dax.py:698`) resolves against
+  `config['credentials']` only; `derived_credentials()` was wired into `creds
+  list`, `creds remove`, and `env show` but not `login`. Since `add`'s claude
+  path is the unguarded one C3 warns against, **no sanctioned way to mint a
+  per-env Claude credential currently exists**, and C3's guard is unreachable
+  for the case it was written for. Steps 4–5 blocked until fixed. Related:
+  `_post_login_import` never writes a `credentials:` entry, so a derived name
+  stays derived permanently and `env show`'s `[not registered yet]` is wrong
+  rather than transient.
+
+  **C5 fixed and confirmed live 2026-07-30.** `_login_credential_def()` resolves
+  registered-then-derived; 5 tests added, suite at **347**. A real
+  `dax creds login claude-personal-fabric` opened Chrome Profile 2, used the
+  device-flow redirect, and minted a new grant — hash changed, which is direct
+  proof of a fresh grant rather than a copy. Step 3 still PASS, 4 distinct
+  grants. **C3's refusal path confirmed live** on a second, cancelled run — the
+  "predates this login" refusal printed and Keychain was untouched.
+
+  **New: C6 — the C3 guard compares the file, not the grant.**
+  `_disk_token_for` returns the whole envelope (`providers/claude.py:77`), so a
+  Claude Code token refresh landing inside the login window makes an abandoned
+  login look successful and imports another env's grant under the new name.
+  Low probability, C3's silent-success signature. Tighter fix: before storing,
+  compare the credential's `refreshToken` hash against every other stored Claude
+  credential and refuse on collision — `check_claude_grants.py`'s logic enforced
+  at import time. Not yet built.
+
+  **Also new: C7 — `dax creds add` rebuilds the definition and drops unprompted
+  fields.** `_define_credential` starts from `{'provider': ...}` (`init.py:113`)
+  and `_run_creds_add` assigns it wholesale (`init.py:369`), so re-running `add`
+  on an existing credential silently loses anything its prompts don't ask for;
+  `dax creds update` is the non-lossy path. Because of this, manual step 6 was
+  downgraded to optional — its three `replace=` behaviors are already unit-tested
+  (`test_dax_creds_init.py:281–320`), and `claude-fre` must never be used as the
+  target since claude's replace path would import the shared credential and
+  manufacture a shared grant.
+
+  **Any Claude login rewrites the shared credential.**
+  `_LOGIN_PROVIDERS['claude']` mounts the host's `~/.claude`
+  (`dax.py:644`), so while `feature_claude`'s wholesale mount is in use, logging
+  in for one env repoints *every* container — inject-if-absent skips a non-empty
+  file, so each authenticates on whichever env logged in last regardless of its
+  own `DAX_CREDS_CLAUDE`. Per-env credentials stay inert at runtime until
+  decision B lands.
+
+  Also corrected: `refreshTokenExpiresAt` does **not** reliably encode mint date
+  (a grant minted 07-30 reported 08-27, earlier than older grants), so staggered
+  expiries cannot corroborate separate mints. A grant hash changing across a
+  known-good login is the evidence that does.
+
+  Note for step 7: `feature_claude_tenant_state` and the wrapper's Gate B are
+  still the **pre-redesign shape** (trees under
+  `~/.local/state/dax/tenants/<t>/<p>`, `dax-creds resolve-tenant`), so
+  decision B is not built and inject-if-absent can only be exercised under the
+  shared `~/.claude` mount, where the divergence it guards against cannot
+  arise. Don't switch on `claude_tenant_state` to test it — that exercises the
+  abandoned design.
+
+- **Claude credentials are per tenant/project** — named
+  `claude-<tenant>-<project>`, each minted by its **own fresh login**. That is
+  load-bearing: independent OAuth grants have independent refresh-token chains,
+  so rotation in one project cannot invalidate another's credential even when
+  every entry authenticates the same account. Minting a credential by *copying*
+  an existing blob (which is what `ClaudeProvider.import_from_disk()` does, via
+  `_setup_claude_credential` and `_post_login_import`) shares one grant between
+  two entries and breaks that property.
+
+  **Done 2026-07-29:** the `claude` wrapper now injects from Keychain only when
+  the state tree has no credential (`-s`, so a zero-byte file counts as absent),
+  and skips the daemon fetch entirely when one exists. Previously it overwrote
+  `.credentials.json` on every launch — harmless under a shared `~/.claude`,
+  but under a persistent per-project tree it would clobber a refreshed token
+  with the stale Keychain snapshot on the next start. Keychain is now a
+  bootstrap; Claude Code owns rotation from first launch.
+
+  **Not built:** teardown write-back to Keychain. Deliberately deferred — see
+  decision C of the design doc. The gap is softened by inject-if-absent: a
+  missed write-back leaves the tree's working credential in place rather than
+  forcing a stale one over it.
 - **Fixed: `dax run` from inside a registered project's subdirectory silently
   mis-scoped the container.** `cmd_run`'s project lookup (`find_project_by_dir`)
   only matches by exact `dir:` equality; a `cd` into `discernment/processes/<name>/`
@@ -75,7 +297,14 @@ functions in `dax.py`.
   already-registered project. See `docs/design/2026-07-27-tenant-isolation.md`
   decision 6's "Gate 0" note. 259 tests pass.
 - **Shared plugins/skills/commands/cache migration** — scoped but not yet
-  built. Plan: one-time, host-wide copy (not a symlink) from
+  built, and **reshaped by the 2026-07-29 redesign**: with the state tree now
+  mounted at `~/.claude` itself, these become *nested* mounts inside it
+  (`shared/plugins` → `~/.claude/plugins`), not a sibling path. Docker orders
+  mounts by destination depth, so the nesting resolves. `skills/` is further
+  changed — discernment's shared skills now arrive via the sidecar's second
+  mount at `~/.claude/skills/`, and project-specific skills belong in the
+  project's own `.claude/skills/`. Original plan, still broadly applicable:
+  one-time, host-wide copy (not a symlink) from
   `~/.claude/{plugins,skills,commands}` into
   `~/.local/state/dax/shared/{plugins,skills,commands,cache}` the first time
   `claude_tenant_state` runs and the shared dir doesn't exist yet, gated on
@@ -87,24 +316,17 @@ functions in `dax.py`.
 
 ## Backlog
 
-- **`dax creds add` doesn't actually overwrite Keychain on re-add** —
-  `_setup_claude_credential`'s `if provider.check(...): return` early-exit
-  means confirming "Overwrite it?" only rewrites YAML metadata, not the
-  Keychain secret itself. Found during tenant-isolation testing when a
-  rotated credential wouldn't take; workaround is `dax creds remove` before
-  `dax creds add`. Fix: the overwrite-confirmed path needs to actually call
-  through to the provider's store, not early-return before it.
-- **`dax creds login`'s browser callback doesn't work for Claude** — same
-  class of bug as Auggie's already-known limitation. Workaround is the
-  device-flow login instead. Found during the same tenant-isolation testing
-  pass as the Keychain-overwrite bug above.
+- **`dax init` should prompt for `tenant`** at registration time — editing an
+  existing env is now covered by `dax env set`.
 
-- **`save_config` destroys `~/.dax.yaml` comments and key order** — `dax_creds/init.py:26`
-  loads via `yaml.safe_load` and rewrites with `yaml.dump`, so comments (which
-  aren't in the parsed dict) vanish and keys get alphabetized by the default
-  `sort_keys=True`. Triggered by `dax creds add`, `dax creds update`, and
-  `dax init`. Fix: switch to `ruamel.yaml` round-trip mode; stopgap is
-  `sort_keys=False` plus a `.dax.yaml.bak` before each write.
+- **Retire `dax tenants` and `dax tenant classify`** — superseded by the merged
+  `dax envs list`.
+
+- **`_run_init` matches projects by exact `dir == cwd`** (`dax_creds/init.py`)
+  — the same blind spot `find_enclosing_project` closed for `cmd_run`, so
+  `dax init` from inside a registered project's subdirectory still registers a
+  duplicate project. Worth fixing in the same pass as wiring `tenant` into
+  init.
 
 - **`claude` wrapper doesn't seed `oauthAccount`/`userID`** — cosmetic only
   (omitting it just costs a profile-fetch round trip and the org name in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,117 @@ dax is a Docker-based development environment manager. It reads `~/.dax.yaml`
 features (volume mounts, port mappings, etc.) assembled from named feature
 functions in `dax.py`.
 
+## Legacy Claude state: migrate the process now, recover history on demand
+
+**Settled 2026-08-02, closing out the `migrate_env_state.py` redesign thread.**
+**Still nothing committed** — this branch has been accumulating uncommitted
+work across several sessions (see `git status`). **505 tests passing** (up
+from 493): `tests/test_dax_migrate_env_state.py` is new (12 tests), plus the
+`tools/migrate_env_state.py` rewrite itself and a doc update. Full detail on
+everything else already built is in "In progress" below; this block covers
+just this session.
+
+**The decision:** don't build further auto-detection into
+`migrate_env_state.py` (no cwd-based env resolution, no auto-including
+discovered legacy keys). When a discernment process is split into its own repo
+and registered as its own env, migrate the process's *files* — the code,
+`context.md`/`inbox.md`, whatever `dax process new`/`new-process.sh` scaffold
+— right away, and **don't fret about pulling its old Claude session state
+along with it at the same time.** If, later, work resumes on that process and
+it's worth asking whether relevant history got left behind, the recovery path
+is: mount the real host `~/.claude` into that env (`dax env set <name> mounts
+'~/.claude:host-claude'`, the `host:container_name` syntax built for exactly
+this), restart, and have a live Claude session crawl `~/host-claude/projects/`
+and `history.jsonl` at that point. A live session can *read content* and use
+judgment about what's actually relevant to the process at hand — which is
+precisely what `migrate_env_state.py` cannot do and deliberately refuses to
+guess at (the ancestor/commingled-parent case below). That makes it strictly
+better than any heuristic bolted onto the script for the one case that
+actually needs a decision, and it defers the work to exactly when it's
+valuable instead of speculatively building it now for processes that may never
+need their old state resurrected. **Condition for this to keep working: don't
+delete `~/.claude/projects/<key>/` or `history.jsonl` entries on the host in
+the meantime** — they're the substrate this on-demand recovery depends on;
+that discipline was already the existing runbook caution, just now load-
+bearing for a second reason.
+
+`migrate_env_state.py` itself stays exactly as built below — explicit
+`--legacy-cwd`, discovery report, no auto-inclusion — since it's still the
+right tool for the unambiguous case (an env that already knows its own
+handful of historical cwds and just wants them copied in mechanically).
+
+**The mounts reconfig from the prior pause landed and worked**:
+`~/host-claude/projects/` is visible and confirmed to be the real host
+`~/.claude`, not a guess.
+
+**What the real data showed** — checked before designing anything, per the
+prior session's own instruction: a discernment sub-process's history is
+genuinely strewn across more than one `projects/` key, and not just by rename.
+For `self-employment-setup` (historically `~/work/processes/self-employment-setup`,
+before dax existed):
+
+- its own nested-path key, `-home-dfarrow-work-processes-self-employment-setup`
+  — 1 session, 30MB, 21 `history.jsonl` lines — is unambiguously this
+  process's.
+- `-home-dfarrow-work-processes` (155 lines) and `-home-dfarrow-work` (1858
+  lines) are **ancestor** keys — sessions recorded with cwd at a shared parent,
+  before/without `cd`-ing into the specific process directory. These commingle
+  every process ever nested under them and cannot be attributed to one process
+  by directory alone; reading content would be required, which the tool
+  deliberately does not attempt.
+
+**`tools/migrate_env_state.py` rewritten accordingly** (not yet run for real —
+this session's testing was read-only dry runs against the mounted
+`~/host-claude` via a scratch `HOME`, never against this container's own live
+`~/.claude`):
+- `--legacy-cwd PATH` (repeatable) supplies historical absolute cwds the tool
+  cannot infer on its own (a rename/restructure is exactly what makes the old
+  path differ from the new one). Each legacy cwd's `projects/<key>/` copies
+  into the tree as **its own directory**, never merged into the canonical
+  key's — `/resume` is scoped to the container's current cwd, so merging
+  wouldn't make old sessions resumable anyway, while separate directories keep
+  provenance honest.
+- Every run — with or without `--legacy-cwd` — now prints a **discovery
+  report** first: other `projects/` keys ending in the env's name that weren't
+  passed (a forgotten legacy cwd), and ancestor keys of anything being
+  migrated (the commingled-parent case above), each with a real path and
+  `history.jsonl` line count pulled from actual recorded data (`path_to_key`
+  can't be reversed reliably on its own — a literal dash in a directory name
+  is indistinguishable from a mangled slash — so paths are cross-referenced
+  from `history.jsonl`'s own `project` field instead of guessed). Ancestor data
+  is reported, never copied.
+- Verified against the real `~/host-claude` data via a scratch `~/.dax.yaml` +
+  `HOME` override (dry run only, no writes): the discovery report's line counts
+  (57 / 1858 / 155) matched the manual `history.jsonl` scan exactly, both with
+  and without `--legacy-cwd` supplied.
+- `docs/testing/2026-07-31-migrate-env-to-state-tree.md` gained a
+  `--legacy-cwd` section with this same worked example.
+
+**Deliberately not done, and not blocking anything — per the decision above.**
+This session only dry-run-verified the tool against real data; it hasn't been
+run with `--apply`, and `self-employment-setup` / `a-priest-and-an-imam` /
+`augmentcode` aren't yet registered as their own dax envs (the real
+`~/.dax.yaml` shown earlier in this project's history only has `dax`,
+`discernment`, `fabric`, `ys-augmentcode`, `a-priest-and-an-imam`,
+`symlink-disclosure`). Registering each as its own env (via `dax process new`)
+migrates the process itself; running `migrate_env_state.py --apply
+--legacy-cwd ...` against it — or skipping straight to the on-demand mount-
+and-crawl recovery — is a later, optional step whenever that process is
+actually revisited, not a prerequisite to registering it.
+
+**Separate open thread, not yet started:** `new-process.sh`'s scaffolding is
+too destructive for migrating a directory that already has its own
+`context.md`/`inbox.md` (refuses on `context.md`, but silently overwrites
+`CLAUDE.md`/`inbox.md` with no check at all if `context.md` happens to be
+absent). Sketched a non-destructive redesign in conversation (merge
+frontmatter into `context.md` rather than refuse; treat `inbox.md`/`CLAUDE.md`
+like `.gitignore` — write only if absent) but **this is a change to
+`new-process.sh` itself, which lives in the virgil/discernment repo, not
+dax** — `docs/design/scripts/new-process.sh` here is only an untracked
+reference copy. Offered to draft the patch against that local copy for the
+user to port over; not done because the user hadn't confirmed they wanted
+that when the mounts question came up instead.
+
 ## Completed
 
 - **Auto port assignment for webpreview**: `_find_preview_port(cwd)` hashes the
@@ -248,6 +359,118 @@ the shared mount, which is the intended fallback.
   re-test of the real fabric/discernment containers — which needs an image
   rebuild (`dax_creds` is a frozen, non-editable install) plus a fresh manual
   pass.
+
+  **Discernment (renaming to "virgil") authored its own dax contract,
+  2026-08-01: `docs/design/VALIDATION.md`** — dropped in-repo, untracked
+  (`docs/design/scripts/` is gitignored and holds `new-process.sh`, `wire.sh`,
+  `process-types.tsv`; never check those in). The user manually validated the
+  substrate's own parts (mounts, wiring, the settings fragment, the
+  PreToolUse guard, the feedback path) against a real process directory
+  before any of this was built — teardown (`destroy-process`) is deferred to
+  a later phase. **Parts 1–5 of the contract are now built and unit-tested**
+  (469 tests, up from 435), superseding stage 2 of the `feature_mounts` note
+  above and the matching backlog item:
+
+  - **`feature_substrate`** (`dax.py`) — a new single-path project field
+    `substrate` (distinct from the generic `mounts:` list: dax needs to know
+    specifically which mount holds `shared/wire.sh`), mounted rw as a sibling
+    under `$HOME` the same way `feature_mounts` does, plus
+    `-e SUBSTRATE_ROOT=<container-path>` — the value both the substrate's own
+    hooks and the `claude` wrapper's gate read. `cmd_run` promotes
+    `project['substrate']` into `config['substrate']` right alongside the
+    `mounts` promotion, learning from the mounts wiring bug rather than
+    repeating it. `dax env show` displays it with the same "feature not
+    active" warning `mounts` gets.
+  - **`dax_creds/wrappers/entrypoint.sh`** (new) — runs `wire.sh --quiet`
+    once per **container boot** when `SUBSTRATE_ROOT` is set, wired in via a
+    new `Dockerfile.tmpl` `ENTRYPOINT` (the image had none before). This is
+    load-bearing, not stylistic: VALIDATION.md's Part 4 failure-mode tests
+    restart a *Claude session* without restarting the *container* specifically
+    to prove the PreToolUse guard fires on its own — if wire.sh's self-heal
+    ran on every `claude` launch instead, a bare session restart would
+    silently repair the very breakage the test exists to catch. Never exits
+    on failure, so the container shell still starts even when substrate
+    wiring is broken (repair has to be possible from inside it). A complete
+    no-op for every env not opted into `substrate` — needs an image rebuild
+    (`dax build`) to take effect, same as the wrapper change below.
+  - **`dax_creds/wrappers/claude`** gate + settings delivery — right before
+    the existing final exec, if `SUBSTRATE_ROOT` is set, runs
+    `wire.sh --check` **only** (never a bare `wire.sh` — see above) and
+    branches: `0` → prepend `--settings .../substrate-settings.json` (unless
+    the caller already passed one) and proceed; `127` (the script itself is
+    gone — the mount is down) and `1` (mounted but wired wrong) each refuse
+    with a distinct message, matching VALIDATION.md's exit-code table.
+  - **`dax process new <name>`** (`dax.py`, alongside `_prompt_tenant`/
+    `_known_tenant_names` — reused directly, which is why this lives in
+    `dax.py` rather than a new `dax_creds` module and avoid a circular
+    import) — every field (`--dir`/`--tenant`/`--substrate`/`--title`/
+    `--type`/`--git`|`--no-git`) is either given on the command line or
+    interactively prompted, wizard-style like `dax init`; dax never lets
+    `new-process.sh`'s own basic prompting fire, since everything is
+    fully resolved before invoking it. `--type` is validated (or, if
+    omitted, offered as a picklist) against the substrate's own
+    `process-types.tsv` — never hardcoded. Runs `new-process.sh`
+    **host-side**, before any container exists, a deliberate flagged
+    deviation from the script's own "runs inside the container" comment:
+    mechanically safe, since the script never touches `$HOME` or any
+    container-only state (confirmed by reading it), and dax has no
+    docker-exec-into-running-container mechanism worth building for one
+    call. Always registers `creds: [claude]` and, unconditionally,
+    `features: [substrate, claude_tenant_state]` — every substrate-backed
+    process needs both, no conditionality.
+
+  **Not yet done: the manual verification pass** (image rebuild + a real
+  `dax process new` / `dax run` / `claude` session, per the plan's
+  verification section) — this session had no Docker access to run it.
+  Confirmed instead via a scripted dry run against the real dropped scripts
+  (fake substrate + fake `~/.dax.yaml`, `dax process new` end-to-end, then
+  `dax -t run` to confirm the assembled `docker run` command carries both
+  `--volume=.../virgil:/home/dfarrow/virgil` + `SUBSTRATE_ROOT` and the
+  `claude_tenant_state` mount) — real, but short of an actual container.
+
+  **`dax process new` hardened, same day: absolute-path guardrails, a
+  full-path confirmation summary, and `--dry-run`.** Found live-testing the
+  first cut: `--dir`/`--substrate` were never resolved to absolute paths (a
+  relative or unresolved value stored verbatim in `~/.dax.yaml`'s `dir:`
+  would silently break every cwd-based env lookup later), there was no check
+  against nesting inside or colliding with an already-registered project
+  (the same mistake `find_enclosing_project`/Gate 0 catches for `dax run`,
+  just not here), and no check that the directory was even under `$HOME`
+  (where `dax run` would refuse it anyway, just much later). `_run_process_new`
+  now `.resolve()`s both paths immediately, and a new `_check_process_dir`
+  refuses all three before anything is created. Every run also prints a
+  full-absolute-paths summary — directory, substrate, tenant, title,
+  type/skill, git decision, image, creds, features, and the exact Claude
+  state-tree path — before doing anything, gated on typing `Y` (or
+  `--dry-run`, which stops right after the summary). 15 new tests, suite at
+  **478**.
+
+  **`dax process destroy` built, same day — the deferred item 6 of the
+  contract, generalized.** Tears down a registered process's directory,
+  Claude state tree (plus its sibling `sync_claude_shared_files` manifest,
+  which lives *beside* the tree and would otherwise survive as orphaned
+  cruft), any per-env **derived** credential (never an explicitly-named/
+  shared one, just because one env's `creds:` listed it), and the
+  `~/.dax.yaml` entry itself. Deliberately not restricted to
+  substrate-tagged envs — the same cleanup applies to any tenant-isolated
+  project, and narrowing it would only get in the way of burning down other
+  test cruft. `dax process destroy [name ...] [--dry-run]`: named envs, or an
+  interactive `_q_checkbox` picker (same widget `dax init`'s credential
+  selection already uses) over every registered env when none are given,
+  nothing pre-checked. Every candidate is checked *before* any deletion
+  begins — refuses if its container is currently running
+  (`docker stop <name>` first), warns (doesn't block) on uncommitted git
+  changes. The confirmation is a typed literal `DESTROY`, not a Y/n — a
+  deliberately higher bar than creation's, since destroying isn't
+  recoverable the way creating is. Filesystem deletion happens before the
+  `~/.dax.yaml` edit, so a mid-batch crash leaves a stale-but-visible
+  registry entry (`dax envs list`'s existing `!` "directory missing" marker)
+  rather than silent loss. 13 new tests, suite at **491**. Verified live with
+  a scripted fixture (fake project + fake state tree, no real Keychain): dry
+  run touched nothing, then a real run with `DESTROY` removed the directory
+  and state tree and cleared the registry entry, degrading gracefully (a
+  warning, not a crash) on the missing-keyring case this sandbox always
+  hits.
 
 - **Manual credential test sequence** —
   `docs/testing/2026-07-30-cred-management-test-sequence.md`. Follow it after
@@ -526,16 +749,37 @@ the shared mount, which is the intended fallback.
   where a host-authored command is invisible in containers, and are *strictly
   less* container write access than today's wholesale rw `~/.claude`.
 
+  **`feature_mounts` gained an explicit container-name syntax, 2026-08-01:**
+  `host:container_name`, defaulting to `dir_basename(host)` as before when no
+  colon is present — a fully backward-compatible extension, not a format
+  change. Immediate driver: `tools/migrate_env_state.py` needs rethinking
+  (process state can be strewn across more than one `~/.claude/projects/<key>`
+  directory — cwd variations, renames — not just the single top-level key it
+  currently assumes), and designing that properly needs the real host
+  `~/.claude/projects/` visible from inside a container to look at. Mounting
+  the host's actual `~/.claude` a second time under its own basename would
+  collide with whatever `claude_tenant_state` already owns at `~/.claude`
+  itself — the explicit name (e.g. `~/.claude:host-claude`) is what avoids
+  that. 2 new tests, suite at **493**. **Not yet applied**: this needs
+  `dax env set dax mounts '~/.claude:host-claude'` (plus `mounts` added to
+  `dax`'s features) and a container restart to take effect — and since this
+  session runs inside that very container, restarting it will interrupt the
+  session, so it's a deliberate step for the user to take when ready, not
+  something to script automatically.
+
 ## Backlog
 
-- **Discernment process migration, stage 2: a helper script for the common
-  process-init sequence.** Stage 1 (`feature_mounts`, above) is the mechanism;
-  every migrated process still needs `dax init`/`dax env set ... mounts
-  ~/discernment`/`dax env set ... features claude,mounts` by hand, and that
-  sequence is identical across processes. Worth scripting once a few processes
-  have gone through it manually. Also not yet built: mounting discernment's
-  `skills/` a second time at `~/.claude/skills/` (original decision D scope) —
-  `feature_mounts` only covers the top-level sidecar mount so far.
+- **~~Discernment process migration, stage 2: a helper script for the common
+  process-init sequence~~ — superseded 2026-08-01 by `dax process new` and
+  the rest of the virgil substrate contract** (see "In progress" above).
+  `dax process new` is that helper script: it wizards through `--dir`/
+  `--tenant`/`--substrate`/`--title`/`--type`/`--git`, scaffolds via
+  `new-process.sh`, and registers the env with `features: [substrate,
+  claude_tenant_state]` unconditionally, in one command. Mounting the
+  substrate's `skills/` a second time at `~/.claude/skills/` is handled
+  differently than originally scoped here (decision D) — `wire.sh` itself
+  symlinks each skill directory into the state tree at container boot, not a
+  second dax-level mount.
 
 - **Per-env features are additive only — no way to opt *out*.** Features
   accumulate from four sources (global `features:`, the env entry, a `.dax.yaml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,16 @@ functions in `dax.py`.
 - **`dax-preview` GitHub-style UI**: directory listings now use a rounded file table with hover; README.md renders below the listing in a boxed panel with a book icon; a sticky left-side file tree with SVG icons, collapsible folders, and sessionStorage persistence appears on all pages (directory, .md, .json, .yaml). Folder names in the tree navigate; chevron toggles expand/collapse. Heavy dirs (.git, node_modules, etc.) are skipped. Page width auto-expands by 256px to keep content area at the configured width.
 - **GitHub host keys baked in**: all three key types (RSA, ECDSA, ed25519) written to `/etc/ssh/ssh_known_hosts` at image build time — no more `ssh-keyscan` on first use.
 
+## In progress
+
+- **Tenant isolation for Claude Code state** — design and status in
+  `docs/design/2026-07-27-tenant-isolation.md`. Replaces the shared `~/.claude`
+  mount with per-tenant/project state trees selected via `CLAUDE_CONFIG_DIR`.
+  Sequencing steps 1–2 (credential wrapper fix, onboarding seed) are done and
+  merged (PR #4). Remaining: steps 3–7 — mount relocation, seed-template
+  wiring for new trees, tenant resolution in the `claude` wrapper, `dax tenant
+  set`/`dax tenants`, and the credential-span escalation check.
+
 ## Backlog
 
 - **`save_config` destroys `~/.dax.yaml` comments and key order** — `dax_creds/init.py:26`

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -445,6 +445,13 @@ RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen \
 	&& echo %%USER%%:%%PASSWD%% | chpasswd \
 	&& echo "done setting up user"
 
+# locale-gen above only builds the locale data — nothing selected it, so every
+# shell defaulted to POSIX/C. Found 2026-07-31: `less` flagged a plain-text
+# CLAUDE.md (containing ordinary em-dashes) as binary under that default.
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
 USER %%USER%%
 
 WORKDIR /home/%%USER%%

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y \
 	nmap \
 	man \
 	pandoc \
+	poppler-utils \
 	procps \
 	python3-pip \
 	socat \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -58,7 +58,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
     && npm install -g @augmentcode/auggie
 
 # install markdown renderer for dax-preview, and MS Office doc support
-RUN pip3 install --break-system-packages markdown pyyaml openpyxl python-docx python-pptx pandas pytest
+RUN pip3 install --break-system-packages markdown pyyaml ruamel.yaml openpyxl python-docx python-pptx pandas pytest
 
 # install dax-preview web server
 RUN cat > /usr/local/bin/dax-preview << 'PYEOF'

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -428,6 +428,9 @@ RUN chmod +x /usr/bin/auggie
 COPY dax_creds/wrappers/dax-creds-open-url /usr/bin/dax-creds-open-url
 RUN chmod +x /usr/bin/dax-creds-open-url
 
+COPY dax_creds/wrappers/entrypoint.sh /usr/local/bin/dax-entrypoint.sh
+RUN chmod +x /usr/local/bin/dax-entrypoint.sh
+
 # pre-populate GitHub host keys so containers don't need ssh-keyscan on first use
 RUN printf '%s\n' \
     'github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=' \
@@ -467,4 +470,5 @@ RUN printf '%s\n' \
     '}' \
     > /home/%%USER%%/.mcp.json
 
+ENTRYPOINT ["/usr/local/bin/dax-entrypoint.sh"]
 CMD ["%%SHELL%%"]

--- a/README.md
+++ b/README.md
@@ -78,9 +78,6 @@ features:
   - dotfiles
   - ssh
 
-workdir:
-  container: work
-
 dotfiles:
   ro:
     - ~/.zshrc
@@ -102,9 +99,6 @@ features:
   - claude
   - auggie
   - webpreview
-
-workdir:
-  container: work
 
 dotfiles:
   ro:
@@ -165,7 +159,6 @@ projects:
 | `image` | Default Docker image to use |
 | `features` | Default feature list for `dax run` |
 | `dotfiles` | Files to mount into the container (`ro` / `rw`) |
-| `workdir` | Container path for the mounted working directory |
 | `credentials` | Named credential definitions (managed by `dax creds`) |
 | `projects` | Registered environments (managed by `dax init`) |
 | `backup` | Host paths to copy into `backup/` when running `dax backup` |
@@ -405,7 +398,7 @@ dax run -p 8080:80         # expose an extra port
 
 | Feature | Description |
 | --- | --- |
-| `workdir` | Mounts the current host directory as the working directory inside the container |
+| `workdir` | Mounts the current host directory into the container, at a path named after the host directory's own basename |
 | `dotfiles` | Mounts dotfiles from `~/.dax.yaml` into the container (`ro` or `rw`) |
 | `ssh` | Forwards the SSH agent into the container; keys stay on the host |
 | `claude` | Mounts `~/.claude` into the container for Claude Code config |

--- a/dax.py
+++ b/dax.py
@@ -123,58 +123,88 @@ def feature_claude(config):
     return _add_volume(config, 'claudedir')
 
 
-# Shared across every tenant (decision 11 in the design doc): plugins/,
-# skills/, commands/, and caches - nested into each project's own state tree
-# so Claude Code finds them at their usual CLAUDE_CONFIG_DIR-relative path
-# without duplicating them per tenant. 'cache' is an inferred addition
-# (observed as a real top-level Claude Code directory during manual testing
-# 2026-07-27) alongside the three the design doc names explicitly - not
-# contractual, worth re-checking after version bumps like the rest of the
-# seed mechanics.
-_CLAUDE_TENANT_SHARED_DIRS = ('plugins', 'skills', 'commands', 'cache')
+# Mounted from the host's own ~/.claude into every state tree, nested at their
+# usual CLAUDE_CONFIG_DIR-relative paths (decision B2, which replaced decision
+# 11's four-directory `shared/` tree and its seeding copy).
+#
+# `commands` is the real user state — 11 commands in active use, and lost per
+# project without this. `plugins` earns its place weakly: nothing is installed
+# there, only the marketplace catalog Claude Code auto-installs and refreshes
+# itself, so this avoids N redundant multi-megabyte clones rather than preserving
+# anything.
+#
+# `skills` and `cache` were dropped. Skills arrive from the discernment sidecar
+# (decision D), so a copy here would go stale against the repo. Cache is derived,
+# generic, cheap to refetch, and the only one of the four where fetched content
+# can turn account-specific.
+_CLAUDE_HOST_SHARED_DIRS = ('commands', 'plugins')
 
 
 def feature_claude_tenant_state(config):
-    # Sequencing step 6 (docs/design/2026-07-27-tenant-isolation.md): the
-    # opt-in replacement for feature_claude's wholesale ~/.claude mount. A
-    # project adds 'claude_tenant_state' to its own features: list (not
-    # feature_claude's name) to switch this on - see the design doc's
-    # Sequencing section for why this stays a separate feature rather than
-    # replacing feature_claude outright.
-    #
-    # Host directories referenced here may not exist yet on first use for a
-    # brand-new tenant/project. Verified 2026-07-27: Docker auto-creates
-    # missing bind-mount host paths owned by the actual host user (not root),
-    # so the container can write into them immediately - see the design
-    # doc's Sequencing step 6 note for how this was checked.
-    from dax_creds.tenant import all_tenant_projects
+    """Decision B: this env's state tree mounts at `~/.claude` itself.
 
+    The opt-in replacement for `feature_claude`'s wholesale `~/.claude` mount —
+    the two are mutually exclusive, since both target the same destination, and
+    `cmd_run` refuses rather than letting Docker fail on a duplicate mount point.
+
+    `CLAUDE_CONFIG_DIR` is a **constant**, not a selector: no cwd resolution, no
+    per-session computation. It is set only because it is what relocates
+    `.claude.json` *into* the tree. Unset, Claude Code writes `~/.claude.json` — a
+    sibling of `~/.claude`, so outside the mount, container-local, and discarded
+    on teardown, taking per-project trust and the `projects{}` block with it. The
+    symptom is the first-run wizard reappearing, not an error.
+
+    Deliberately does not set `DAX_TENANT_STATE`. That was Gate B's master switch,
+    telling the wrapper to resolve a tenant from cwd and compute the path itself.
+    The path is now handed down, so a wrapper that still contains Gate B (any
+    image built before this change) simply skips it and honours what is set here —
+    which is what makes this testable without an image rebuild.
+
+    Tenant comes from the env's `~/.dax.yaml` entry (decision A: a declared
+    grouping label), not a `.dax-tenant` file. Without one there is no path to
+    mount, and pooling into a default is the isolation failure this design exists
+    to prevent, so it refuses.
+
+    Host directories may not exist yet for a brand-new env. Verified 2026-07-27:
+    Docker auto-creates missing bind-mount host paths owned by the real host user
+    rather than root, so the container can write into them immediately.
+    """
     project_name = config['workdir_name']
-    multi_tenant = bool(config.get('multi_tenant'))
-    tenant_subdir = config.get('tenant_subdir', '')
-    repo_root = Path(config['cwd'])
+    tenant = config.get('tenant')
+    if not tenant:
+        dax_print('[!] claude_tenant_state needs a tenant for {}, and none is '
+                  'declared.'.format(project_name))
+        dax_print('    The state tree lives at '
+                  '~/.local/state/dax/tenants/<tenant>/{}/, so there is nowhere'.format(
+                      project_name))
+        dax_print('    to mount without one. Set it with:')
+        dax_print('      dax env set {} tenant <name>'.format(project_name))
+        sys.exit(1)
+
     container_home = _container_home(config)
-    host_root = os.path.expanduser('~/.local/state/dax')
-    container_root = os.path.join(container_home, '.local/state/dax')
+    cfg_dir = os.path.join(container_home, '.claude')
+    host_tree = os.path.expanduser(
+        os.path.join('~/.local/state/dax/tenants', tenant, project_name))
 
     opts = [
-        '-e', 'DAX_TENANT_STATE=1',
-        '-e', 'DAX_PROJECT_NAME={}'.format(project_name),
+        '-e', 'CLAUDE_CONFIG_DIR={}'.format(cfg_dir),
+        '--volume={}:{}'.format(host_tree, cfg_dir),
     ]
-    if multi_tenant:
-        opts += ['-e', 'DAX_MULTI_TENANT=1']
-    if tenant_subdir:
-        opts += ['-e', 'DAX_TENANT_SUBDIR={}'.format(tenant_subdir)]
 
-    for tenant, project in sorted(all_tenant_projects(repo_root, multi_tenant, tenant_subdir)):
-        host_dir = os.path.join(host_root, 'tenants', tenant, project)
-        container_dir = os.path.join(container_root, 'tenants', tenant, project)
-        opts.append('--volume={}:{}'.format(host_dir, container_dir))
-
-        for shared_dir in _CLAUDE_TENANT_SHARED_DIRS:
-            host_shared = os.path.join(host_root, 'shared', shared_dir)
-            container_shared = os.path.join(container_dir, shared_dir)
-            opts.append('--volume={}:{}'.format(host_shared, container_shared))
+    # Decision B2: mounted straight from the host's own ~/.claude rather than
+    # copied into a shared/ tree, so there is one source of truth and no seeding
+    # step. Nested inside the tree mount above — Docker orders mounts by
+    # destination depth, so the deeper paths land after it.
+    #
+    # Skipped when absent rather than letting Docker create them: a host with no
+    # commands of its own should not acquire an empty ~/.claude/commands as a side
+    # effect of running a container.
+    for shared_dir in _CLAUDE_HOST_SHARED_DIRS:
+        host_shared = os.path.expanduser(os.path.join('~/.claude', shared_dir))
+        if not os.path.isdir(host_shared):
+            continue
+        opts.append('--volume={}:{}'.format(
+            host_shared, os.path.join(cfg_dir, shared_dir)))
 
     return opts
 
@@ -301,11 +331,16 @@ def _add_feature(feature, config):
     return fn(config)
 
 
+def _feature_names():
+    """Every feature a config may name, from the feature_* functions themselves."""
+    return {name[len('feature_'):] for name in globals()
+            if name.startswith('feature_')}
+
+
 def _print_features():
     dax_print("[!] available features:")
-    for name in sorted(globals()):
-        if name.startswith('feature_'):
-            dax_print("\t{}".format(name[len('feature_'):]))
+    for name in sorted(_feature_names()):
+        dax_print("\t{}".format(name))
 
 
 def _get_version():
@@ -531,6 +566,22 @@ def cmd_run(args):
         # Nothing needs persisting, so `dax run` stays a non-writer.
         for _name, _cdef in project_creds.items():
             dax_config.setdefault('credentials', {}).setdefault(_name, _cdef)
+        # Decision A: a declared grouping label on the env's entry. This is what
+        # feature_claude_tenant_state builds the state-tree path from — no
+        # `.dax-tenant` file, no cwd resolution.
+        config['tenant'] = project.get('tenant')
+
+        # Per-env feature opt-in, which was never actually wired up: features came
+        # only from the global `features:` list, a `.dax.yaml` in cwd, and `-f`.
+        # The design doc, CLAUDE.md, and feature_claude_tenant_state's own
+        # docstring all describe adding a feature to an env's own `features:` list
+        # — and doing so did nothing at all. Without this there is no per-env
+        # opt-in, so `claude_tenant_state` could only be switched on for every env
+        # at once or passed by hand on every launch.
+        for feature in project.get('features') or []:
+            if feature not in config['features']:
+                config['features'].append(feature)
+
         config['multi_tenant'] = bool(project.get('multi_tenant'))
         config['tenant_subdir'] = project.get('tenant_subdir', '')
 
@@ -568,14 +619,20 @@ def cmd_run(args):
         if 'ports' not in features:
             features.append('ports')
 
-    if 'claude_tenant_state' in features:
-        # Gate A, before mounts are computed: interactively fill in anything
-        # undeclared (silent no-op if everything already is) - this is what
-        # makes dax_creds/tenant.py's "no unattributed fallback, refuse
-        # instead" rule not just friction. Safe to prompt here specifically
-        # because nothing has launched yet; see _ensure_tenants_classified's
-        # own docstring for why the same isn't true mid-session.
-        _ensure_tenants_classified(config)
+    if 'claude_tenant_state' in features and 'claude' in features:
+        # Both mount ~/.claude, so Docker would fail on a duplicate mount point
+        # with a message that says nothing about which feature to remove. The
+        # tenant-state tree is the *replacement* for the shared mount, not an
+        # addition to it (decision B).
+        dax_print('[!] features `claude` and `claude_tenant_state` both mount '
+                  '~/.claude — pick one.')
+        dax_print('    claude_tenant_state replaces the shared mount with this '
+                  'env\'s own state tree.')
+        dax_print('    `claude` is probably in the global features list: remove it '
+                  'there and add it')
+        dax_print('    to the envs that still want the shared mount, or drop '
+                  'claude_tenant_state here.')
+        sys.exit(1)
 
     for feature in features:
         cmd.extend(_add_feature(feature, config))
@@ -1010,7 +1067,8 @@ def cmd_env(args):
         if args.env_command == 'show':
             run_env_show(config, name)
         elif args.env_command == 'set':
-            run_env_set(config, name, args.field, args.value)
+            run_env_set(config, name, args.field, args.value,
+                        valid_features=_feature_names())
     except (KeyError, ValueError) as e:
         dax_print('[!] {}'.format(e.args[0] if e.args else e))
         sys.exit(1)

--- a/dax.py
+++ b/dax.py
@@ -74,6 +74,9 @@ def load_config():
 
     defaults['envname'] = cwd.replace(home, '').lstrip('/').replace('/', '-')
 
+    from dax_creds.config import dir_basename
+    defaults['workdir_name'] = dir_basename(cwd)
+
     local_features = local.pop('features', [])
     defaults.update(local)
     defaults['features'].extend(local_features)
@@ -103,7 +106,7 @@ def _add_volume(config, feature_key):
 
 
 def feature_workdir(config):
-    container = os.path.join(_container_home(config), config['workdir']['container'])
+    container = os.path.join(_container_home(config), config['workdir_name'])
     return ['--volume={}:{}'.format(config['cwd'], container)]
 
 
@@ -118,6 +121,62 @@ def feature_aws(config):
 
 def feature_claude(config):
     return _add_volume(config, 'claudedir')
+
+
+# Shared across every tenant (decision 11 in the design doc): plugins/,
+# skills/, commands/, and caches - nested into each project's own state tree
+# so Claude Code finds them at their usual CLAUDE_CONFIG_DIR-relative path
+# without duplicating them per tenant. 'cache' is an inferred addition
+# (observed as a real top-level Claude Code directory during manual testing
+# 2026-07-27) alongside the three the design doc names explicitly - not
+# contractual, worth re-checking after version bumps like the rest of the
+# seed mechanics.
+_CLAUDE_TENANT_SHARED_DIRS = ('plugins', 'skills', 'commands', 'cache')
+
+
+def feature_claude_tenant_state(config):
+    # Sequencing step 6 (docs/design/2026-07-27-tenant-isolation.md): the
+    # opt-in replacement for feature_claude's wholesale ~/.claude mount. A
+    # project adds 'claude_tenant_state' to its own features: list (not
+    # feature_claude's name) to switch this on - see the design doc's
+    # Sequencing section for why this stays a separate feature rather than
+    # replacing feature_claude outright.
+    #
+    # Host directories referenced here may not exist yet on first use for a
+    # brand-new tenant/project. Verified 2026-07-27: Docker auto-creates
+    # missing bind-mount host paths owned by the actual host user (not root),
+    # so the container can write into them immediately - see the design
+    # doc's Sequencing step 6 note for how this was checked.
+    from dax_creds.tenant import all_tenant_projects
+
+    project_name = config['workdir_name']
+    multi_tenant = bool(config.get('multi_tenant'))
+    tenant_subdir = config.get('tenant_subdir', '')
+    repo_root = Path(config['cwd'])
+    container_home = _container_home(config)
+    host_root = os.path.expanduser('~/.local/state/dax')
+    container_root = os.path.join(container_home, '.local/state/dax')
+
+    opts = [
+        '-e', 'DAX_TENANT_STATE=1',
+        '-e', 'DAX_PROJECT_NAME={}'.format(project_name),
+    ]
+    if multi_tenant:
+        opts += ['-e', 'DAX_MULTI_TENANT=1']
+    if tenant_subdir:
+        opts += ['-e', 'DAX_TENANT_SUBDIR={}'.format(tenant_subdir)]
+
+    for tenant, project in sorted(all_tenant_projects(repo_root, multi_tenant, tenant_subdir)):
+        host_dir = os.path.join(host_root, 'tenants', tenant, project)
+        container_dir = os.path.join(container_root, 'tenants', tenant, project)
+        opts.append('--volume={}:{}'.format(host_dir, container_dir))
+
+        for shared_dir in _CLAUDE_TENANT_SHARED_DIRS:
+            host_shared = os.path.join(host_root, 'shared', shared_dir)
+            container_shared = os.path.join(container_dir, shared_dir)
+            opts.append('--volume={}:{}'.format(host_shared, container_shared))
+
+    return opts
 
 
 def feature_auggie(config):
@@ -184,8 +243,7 @@ def feature_webpreview(config):
     port = config.get('webpreview', {}).get('port') or _find_preview_port(config['cwd'])
     shell = os.environ.get('SHELL', '/bin/zsh')
     container_home = _container_home(config)
-    work_subdir = config.get('workdir', {}).get('container', 'work')
-    preview_dir = os.path.join(container_home, work_subdir)
+    preview_dir = os.path.join(container_home, config['workdir_name'])
     dax_print("[-]   webpreview port: {}".format(port))
     config['_shell_cmd'] = 'DAX_PREVIEW_PORT={} DAX_PREVIEW_DIR={} dax-preview & exec {}'.format(
         port, preview_dir, shell)
@@ -350,8 +408,14 @@ def _start_login_daemon(credentials, port):
         '--tcp-port', str(port),
         '--credentials', json.dumps(credentials),
     ]
+    log_path = Path.home() / '.dax' / f'login-{port}.log'
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_file = open(log_path, 'a')
     dax_print("[+] starting login credential daemon")
-    return subprocess.Popen(cmd, cwd=str(Path(__file__).parent))
+    proc = subprocess.Popen(cmd, cwd=str(Path(__file__).parent),
+                             stdout=log_file, stderr=log_file)
+    proc._dax_log_path = log_path
+    return proc
 
 
 def _find_free_port():
@@ -385,6 +449,29 @@ def _wait_for_tcp(host, port, timeout=5.0):
     return False
 
 
+_DOCKER_TWO_TOKEN_FLAGS = {'--name', '-h', '-v', '--volume', '-e', '-p', '--group-add', '-c'}
+
+
+def _format_docker_cmd(cmd):
+    """One flag (with its value, if it takes a separate one) per line.
+
+    `cmd` mixes combined single tokens (`--volume=host:container`) and
+    flag/value pairs (`-e`, `KEY=val`) depending on which feature built them;
+    this reads correctly either way rather than assuming one form throughout.
+    """
+    lines = []
+    i = 0
+    while i < len(cmd):
+        token = cmd[i]
+        if token in _DOCKER_TWO_TOKEN_FLAGS and i + 1 < len(cmd):
+            lines.append('{} {}'.format(token, cmd[i + 1]))
+            i += 2
+        else:
+            lines.append(token)
+            i += 1
+    return '\n  '.join(lines)
+
+
 def cmd_run(args):
     config = load_config()
     username = _get_username()
@@ -401,17 +488,32 @@ def cmd_run(args):
     daemon_proc = None
     project_creds = {}
     try:
-        from dax_creds.config import load_dax_config, find_project_by_dir, get_project_credentials, daemon_socket_path
+        from dax_creds.config import (
+            load_dax_config, find_project_by_dir, find_enclosing_project,
+            get_project_credentials, daemon_socket_path,
+        )
         from dax_creds.providers.ssh import SshProvider, start_ephemeral_agent, stop_ephemeral_agent
         dax_config = load_dax_config()
         try:
             project = find_project_by_dir(dax_config, Path.cwd())
         except KeyError:
+            enclosing = find_enclosing_project(dax_config, Path.cwd())
+            if enclosing is not None:
+                enclosing_name, enclosing_project = enclosing
+                project_dir = Path(enclosing_project['dir']).expanduser()
+                dax_print(
+                    "[!] {} is inside registered project '{}' at {} but is "
+                    "not its root. Run `dax run` from {}, then cd here "
+                    "inside the container.".format(
+                        Path.cwd(), enclosing_name, project_dir, project_dir))
+                sys.exit(1)
             dax_print("[+] project not registered — starting dax init")
             from dax_creds.init import run_init
             dax_config = run_init(dax_config, Path.cwd())
             project = find_project_by_dir(dax_config, Path.cwd())
         project_creds = get_project_credentials(dax_config, project)
+        config['multi_tenant'] = bool(project.get('multi_tenant'))
+        config['tenant_subdir'] = project.get('tenant_subdir', '')
 
         ssh_creds = {n: d for n, d in project_creds.items() if d.get('provider') == 'ssh'}
         if ssh_creds:
@@ -447,6 +549,15 @@ def cmd_run(args):
         if 'ports' not in features:
             features.append('ports')
 
+    if 'claude_tenant_state' in features:
+        # Gate A, before mounts are computed: interactively fill in anything
+        # undeclared (silent no-op if everything already is) - this is what
+        # makes dax_creds/tenant.py's "no unattributed fallback, refuse
+        # instead" rule not just friction. Safe to prompt here specifically
+        # because nothing has launched yet; see _ensure_tenants_classified's
+        # own docstring for why the same isn't true mid-session.
+        _ensure_tenants_classified(config)
+
     for feature in features:
         cmd.extend(_add_feature(feature, config))
 
@@ -480,7 +591,7 @@ def cmd_run(args):
     if '_shell_cmd' in config:
         cmd += ['/bin/sh', '-c', config['_shell_cmd']]
 
-    dax_print("[+] running: " + ' '.join(cmd))
+    dax_print("[+] running:\n  " + _format_docker_cmd(cmd))
     try:
         if not args.test_only:
             subprocess.run(cmd)
@@ -511,7 +622,7 @@ _LOGIN_PROVIDERS = {
         'auth_command': 'gh auth login --hostname github.com --git-protocol https --web',
     },
     'claude': {
-        'mounts': ['~/.claude'],
+        'mounts': ['~/.claude', '~/.dax-debug'],
         'auth_command': 'claude auth login',
     },
 }
@@ -622,6 +733,7 @@ def cmd_creds_login(cred_name, config):
         subprocess.run(cmd)
     finally:
         daemon_proc.terminate()
+        dax_print(f'[-] login daemon log: {daemon_proc._dax_log_path}')
 
     # Post-login: import token to Keychain
     _post_login_import(cred_name, cred_def, config, provider)
@@ -639,7 +751,14 @@ def _post_login_import(cred_name, cred_def, config, provider):
         else:
             dax_print(f'[!] {cred_name}: no token found after auth flow.')
     elif provider == 'claude':
-        dax_print(f'[+] {cred_name}: auth complete. Run `dax creds add` to store the token if needed.')
+        from dax_creds.providers.claude import ClaudeProvider
+        provider_obj = ClaudeProvider()
+        token = provider_obj.import_from_disk(cred_def)
+        if token:
+            provider_obj.store(cred_name, token)
+            dax_print(f'[+] {cred_name}: token imported to Keychain.')
+        else:
+            dax_print(f'[!] {cred_name}: no token found after auth flow.')
     elif provider == 'auggie':
         from dax_creds.providers.auggie import AuggieProvider
         provider_obj = AuggieProvider()
@@ -732,6 +851,196 @@ def cmd_envs(args):
 
 def cmd_features(args):
     _print_features()
+
+
+def _known_tenant_names():
+    """Every tenant name declared anywhere across every registered project on
+    this host - the pick-list for the classification prompt below."""
+    from dax_creds.config import load_dax_config
+    from dax_creds.tenant import all_tenant_projects
+
+    try:
+        dax_config = load_dax_config()
+    except FileNotFoundError:
+        return set()
+
+    names = set()
+    for project_cfg in dax_config.get('projects', {}).values():
+        proj_dir = Path(project_cfg.get('dir', '')).expanduser()
+        if not proj_dir.is_dir():
+            continue
+        multi_tenant = bool(project_cfg.get('multi_tenant'))
+        tenant_subdir = project_cfg.get('tenant_subdir', '')
+        for tenant, _ in all_tenant_projects(proj_dir, multi_tenant, tenant_subdir):
+            names.add(tenant)
+    return names
+
+
+_NEW_TENANT_CHOICE = '(new tenant)'
+
+
+def _q_select_tenant(prompt, choices, default):
+    import questionary
+    return questionary.select(prompt, choices=choices, default=default).ask()
+
+
+def _q_text_tenant(prompt, default):
+    import questionary
+    return questionary.text(prompt, default=default).ask()
+
+
+def _prompt_tenant(subdir, known_tenants, default=None, _select=None, _text=None):
+    """Interactively ask which tenant `subdir` belongs to.
+
+    Offers a pick-list of tenants already known host-wide (reduces typo'd
+    variants like 'Ysecurity' vs 'ysecurity' fragmenting one tenant into
+    two), with an escape hatch to type a new one - falls straight to free
+    text if nothing is known yet. `_select`/`_text` are injectable for
+    testing, matching the `_picker` pattern already used in dax_creds/init.py
+    - real questionary prompts otherwise.
+    """
+    _select = _select or _q_select_tenant
+    _text = _text or _q_text_tenant
+
+    choices = sorted(known_tenants)
+    if choices:
+        picked = _select("Tenant for {}:".format(subdir), choices + [_NEW_TENANT_CHOICE],
+                          default if default in choices else None)
+        if picked is None:
+            raise KeyboardInterrupt
+        if picked != _NEW_TENANT_CHOICE:
+            return picked
+    result = _text("Tenant name for {}:".format(subdir), default or '')
+    if result is None or not result.strip():
+        raise KeyboardInterrupt
+    return result.strip()
+
+
+def _ensure_tenants_classified(config, reclassify_all=False):
+    """Interactively fill in (or, with reclassify_all, revise) tenant
+    assignments for a claude_tenant_state project: the repo root, and every
+    immediate child under tenant_subdir if multi-tenant.
+
+    Runs at `dax run` time (Gate A), before mounts are computed - which is
+    what makes doing this interactively safe here: nothing needs Docker to
+    add a mount to an already-running container after the fact. A brand-new
+    subdirectory discovered *mid-session* still just hard-refuses
+    (dax_creds/tenant.py's resolve_tenant) - this function only ever runs
+    before a container exists at all.
+
+    reclassify_all=False (the automatic dax-run-time check): silently skips
+    anything already declared - zero friction on routine use.
+    reclassify_all=True (`dax tenant classify`): prompts for everything,
+    defaulting to the current value, so pressing Enter keeps it and typing
+    something new changes it.
+    """
+    from dax_creds.tenant import _read_tenant_label, TENANT_FILE, _NOT_A_PROJECT_SUBDIR
+
+    repo_root = Path(config['cwd'])
+    multi_tenant = bool(config.get('multi_tenant'))
+    tenant_subdir = config.get('tenant_subdir', '')
+    known = _known_tenant_names()
+
+    def _classify(subdir):
+        current = _read_tenant_label(subdir / TENANT_FILE)
+        if current and not reclassify_all:
+            return
+        tenant = _prompt_tenant(subdir, known, default=current)
+        (subdir / TENANT_FILE).write_text(tenant)
+        known.add(tenant)
+
+    _classify(repo_root)
+
+    if multi_tenant:
+        tenant_base = (repo_root / tenant_subdir) if tenant_subdir else repo_root
+        if tenant_base.is_dir():
+            for child in sorted(tenant_base.iterdir()):
+                if not child.is_dir() or child.name in _NOT_A_PROJECT_SUBDIR:
+                    continue
+                _classify(child)
+
+
+def cmd_tenant(args):
+    if args.tenant_command == 'set':
+        subdir = Path(args.subdir)
+        if not subdir.is_dir():
+            dax_print("[!] {} is not a directory".format(subdir))
+            sys.exit(1)
+        (subdir / '.dax-tenant').write_text(args.tenant)
+        dax_print("[+] {}/.dax-tenant set to '{}'".format(subdir, args.tenant))
+    elif args.tenant_command == 'classify':
+        from dax_creds.config import load_dax_config, find_project_by_dir
+        dax_config = load_dax_config()
+        try:
+            project = find_project_by_dir(dax_config, Path.cwd())
+        except KeyError:
+            dax_print("[!] {} is not a registered dax project - run `dax init` "
+                      "first".format(Path.cwd()))
+            sys.exit(1)
+        config = {
+            'cwd': str(Path.cwd()),
+            'multi_tenant': bool(project.get('multi_tenant')),
+            'tenant_subdir': project.get('tenant_subdir', ''),
+        }
+        _ensure_tenants_classified(config, reclassify_all=True)
+
+
+def cmd_tenants(args):
+    # Registry- and declaration-driven, not state-tree-driven: this re-derives
+    # the live (tenant, project) set from ~/.dax.yaml's projects plus whatever
+    # .dax-tenant files actually say right now, the same way dax run would -
+    # so every declared tenant shows up immediately, not only ones that have
+    # had a session, and a stale/renamed declaration can never show something
+    # that no longer resolves that way.
+    from dax_creds.config import load_dax_config, dir_basename
+    from dax_creds.tenant import all_tenant_projects
+
+    try:
+        dax_config = load_dax_config()
+    except FileNotFoundError:
+        dax_print("[-] no ~/.dax.yaml found")
+        return
+
+    state_root = Path(os.path.expanduser('~/.local/state/dax/tenants'))
+    rows = []  # (tenant, project, session, path) - matches display column order
+
+    for project_cfg in dax_config.get('projects', {}).values():
+        proj_dir = Path(project_cfg.get('dir', '')).expanduser()
+        if not proj_dir.is_dir():
+            continue
+        multi_tenant = bool(project_cfg.get('multi_tenant'))
+        tenant_subdir = project_cfg.get('tenant_subdir', '')
+        tenant_base = (proj_dir / tenant_subdir) if (multi_tenant and tenant_subdir) else proj_dir
+        reponame = dir_basename(proj_dir)
+
+        for tenant, project in all_tenant_projects(proj_dir, multi_tenant, tenant_subdir):
+            # project == reponame identifies the repo root's own entry (both
+            # single-tenant and, since 2026-07-28, a multi-tenant repo's own
+            # root project) - everything else is a labeled child under
+            # tenant_base.
+            path = proj_dir if project == reponame else (tenant_base / project)
+            state_dir = state_root / tenant / project
+            used = (state_dir / '.claude.json').exists() or (state_dir / '.credentials.json').exists()
+            rows.append((tenant, project, 'yes' if used else 'no', str(path)))
+
+    if not rows:
+        dax_print("[-] no projects resolve to a tenant yet")
+        return
+
+    rows.sort(key=lambda r: (r[0], r[1]))
+
+    headers = ('TENANT', 'PROJECT', 'SESSION', 'PATH')
+    widths = [max(len(headers[i]), max(len(r[i]) for r in rows)) for i in range(4)]
+    fmt = '  '.join('{{:<{}}}'.format(w) for w in widths)
+    print()
+    print(fmt.format(*headers))
+    previous_tenant = None
+    for row in rows:
+        if previous_tenant is not None and row[0] != previous_tenant:
+            print()
+        print(fmt.format(*row))
+        previous_tenant = row[0]
+    print()
 
 
 def cmd_backup(args):
@@ -840,6 +1149,18 @@ def main():
     envs_sub = envs_p.add_subparsers(dest='envs_command', required=True)
     envs_sub.add_parser('list', help='List registered environments')
 
+    tenant_p = subparsers.add_parser('tenant', help='Manage tenant declarations')
+    tenant_sub = tenant_p.add_subparsers(dest='tenant_command', required=True)
+    tenant_set_p = tenant_sub.add_parser('set', help='Declare the tenant for a subdirectory')
+    tenant_set_p.add_argument('subdir', help='Directory to declare (writes its .dax-tenant file)')
+    tenant_set_p.add_argument('tenant', help='Tenant name to declare')
+    tenant_sub.add_parser(
+        'classify',
+        help='Walk through every subdirectory needing a tenant (run from the project root); '
+             're-prompts even already-declared ones, defaulting to the current value')
+
+    subparsers.add_parser('tenants', help='List known tenants and their projects')
+
     args = parser.parse_args()
 
     if args.command == 'build':
@@ -856,6 +1177,10 @@ def main():
         cmd_creds(args)
     elif args.command == 'envs':
         cmd_envs(args)
+    elif args.command == 'tenant':
+        cmd_tenant(args)
+    elif args.command == 'tenants':
+        cmd_tenants(args)
 
 
 if __name__ == '__main__':

--- a/dax.py
+++ b/dax.py
@@ -10,7 +10,7 @@ import subprocess
 from pathlib import Path
 import yaml
 
-from dax_creds.config import CLAUDE_SHARED_FILES, sync_claude_shared_files
+from dax_creds.config import CLAUDE_SHARED_FILES, dir_basename, sync_claude_shared_files
 
 
 def dax_print(msg):
@@ -350,6 +350,34 @@ def feature_ports(config):
     return opts
 
 
+def feature_mounts(config):
+    """Extra host directories mounted read-write as siblings under $HOME, on
+    top of the project's own workdir mount — e.g. a migrated discernment
+    process's own repo plus the discernment sidecar repo alongside it.
+
+    Deliberately siblings under $HOME rather than nested inside another mount:
+    nesting is exactly the class of bug that broke the CLAUDE.md/settings.json
+    file mounts (see sync_claude_shared_files and the design doc's decision
+    B2) — this sidesteps it rather than relying on directory nesting (which
+    does work) staying that way.
+
+    Named `mounts` on the project entry, comma-split by `dax env set` the same
+    way `creds`/`features` are. Opt-in per env via `features: [mounts]`, same
+    shape as `feature_ports`.
+    """
+    opts = []
+    mounts = config.get('mounts', [])
+    if not mounts:
+        dax_print("[!] no mounts defined for this env")
+        return opts
+    container_home = _container_home(config)
+    for host_path in mounts:
+        host = os.path.expanduser(host_path)
+        container = os.path.join(container_home, dir_basename(host))
+        opts.append('--volume={}:{}'.format(host, container))
+    return opts
+
+
 def _add_feature(feature, config):
     fn_name = 'feature_{}'.format(feature)
     fn = globals().get(fn_name)
@@ -614,6 +642,11 @@ def cmd_run(args):
 
         config['multi_tenant'] = bool(project.get('multi_tenant'))
         config['tenant_subdir'] = project.get('tenant_subdir', '')
+
+        # feature_mounts reads this the same way feature_claude_tenant_state
+        # reads config['tenant'] above — project entries aren't otherwise
+        # promoted into the flat config feature functions see.
+        config['mounts'] = project.get('mounts') or []
 
         ssh_creds = {n: d for n, d in project_creds.items() if d.get('provider') == 'ssh'}
         if ssh_creds:

--- a/dax.py
+++ b/dax.py
@@ -515,14 +515,27 @@ def cmd_build(args):
     dax_print("[+] Commence to take over the world...")
 
 
-def _start_creds_daemon(credentials, socket_path):
+def _start_creds_daemon(credentials, port):
+    """TCP, not a bind-mounted Unix socket — Docker Desktop's Mac-VM file
+    sharing does not reliably forward a live macOS-native Unix socket's
+    connect/accept semantics into a container (regular-file bind mounts
+    mostly work; a socket crossing that same boundary is much shakier).
+    `dax creds login`'s daemon (`_start_login_daemon`) already hit this and
+    switched to `tcp:host.docker.internal:<port>`; found 2026-08 that
+    `cmd_run`'s persistent per-project daemon never got the same fix, so two
+    or more projects running concurrently would each start their own daemon
+    fine, but only the most recently started container's socket-forwarding
+    actually worked — every other one saw ECONNREFUSED from `dax-creds list`
+    despite its daemon process being alive and well on the host.
+    """
     import json
     cmd = [
         sys.executable, '-m', 'dax_creds.daemon',
-        '--socket', str(socket_path),
+        '--tcp-port', str(port),
         '--credentials', json.dumps(credentials),
     ]
-    log_path = socket_path.with_suffix('.log')
+    log_path = Path.home() / '.dax' / f'creds-{port}.log'
+    log_path.parent.mkdir(parents=True, exist_ok=True)
     log_file = open(log_path, 'a')
     dax_print("[+] starting credential daemon (log: {})".format(log_path))
     return subprocess.Popen(cmd, cwd=str(Path(__file__).parent),
@@ -551,16 +564,6 @@ def _find_free_port():
     with _sock.socket() as s:
         s.bind(('', 0))
         return s.getsockname()[1]
-
-
-def _wait_for_socket(path, timeout=5.0):
-    import time
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if path.exists():
-            return True
-        time.sleep(0.05)
-    return False
 
 
 def _wait_for_tcp(host, port, timeout=5.0):
@@ -618,7 +621,7 @@ def cmd_run(args):
     try:
         from dax_creds.config import (
             load_dax_config, find_named_project_by_dir, find_enclosing_project,
-            get_project_credentials, daemon_socket_path,
+            get_project_credentials,
         )
         from dax_creds.providers.ssh import SshProvider, start_ephemeral_agent, stop_ephemeral_agent
         dax_config = load_dax_config()
@@ -738,14 +741,11 @@ def cmd_run(args):
 
     try:
         if project_creds:
-            from dax_creds.config import daemon_socket_path
-            sock_path = daemon_socket_path(Path.cwd())
-            daemon_proc = _start_creds_daemon(project_creds, sock_path)
-            if _wait_for_socket(sock_path):
-                container_sock = '/run/dax-creds.sock'
-                cmd += ['-v', '{}:{}'.format(sock_path, container_sock)]
-                cmd += ['-v', '{}:/run/dax-state:ro'.format(sock_path.parent)]
-                cmd += ['-e', 'DAX_CREDS_SOCK={}'.format(container_sock)]
+            port = _find_free_port()
+            daemon_proc = _start_creds_daemon(project_creds, port)
+            if _wait_for_tcp('127.0.0.1', port):
+                cmd += ['--add-host=host.docker.internal:host-gateway']
+                cmd += ['-e', 'DAX_CREDS_SOCK=tcp:host.docker.internal:{}'.format(port)]
                 cmd += ['-e', 'DAX_CREDS_NAMES={}'.format(','.join(project_creds.keys()))]
                 seen_providers = set()
                 for cred_name, cred_def in project_creds.items():
@@ -755,7 +755,7 @@ def cmd_run(args):
                         seen_providers.add(provider)
                 dax_print("[-]   credentials: {}".format(list(project_creds.keys())))
             else:
-                dax_print("[!] credential daemon socket did not appear — skipping")
+                dax_print("[!] credential daemon did not start — skipping")
                 daemon_proc.terminate()
                 daemon_proc = None
     except Exception as e:

--- a/dax.py
+++ b/dax.py
@@ -10,6 +10,8 @@ import subprocess
 from pathlib import Path
 import yaml
 
+from dax_creds.config import CLAUDE_SHARED_FILES, sync_claude_shared_files
+
 
 def dax_print(msg):
     msg = msg.replace("[+]", '\033[92m' + "[+]" + '\033[0m')
@@ -144,14 +146,19 @@ _CLAUDE_HOST_SHARED_DIRS = ('commands', 'plugins')
 # been running without them: no error, just absent — which is the worst shape a
 # loss can take.
 #
-# Mounted read-only, unlike the directories above. Claude Code rewrites
-# settings.json when `/config` changes it, and a *writable* single-file bind mount
-# is precisely where write-temp-plus-rename breaks on grpcfuse (see the design
-# doc's Concurrency section) — the rename replaces the mount with a regular file
-# and the write silently stops reaching the host. Read-only makes that failure
-# explicit instead: `/config` edits inside a container don't persist, so make them
-# on the host.
-_CLAUDE_HOST_SHARED_FILES = ('CLAUDE.md', 'settings.json', 'settings.local.json')
+# Attempted fix, same day: mount these read-only, nested inside the tree mount,
+# the same way `_CLAUDE_HOST_SHARED_DIRS` nests `commands`/`plugins`. Abandoned
+# within hours — unlike the directories, a single-*file* bind mount nested inside
+# the tree mount did not deliver the host's content at all: the container saw an
+# empty file, not the host's real `CLAUDE.md`. (Separately, a writable version of
+# this would have hit the write-temp-plus-rename failure described in the design
+# doc's Concurrency section; moot, since the read side never worked.)
+#
+# Replaced with a plain copy at `dax run` time — see
+# `dax_creds.config.sync_claude_shared_files`. `_CLAUDE_HOST_SHARED_FILES` is
+# `dax_creds.config.CLAUDE_SHARED_FILES`, imported at the top of this file;
+# kept under this name here for the existing tests that import it from `dax`.
+_CLAUDE_HOST_SHARED_FILES = CLAUDE_SHARED_FILES
 
 
 def feature_claude_tenant_state(config):
@@ -220,12 +227,14 @@ def feature_claude_tenant_state(config):
         opts.append('--volume={}:{}'.format(
             host_shared, os.path.join(cfg_dir, shared_dir)))
 
-    for shared_file in _CLAUDE_HOST_SHARED_FILES:
-        host_file = os.path.expanduser(os.path.join('~/.claude', shared_file))
-        if not os.path.isfile(host_file):
-            continue
-        opts.append('--volume={}:{}:ro'.format(
-            host_file, os.path.join(cfg_dir, shared_file)))
+    # Copied in rather than mounted (see the comment on _CLAUDE_HOST_SHARED_FILES
+    # above) — a plain file write into the tree, picked up by the volume mount
+    # already assembled for `host_tree` further up.
+    for drifted in sync_claude_shared_files(tenant, project_name):
+        dax_print('[!] {}: {} in state tree differs from both host and '
+                  'last-synced copy — leaving it alone.'.format(project_name, drifted))
+        dax_print('    Run `dax env accept-shared-files {}` to adopt the host '
+                  'version, or inspect the diff yourself.'.format(project_name))
 
     return opts
 
@@ -1075,7 +1084,7 @@ def _resolve_env_name(config, explicit):
 
 def cmd_env(args):
     from dax_creds.config import load_dax_config
-    from dax_creds.init import run_env_set, run_env_show
+    from dax_creds.init import run_env_accept_shared_files, run_env_set, run_env_show
 
     try:
         config = load_dax_config()
@@ -1090,6 +1099,8 @@ def cmd_env(args):
         elif args.env_command == 'set':
             run_env_set(config, name, args.field, args.value,
                         valid_features=_feature_names())
+        elif args.env_command == 'accept-shared-files':
+            run_env_accept_shared_files(config, name)
     except (KeyError, ValueError) as e:
         dax_print('[!] {}'.format(e.args[0] if e.args else e))
         sys.exit(1)
@@ -1413,6 +1424,12 @@ def main():
     env_set_p.add_argument('name', nargs='?', help='Env name (default: the env containing cwd)')
     env_set_p.add_argument('field', choices=sorted(ENV_FIELDS), help='Field to set')
     env_set_p.add_argument('value', help='New value')
+
+    env_accept_p = env_sub.add_parser(
+        'accept-shared-files',
+        help="Force-adopt the host's CLAUDE.md/settings.json/settings.local.json "
+             "into this env's state tree, resolving a drift warning from `dax run`")
+    env_accept_p.add_argument('name', nargs='?', help='Env name (default: the env containing cwd)')
 
     tenant_p = subparsers.add_parser('tenant', help='Manage tenant declarations')
     tenant_sub = tenant_p.add_subparsers(dest='tenant_command', required=True)

--- a/dax.py
+++ b/dax.py
@@ -386,6 +386,33 @@ def feature_mounts(config):
     return opts
 
 
+def feature_substrate(config):
+    """Mounts a virgil-style substrate repo (rw) and exposes it as
+    $SUBSTRATE_ROOT — the container path both the substrate's own hooks and
+    the `claude` wrapper's gate/settings-delivery logic read (see
+    docs/design/VALIDATION.md's dax contract).
+
+    A single path, unlike the generic `mounts` list feature_mounts handles:
+    dax needs to know specifically which mount holds `shared/wire.sh` and
+    `shared/new-process.sh`, not just that something extra is mounted.
+
+    `wire.sh --quiet` itself runs once per container boot (dax-entrypoint.sh,
+    baked into the image), not here and not on every `claude` launch — see
+    the design doc's Part 4 for why that distinction is load-bearing.
+    """
+    substrate = config.get('substrate')
+    if not substrate:
+        dax_print("[!] no substrate configured for this env "
+                  "(dax env set <name> substrate <path>)")
+        return []
+    host = os.path.expanduser(substrate)
+    container = os.path.join(_container_home(config), dir_basename(host))
+    return [
+        '--volume={}:{}'.format(host, container),
+        '-e', 'SUBSTRATE_ROOT={}'.format(container),
+    ]
+
+
 def _add_feature(feature, config):
     fn_name = 'feature_{}'.format(feature)
     fn = globals().get(fn_name)
@@ -655,6 +682,7 @@ def cmd_run(args):
         # reads config['tenant'] above — project entries aren't otherwise
         # promoted into the flat config feature functions see.
         config['mounts'] = project.get('mounts') or []
+        config['substrate'] = project.get('substrate')
 
         ssh_creds = {n: d for n, d in project_creds.items() if d.get('provider') == 'ssh'}
         if ssh_creds:
@@ -1341,6 +1369,386 @@ def cmd_tenants(args):
     print()
 
 
+def _read_process_types(substrate_root):
+    """[(type, skill, description), ...] from the substrate's own registry.
+
+    Never hardcoded here — dax reads whatever the substrate declares, so
+    adding a process type there never needs a dax release (see the "What dax
+    must not do" section of docs/design/VALIDATION.md).
+    """
+    tsv = Path(substrate_root) / 'shared' / 'process-types.tsv'
+    if not tsv.is_file():
+        raise ValueError('no process-types.tsv at {} — is {} a substrate repo?'.format(
+            tsv, substrate_root))
+    types = []
+    for line in tsv.read_text().splitlines():
+        if not line or line.startswith('#'):
+            continue
+        parts = line.split('\t')
+        if len(parts) >= 3:
+            types.append((parts[0], parts[1], parts[2]))
+    return types
+
+
+def _check_process_dir(config, process_dir):
+    """Refuse structurally bad choices for a new process directory, before
+    anything is created or registered.
+
+    Two classes of mistake, both cheap to catch here and expensive to
+    unwind later: nesting/colliding with an already-registered project (the
+    same mistake `find_enclosing_project`/Gate 0 catches for `dax run`, just
+    much earlier — before there's anything to untangle), and landing outside
+    $HOME, where `dax run` would refuse to launch it anyway (`load_config`'s
+    "dax must be run from somewhere under your home dir"), just much later.
+    """
+    from dax_creds.config import find_enclosing_project
+
+    home = Path.home().resolve()
+    try:
+        process_dir.relative_to(home)
+    except ValueError:
+        dax_print('[!] {} is not under your home directory ({}) — `dax run` '
+                  'refuses to launch from outside $HOME'.format(process_dir, home))
+        sys.exit(1)
+
+    enclosing = find_enclosing_project(config, process_dir)
+    if enclosing is not None:
+        enclosing_name, enclosing_project = enclosing
+        dax_print('[!] {} is inside already-registered project {!r} at {}'.format(
+            process_dir, enclosing_name, Path(enclosing_project['dir']).expanduser().resolve()))
+        sys.exit(1)
+
+    for other_name, other_project in (config.get('projects') or {}).items():
+        other_dir = other_project.get('dir')
+        if not other_dir:
+            continue
+        other_dir = Path(other_dir).expanduser().resolve()
+        if other_dir == process_dir:
+            dax_print('[!] {} is already registered as project {!r}'.format(
+                process_dir, other_name))
+            sys.exit(1)
+        if process_dir in other_dir.parents:
+            dax_print('[!] {} would enclose already-registered project {!r} at {}'.format(
+                process_dir, other_name, other_dir))
+            sys.exit(1)
+
+
+def _run_process_new(config, args):
+    """Scaffold a new substrate-backed process and register it as a dax env.
+
+    Every field is either given on the command line or interactively
+    prompted — never silently defaulted, and never left to new-process.sh's
+    own basic prompting: dax resolves everything itself first, then invokes
+    the script with a complete, fully-resolved flag set so its own `ask()`
+    prompts never trigger regardless of stdio.
+
+    Directory and substrate paths are resolved to absolute, symlink-free
+    paths (`.resolve()`) as soon as they're known — `register_project`
+    documents `dir` as an absolute host path, a relative or `~`-shorthand
+    value stored verbatim would silently break every cwd-based env lookup,
+    and the confirmation summary below is only trustworthy if the paths in
+    it are the real ones.
+    """
+    from dax_creds.init import _prompt, _q_confirm, _q_select, register_project, run_env_set, save_config
+    from dax_creds.config import state_tree_path
+    import questionary
+
+    name = args.name
+
+    process_dir = args.dir or _prompt('Process directory')
+    if not process_dir:
+        dax_print('[!] a process directory is required')
+        sys.exit(1)
+    process_dir = Path(process_dir).expanduser().resolve()
+
+    _check_process_dir(config, process_dir)
+
+    tenant = args.tenant or _prompt_tenant(process_dir, _known_tenant_names())
+
+    substrate = args.substrate or _prompt('Substrate path', default=config.get('substrate'))
+    if not substrate:
+        dax_print('[!] a substrate path is required (pass --substrate, or set a top-level '
+                  '`substrate:` default in ~/.dax.yaml)')
+        sys.exit(1)
+    substrate_root = Path(substrate).expanduser().resolve()
+
+    title = args.title or _prompt('Process title')
+    if not title:
+        dax_print('[!] a process title is required')
+        sys.exit(1)
+
+    try:
+        types = _read_process_types(substrate_root)
+    except ValueError as e:
+        dax_print('[!] {}'.format(e))
+        sys.exit(1)
+
+    if args.type:
+        process_type = args.type
+        skill = next((s for t, s, _d in types if t == process_type), None)
+        if skill is None:
+            dax_print('[!] unknown type {!r} — see {}/shared/process-types.tsv'.format(
+                process_type, substrate_root))
+            sys.exit(1)
+    else:
+        choices = [questionary.Choice('{} — {}'.format(t, desc), value=(t, skill))
+                   for t, skill, desc in types]
+        process_type, skill = _q_select('Process type:', choices)
+
+    if args.git and args.no_git:
+        dax_print('[!] pass --git or --no-git, not both')
+        sys.exit(1)
+    elif args.git:
+        git_decision = True
+    elif args.no_git:
+        git_decision = False
+    else:
+        print('Keep this process under version control?')
+        print('  git history cannot be selectively scrubbed later — a process that may')
+        print('  need to be destroyed is cleaner without it.')
+        git_decision = _q_confirm('git?', default=False)
+
+    default_image = config.get('defaults', {}).get('image', 'dax-base')
+    state_dir = state_tree_path(tenant, name)
+
+    if process_dir.exists():
+        count = sum(1 for _ in process_dir.iterdir())
+        dir_note = 'already exists, empty' if count == 0 else \
+            'already exists, {} item(s) inside'.format(count)
+    else:
+        dir_note = 'will be created'
+
+    print()
+    print('About to create a new process:')
+    print('  env name    {}'.format(name))
+    print('  directory   {}   [{}]'.format(process_dir, dir_note))
+    print('  substrate   {}'.format(substrate_root))
+    print('  tenant      {}'.format(tenant))
+    print('  title       {}'.format(title))
+    print('  type        {} (skill: {})'.format(process_type, skill))
+    print('  git         {}'.format('yes' if git_decision else 'no'))
+    print('  image       {}'.format(default_image))
+    print('  creds       claude   (derived per-env credential)')
+    print('  features    substrate, claude_tenant_state')
+    print('  state tree  {}'.format(state_dir))
+    print()
+
+    if args.dry_run:
+        dax_print('[-]   dry run — nothing created or registered')
+        return
+
+    if not _q_confirm('Proceed?', default=True):
+        dax_print('[-]   aborted — nothing created or registered')
+        return
+
+    new_process_cmd = [
+        str(substrate_root / 'shared' / 'new-process.sh'),
+        '--dir', str(process_dir),
+        '--title', title,
+        '--type', process_type,
+        '--git' if git_decision else '--no-git',
+    ]
+    result = subprocess.run(new_process_cmd)
+    if result.returncode != 0:
+        dax_print('[!] new-process.sh failed (exit {}) — not registering an env'.format(
+            result.returncode))
+        sys.exit(1)
+
+    register_project(config, name=name, project_dir=process_dir,
+                     image=default_image, creds=['claude'])
+    save_config(config)
+    run_env_set(config, name, 'tenant', tenant)
+    run_env_set(config, name, 'substrate', str(substrate_root))
+    # Always both, unconditionally — every substrate-backed process needs its
+    # own Claude state tree as well as the substrate mount, never just one.
+    run_env_set(config, name, 'features', 'substrate,claude_tenant_state',
+                valid_features=_feature_names())
+
+    dax_print('[+] registered {}. Run `dax run` from {} to launch it.'.format(name, process_dir))
+
+
+def _uncommitted_git_note(dir_path):
+    """A short "N uncommitted change(s)" note, or None if the directory isn't
+    a git repo or has nothing outstanding. Surfaced in the destroy summary
+    rather than silently lost — a `--git` process with no remote means this
+    is the only copy of that work."""
+    if not (dir_path / '.git').is_dir():
+        return None
+    try:
+        result = subprocess.run(['git', '-C', str(dir_path), 'status', '--porcelain'],
+                                capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    changed = [line for line in result.stdout.splitlines() if line.strip()]
+    if not changed:
+        return None
+    return '! {} uncommitted git change(s)'.format(len(changed))
+
+
+def _derived_creds_for(project, name):
+    """[derived credential name, ...] for one project — never an
+    explicitly-named/shared credential, only ones dax itself derived for
+    this env specifically (see BARE_PROVIDER_CREDS)."""
+    from dax_creds.config import resolve_credential_names
+    try:
+        resolved = resolve_credential_names(project, name)
+    except ValueError:
+        # A bare provider entry with no tenant to derive from — already
+        # broken in a way `dax run`/`env show` would refuse on, and not
+        # this command's job to fix. Nothing resolvable to clean up.
+        return []
+    return [cred_name for cred_name, provider in resolved if provider]
+
+
+def _run_process_destroy(config, args):
+    """Tear down one or more registered processes: directory, Claude state
+    tree (plus its sibling shared-files manifest), any per-env derived
+    credential, and the ~/.dax.yaml entry itself.
+
+    docs/design/VALIDATION.md's `destroy-process` (item 6), generalized past
+    substrate processes specifically — the same cleanup (dir + state tree +
+    credential + registry entry) applies to any tenant-isolated env, and
+    restricting this to substrate-tagged ones would only get in the way of
+    burning down other test cruft.
+    """
+    from dax_creds.config import state_tree_path, _shared_files_manifest_path
+    from dax_creds.init import (
+        _q_checkbox, _container_name_for, _is_container_running,
+        _tree_stats, _human_size, _human_age, run_creds_remove, save_config,
+    )
+    import questionary
+
+    projects = config.get('projects') or {}
+
+    names = list(args.name or [])
+    if not names:
+        if not projects:
+            dax_print('[!] no registered envs to destroy')
+            return
+        choices = []
+        for pname, project in sorted(projects.items()):
+            tenant = project.get('tenant')
+            label = '{}   [{}{}]'.format(
+                pname, project.get('dir', '?'),
+                ', tenant {}'.format(tenant) if tenant else ', no tenant')
+            choices.append(questionary.Choice(label, value=pname))
+        names = _q_checkbox('Select processes to destroy (nothing pre-checked):', choices)
+        if not names:
+            dax_print('[-]   nothing selected')
+            return
+
+    unknown = [n for n in names if n not in projects]
+    if unknown:
+        dax_print('[!] not registered: {}'.format(', '.join(unknown)))
+        sys.exit(1)
+
+    # Guardrails, checked for every candidate before any deletion begins — a
+    # problem with one candidate must never leave the batch half-destroyed.
+    for name in names:
+        dir_path = Path(projects[name].get('dir', '')).expanduser()
+        container = _container_name_for(dir_path)
+        if _is_container_running(container):
+            dax_print('[!] {} is running — stop it first (`docker stop {}`)'.format(
+                name, container))
+            sys.exit(1)
+
+    print()
+    print('About to destroy:')
+    for name in names:
+        project = projects[name]
+        dir_path = Path(project.get('dir', '')).expanduser()
+        tenant = project.get('tenant')
+
+        print()
+        print(name)
+        if dir_path.exists():
+            count = sum(1 for _ in dir_path.iterdir())
+            note = '{} item(s)'.format(count)
+            git_note = _uncommitted_git_note(dir_path)
+            if git_note:
+                note += '; ' + git_note
+            print('  directory   {}   [{}]'.format(dir_path, note))
+        else:
+            print('  directory   {}   [already gone]'.format(dir_path))
+
+        if tenant:
+            state = state_tree_path(tenant, name)
+            if state.exists():
+                size, used = _tree_stats(state)
+                print('  state tree  {}   [{}, used {} ago]'.format(
+                    state, _human_size(size), _human_age(used)))
+            else:
+                print('  state tree  {}   [already gone]'.format(state))
+        else:
+            print('  state tree  (no tenant declared — none)')
+
+        derived = _derived_creds_for(project, name)
+        if derived:
+            print('  credential  {}   (derived — also removed from Keychain)'.format(
+                ', '.join(derived)))
+        else:
+            print('  credential  (none derived)')
+
+        print('  registry    ~/.dax.yaml entry')
+
+    print()
+    print('{} process(es) above will be permanently destroyed. This cannot be undone.'.format(
+        len(names)))
+    print()
+
+    if args.dry_run:
+        dax_print('[-]   dry run — nothing destroyed')
+        return
+
+    typed = input('Type DESTROY to confirm: ')
+    if typed != 'DESTROY':
+        dax_print('[-]   aborted — nothing destroyed')
+        return
+
+    for name in names:
+        project = projects[name]
+        dir_path = Path(project.get('dir', '')).expanduser()
+        tenant = project.get('tenant')
+
+        if dir_path.exists():
+            shutil.rmtree(dir_path)
+            dax_print('[-]   removed {}'.format(dir_path))
+
+        if tenant:
+            state = state_tree_path(tenant, name)
+            if state.exists():
+                shutil.rmtree(state)
+                dax_print('[-]   removed {}'.format(state))
+            manifest = _shared_files_manifest_path(tenant, name)
+            if manifest.exists():
+                manifest.unlink()
+
+        for cred_name in _derived_creds_for(project, name):
+            try:
+                run_creds_remove(config, cred_name)
+            except Exception as e:
+                dax_print('[!] could not remove credential {}: {}'.format(cred_name, e))
+
+        del config['projects'][name]
+        save_config(config)
+        dax_print('[+] destroyed {}'.format(name))
+
+
+def cmd_process(args):
+    from dax_creds.config import load_dax_config
+
+    try:
+        config = load_dax_config()
+    except FileNotFoundError:
+        dax_print('[!] no ~/.dax.yaml found — run `dax init` first')
+        sys.exit(1)
+
+    if args.process_command == 'new':
+        _run_process_new(config, args)
+    elif args.process_command == 'destroy':
+        _run_process_destroy(config, args)
+
+
 def cmd_backup(args):
     home = os.path.expanduser('~')
     repo_root = Path(__file__).parent
@@ -1484,6 +1892,41 @@ def main():
 
     subparsers.add_parser('tenants', help='List known tenants and their projects')
 
+    process_p = subparsers.add_parser('process', help='Manage virgil-style substrate processes')
+    process_sub = process_p.add_subparsers(dest='process_command', required=True)
+    process_new_p = process_sub.add_parser(
+        'new', help='Scaffold a new substrate-backed process and register it as a dax env')
+    process_new_p.add_argument('name', help='Env name to register')
+    process_new_p.add_argument('--dir', help='Host directory for the new process (prompted if omitted)')
+    process_new_p.add_argument('--tenant', help='Tenant/grouping label (prompted if omitted)')
+    process_new_p.add_argument(
+        '--substrate',
+        help="Path to the substrate repo (prompted if omitted, defaulting to the top-level "
+             "`substrate:` in ~/.dax.yaml if set)")
+    process_new_p.add_argument('--title', help='Process title (prompted if omitted)')
+    process_new_p.add_argument('--type', help='Process type (prompted if omitted)')
+    process_new_git = process_new_p.add_mutually_exclusive_group()
+    process_new_git.add_argument('--git', action='store_true',
+                                 help='Keep the process under version control')
+    process_new_git.add_argument('--no-git', action='store_true',
+                                 help='Do not put the process under version control')
+    process_new_p.add_argument(
+        '--dry-run', action='store_true',
+        help='Resolve every field and print the full-path summary, then exit '
+             'without creating or registering anything')
+
+    process_destroy_p = process_sub.add_parser(
+        'destroy',
+        help='Permanently remove one or more processes: directory, state tree, '
+             'derived credential, and registry entry')
+    process_destroy_p.add_argument(
+        'name', nargs='*',
+        help='Env name(s) to destroy (omit for an interactive picker over every registered env)')
+    process_destroy_p.add_argument(
+        '--dry-run', action='store_true',
+        help='Print the full-path summary of what would be destroyed, then exit '
+             'without changing anything')
+
     args = parser.parse_args()
 
     if args.command == 'build':
@@ -1506,6 +1949,8 @@ def main():
         cmd_tenant(args)
     elif args.command == 'tenants':
         cmd_tenants(args)
+    elif args.command == 'process':
+        cmd_process(args)
 
 
 if __name__ == '__main__':

--- a/dax.py
+++ b/dax.py
@@ -139,6 +139,20 @@ def feature_claude(config):
 # can turn account-specific.
 _CLAUDE_HOST_SHARED_DIRS = ('commands', 'plugins')
 
+# User-level *files* that a tree mount would otherwise replace, taking your global
+# instructions and settings with it. Found 2026-07-31, after `fabric` had already
+# been running without them: no error, just absent — which is the worst shape a
+# loss can take.
+#
+# Mounted read-only, unlike the directories above. Claude Code rewrites
+# settings.json when `/config` changes it, and a *writable* single-file bind mount
+# is precisely where write-temp-plus-rename breaks on grpcfuse (see the design
+# doc's Concurrency section) — the rename replaces the mount with a regular file
+# and the write silently stops reaching the host. Read-only makes that failure
+# explicit instead: `/config` edits inside a container don't persist, so make them
+# on the host.
+_CLAUDE_HOST_SHARED_FILES = ('CLAUDE.md', 'settings.json', 'settings.local.json')
+
 
 def feature_claude_tenant_state(config):
     """Decision B: this env's state tree mounts at `~/.claude` itself.
@@ -205,6 +219,13 @@ def feature_claude_tenant_state(config):
             continue
         opts.append('--volume={}:{}'.format(
             host_shared, os.path.join(cfg_dir, shared_dir)))
+
+    for shared_file in _CLAUDE_HOST_SHARED_FILES:
+        host_file = os.path.expanduser(os.path.join('~/.claude', shared_file))
+        if not os.path.isfile(host_file):
+            continue
+        opts.append('--volume={}:{}:ro'.format(
+            host_file, os.path.join(cfg_dir, shared_file)))
 
     return opts
 

--- a/dax.py
+++ b/dax.py
@@ -362,8 +362,15 @@ def feature_mounts(config):
     does work) staying that way.
 
     Named `mounts` on the project entry, comma-split by `dax env set` the same
-    way `creds`/`features` are. Opt-in per env via `features: [mounts]`, same
-    shape as `feature_ports`.
+    way `creds`/`features` are. Opt-in via `features: [mounts]`, same shape as
+    `feature_ports`.
+
+    Each entry is `<host_path>` or `<host_path>:<container_name>` — the name
+    defaults to `dir_basename(host_path)`, but an explicit one is what lets a
+    host directory be mounted under a name other than its own basename,
+    e.g. the host's own `~/.claude` mounted as `~/host-claude` to inspect its
+    real content from inside a container without colliding with whatever
+    `claude_tenant_state` already mounted at `~/.claude` itself.
     """
     opts = []
     mounts = config.get('mounts', [])
@@ -371,9 +378,10 @@ def feature_mounts(config):
         dax_print("[!] no mounts defined for this env")
         return opts
     container_home = _container_home(config)
-    for host_path in mounts:
+    for entry in mounts:
+        host_path, _sep, container_name = entry.partition(':')
         host = os.path.expanduser(host_path)
-        container = os.path.join(container_home, dir_basename(host))
+        container = os.path.join(container_home, container_name or dir_basename(host))
         opts.append('--volume={}:{}'.format(host, container))
     return opts
 

--- a/dax.py
+++ b/dax.py
@@ -813,6 +813,15 @@ def _disk_token_for(cred_def, provider):
     return None
 
 
+def _report_grant_collision(cred_name, other_name):
+    from dax_creds.providers.claude import grant_collision_message
+
+    lines = grant_collision_message(cred_name, other_name)
+    dax_print(f'[!] {cred_name}: {lines[0]}')
+    for line in lines[1:]:
+        dax_print(f'    {line}')
+
+
 def _post_login_import(cred_name, cred_def, config, provider, before=None):
     """Store whatever the auth flow just wrote to disk into Keychain.
 
@@ -843,10 +852,20 @@ def _post_login_import(cred_name, cred_def, config, provider, before=None):
         else:
             dax_print(f'[!] {cred_name}: no token found after auth flow.')
     elif provider == 'claude':
+        from dax_creds.config import credential_names_for_provider
         from dax_creds.providers.claude import ClaudeProvider
         provider_obj = ClaudeProvider()
         token = provider_obj.import_from_disk(cred_def)
         if token:
+            # The `before` comparison above only answers whether the file
+            # changed, not whether the grant did — a Claude Code token refresh
+            # landing inside the login window makes an abandoned login look
+            # successful. Checking the grant itself closes that (decision C6).
+            clash = provider_obj.grant_collision(
+                cred_name, token, credential_names_for_provider(config, 'claude'))
+            if clash:
+                _report_grant_collision(cred_name, clash)
+                return
             provider_obj.store(cred_name, token)
             dax_print(f'[+] {cred_name}: token imported to Keychain.')
         else:

--- a/dax.py
+++ b/dax.py
@@ -489,13 +489,13 @@ def cmd_run(args):
     project_creds = {}
     try:
         from dax_creds.config import (
-            load_dax_config, find_project_by_dir, find_enclosing_project,
+            load_dax_config, find_named_project_by_dir, find_enclosing_project,
             get_project_credentials, daemon_socket_path,
         )
         from dax_creds.providers.ssh import SshProvider, start_ephemeral_agent, stop_ephemeral_agent
         dax_config = load_dax_config()
         try:
-            project = find_project_by_dir(dax_config, Path.cwd())
+            project_name, project = find_named_project_by_dir(dax_config, Path.cwd())
         except KeyError:
             enclosing = find_enclosing_project(dax_config, Path.cwd())
             if enclosing is not None:
@@ -510,8 +510,27 @@ def cmd_run(args):
             dax_print("[+] project not registered — starting dax init")
             from dax_creds.init import run_init
             dax_config = run_init(dax_config, Path.cwd())
-            project = find_project_by_dir(dax_config, Path.cwd())
-        project_creds = get_project_credentials(dax_config, project)
+            project_name, project = find_named_project_by_dir(dax_config, Path.cwd())
+        try:
+            project_creds = get_project_credentials(dax_config, project, project_name)
+        except ValueError as e:
+            # A bare provider token with no tenant to derive from. Refusing
+            # beats silently falling back to a shared credential, which is the
+            # exact isolation failure this convention exists to prevent.
+            dax_print(f'[!] {e}')
+            sys.exit(1)
+
+        # Make synthesized definitions for derived names visible to everything
+        # downstream that looks credentials up by name in the config — notably
+        # cmd_creds_login below, which would otherwise raise KeyError on an
+        # env's first run and have it swallowed by this block's except clause,
+        # silently skipping both the login and the daemon.
+        #
+        # In memory only, deliberately: after a successful login the secret is
+        # in Keychain, and the next run re-derives the same name and finds it.
+        # Nothing needs persisting, so `dax run` stays a non-writer.
+        for _name, _cdef in project_creds.items():
+            dax_config.setdefault('credentials', {}).setdefault(_name, _cdef)
         config['multi_tenant'] = bool(project.get('multi_tenant'))
         config['tenant_subdir'] = project.get('tenant_subdir', '')
 
@@ -675,10 +694,39 @@ def _cmd_creds_login_google(cred_name, cred_def, config):
         sys.exit(1)
 
 
-def cmd_creds_login(cred_name, config):
+def _login_credential_def(config, cred_name):
+    """The definition to log in with — registered in `credentials:` or derived.
+
+    A per-env Claude credential normally has *no* registry entry: its name is
+    derived from the env's bare `claude` token (decision C2), and
+    `_post_login_import` stores a Keychain secret without ever writing a
+    `credentials:` block. So resolving against the registry alone refused every
+    derived name, and since `dax creds add`'s claude path is the unguarded
+    copy-from-disk route decision C3 exists to prevent, that left *no* sanctioned
+    way to mint a per-env credential at all. `creds list`, `creds remove`, and
+    `env show` already resolved derived names; login was missed. Found by manual
+    step 4 on 2026-07-30 — see decision C5.
+
+    An explicit registration wins, matching resolution everywhere else. The
+    derived definition arrives via `synthesized_credential()`, so it carries the
+    `credential_defaults` browser/profile settings (C4) rather than falling back
+    to the default browser.
+
+    Raises KeyError for a name that is neither, which `cmd_creds` renders as the
+    "Unknown credential" message.
+    """
+    from dax_creds.config import derived_credentials
+
     cred_def = config.get('credentials', {}).get(cred_name)
     if cred_def is None:
+        cred_def = derived_credentials(config).get(cred_name)
+    if cred_def is None:
         raise KeyError(cred_name)
+    return cred_def
+
+
+def cmd_creds_login(cred_name, config):
+    cred_def = _login_credential_def(config, cred_name)
 
     provider = cred_def.get('provider')
     if provider == 'auggie':
@@ -728,6 +776,15 @@ def cmd_creds_login(cred_name, config):
 
     cmd += [image, '/bin/sh', '-c', provider_cfg['auth_command']]
 
+    # What the provider's on-disk location holds *before* the flow runs. The
+    # import below reads that same location, and cannot otherwise tell a token
+    # the login just wrote from one that was already sitting there — so an
+    # abandoned login silently stored the pre-existing shared credential under
+    # the new name, producing two Keychain entries backed by one OAuth grant.
+    # That is the exact sharing the per-env naming exists to prevent, and it
+    # presented as success. Observed 2026-07-30.
+    before = _disk_token_for(cred_def, provider)
+
     dax_print(f'[+] dax creds login: starting auth flow for {cred_name} ({provider})')
     try:
         subprocess.run(cmd)
@@ -736,10 +793,45 @@ def cmd_creds_login(cred_name, config):
         dax_print(f'[-] login daemon log: {daemon_proc._dax_log_path}')
 
     # Post-login: import token to Keychain
-    _post_login_import(cred_name, cred_def, config, provider)
+    _post_login_import(cred_name, cred_def, config, provider, before=before)
 
 
-def _post_login_import(cred_name, cred_def, config, provider):
+def _disk_token_for(cred_def, provider):
+    """Whatever the provider would import from disk right now, or None."""
+    try:
+        if provider == 'github':
+            from dax_creds.providers.github import GitHubProvider
+            return GitHubProvider().import_from_disk(cred_def)
+        if provider == 'claude':
+            from dax_creds.providers.claude import ClaudeProvider
+            return ClaudeProvider().import_from_disk(cred_def)
+        if provider == 'auggie':
+            from dax_creds.providers.auggie import AuggieProvider
+            return AuggieProvider().import_from_disk(cred_def)
+    except Exception:
+        pass
+    return None
+
+
+def _post_login_import(cred_name, cred_def, config, provider, before=None):
+    """Store whatever the auth flow just wrote to disk into Keychain.
+
+    `before` is what that same on-disk location held beforehand. When the flow
+    leaves it unchanged — the user abandoned the login, closed the browser, or
+    it failed — importing would store a credential the flow did not create. For
+    Claude that means copying an existing grant under a new name, silently
+    defeating per-env isolation, so an unchanged token is refused rather than
+    imported.
+    """
+    if before is not None:
+        after = _disk_token_for(cred_def, provider)
+        if after == before:
+            dax_print(f'[!] {cred_name}: the auth flow did not write a new credential.')
+            dax_print(f'    Nothing was imported — the token already on disk predates this '
+                      f'login and storing it would share an existing grant.')
+            dax_print(f'    Re-run `dax creds login {cred_name}` and complete the browser flow.')
+            return
+
     if provider == 'github':
         from dax_creds.providers.github import GitHubProvider
         provider_obj = GitHubProvider()
@@ -824,6 +916,9 @@ def cmd_creds(args):
         except KeyError:
             print(f"Unknown credential '{args.name}'. Run `dax creds list` to see registered credentials.")
             sys.exit(1)
+        except ValueError as e:
+            dax_print(f'[!] {e}')
+            sys.exit(1)
     elif args.creds_command == 'update':
         try:
             run_creds_update(config, args.name)
@@ -847,6 +942,53 @@ def cmd_envs(args):
         config = {'defaults': {'image': 'dax-base'}, 'credentials': {}, 'projects': {}}
     if args.envs_command == 'list':
         run_envs_list(config)
+
+
+def _resolve_env_name(config, explicit):
+    """The name given on the command line, or the env that contains cwd.
+
+    Defaulting to cwd is what makes `dax env show` answer "what am I in right
+    now" without having to remember the registered name. Falls back to the
+    *enclosing* project so it also works from a subdirectory, where `dax run`
+    itself refuses (Gate 0).
+    """
+    if explicit:
+        return explicit
+
+    from dax_creds.config import find_enclosing_project
+
+    cwd = Path.cwd()
+    for name, proj in config.get('projects', {}).items():
+        if Path(proj.get('dir', '')).expanduser() == cwd:
+            return name
+
+    enclosing = find_enclosing_project(config, cwd)
+    if enclosing:
+        return enclosing[0]
+
+    dax_print(f'[!] {cwd} is not inside a registered env — pass a name explicitly')
+    sys.exit(1)
+
+
+def cmd_env(args):
+    from dax_creds.config import load_dax_config
+    from dax_creds.init import run_env_set, run_env_show
+
+    try:
+        config = load_dax_config()
+    except FileNotFoundError:
+        dax_print('[!] no ~/.dax.yaml found — run `dax init` first')
+        sys.exit(1)
+
+    name = _resolve_env_name(config, args.name)
+    try:
+        if args.env_command == 'show':
+            run_env_show(config, name)
+        elif args.env_command == 'set':
+            run_env_set(config, name, args.field, args.value)
+    except (KeyError, ValueError) as e:
+        dax_print('[!] {}'.format(e.args[0] if e.args else e))
+        sys.exit(1)
 
 
 def cmd_features(args):
@@ -1149,6 +1291,25 @@ def main():
     envs_sub = envs_p.add_subparsers(dest='envs_command', required=True)
     envs_sub.add_parser('list', help='List registered environments')
 
+    # Singular `env` acts on one environment, plural `envs` lists them — the
+    # same split the existing `tenant`/`tenants` pair uses.
+    from dax_creds.config import ENV_FIELDS, env_field_help
+    env_p = subparsers.add_parser(
+        'env', help='Inspect or edit a single environment',
+        description='Operates on the env for the current directory when no name is given.')
+    env_sub = env_p.add_subparsers(dest='env_command', required=True)
+
+    env_show_p = env_sub.add_parser('show', help="Show one env's configuration")
+    env_show_p.add_argument('name', nargs='?', help='Env name (default: the env containing cwd)')
+
+    env_set_p = env_sub.add_parser(
+        'set', help='Set a single field on an env',
+        epilog=env_field_help(),
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    env_set_p.add_argument('name', nargs='?', help='Env name (default: the env containing cwd)')
+    env_set_p.add_argument('field', choices=sorted(ENV_FIELDS), help='Field to set')
+    env_set_p.add_argument('value', help='New value')
+
     tenant_p = subparsers.add_parser('tenant', help='Manage tenant declarations')
     tenant_sub = tenant_p.add_subparsers(dest='tenant_command', required=True)
     tenant_set_p = tenant_sub.add_parser('set', help='Declare the tenant for a subdirectory')
@@ -1177,6 +1338,8 @@ def main():
         cmd_creds(args)
     elif args.command == 'envs':
         cmd_envs(args)
+    elif args.command == 'env':
+        cmd_env(args)
     elif args.command == 'tenant':
         cmd_tenant(args)
     elif args.command == 'tenants':

--- a/dax.py
+++ b/dax.py
@@ -926,7 +926,13 @@ def cmd_creds(args):
     except FileNotFoundError:
         config = {'defaults': {'image': 'dax-base'}, 'credentials': {}, 'projects': {}}
     if args.creds_command == 'add':
-        run_creds_add(config)
+        # A per-env credential's secret is only ever minted by its own login, so
+        # `add` sets up the definition and then hands off rather than copying a
+        # token off disk (decisions C, C6).
+        config, pending_login = run_creds_add(config)
+        if pending_login:
+            print()
+            cmd_creds_login(pending_login, config)
     elif args.creds_command == 'list':
         run_creds_list(config)
     elif args.creds_command == 'remove':

--- a/dax_creds/cli.py
+++ b/dax_creds/cli.py
@@ -1,11 +1,12 @@
 import os
 import sys
 from dax_creds.client import get_token, open_url, list_credentials, CredentialNotAvailable
+from dax_creds.tenant import resolve_for_cwd
 
 
 def main():
     if len(sys.argv) < 2:
-        print('Usage: dax-creds <get|open-url|list> ...', file=sys.stderr)
+        print('Usage: dax-creds <get|open-url|list|resolve-tenant> ...', file=sys.stderr)
         sys.exit(1)
 
     subcmd = sys.argv[1]
@@ -49,6 +50,26 @@ def main():
         except CredentialNotAvailable as e:
             print(f'dax-creds: {e}', file=sys.stderr)
             sys.exit(1)
+
+    elif subcmd == 'resolve-tenant':
+        if len(sys.argv) != 2:
+            print('Usage: dax-creds resolve-tenant', file=sys.stderr)
+            sys.exit(1)
+        project_name = os.environ.get('DAX_PROJECT_NAME')
+        if not project_name:
+            print('dax-creds: DAX_PROJECT_NAME is not set - dax run should '
+                  'always set this alongside DAX_TENANT_STATE', file=sys.stderr)
+            sys.exit(1)
+        multi_tenant = bool(os.environ.get('DAX_MULTI_TENANT'))
+        tenant_subdir = os.environ.get('DAX_TENANT_SUBDIR', '')
+        result = resolve_for_cwd(
+            os.getcwd(), os.environ.get('HOME', ''), multi_tenant, project_name,
+            tenant_subdir)
+        if result.refuse:
+            print(f'dax-creds: {result.detail}', file=sys.stderr)
+            sys.exit(1)
+        print(f'TENANT={result.tenant}')
+        print(f'PROJECT={result.project}')
 
     else:
         print(f'dax-creds: unknown subcommand {subcmd!r}', file=sys.stderr)

--- a/dax_creds/config.py
+++ b/dax_creds/config.py
@@ -20,6 +20,22 @@ def find_project_by_dir(config, cwd):
     raise KeyError(f'no project configured for {cwd} — run `dax init` first')
 
 
+def find_enclosing_project(config, cwd):
+    """Find a registered project whose `dir` is a strict ancestor of cwd.
+
+    Distinct from `find_project_by_dir`'s exact-match lookup: this catches
+    the case where `dax run` is invoked from *inside* an already-registered
+    project (e.g. a multi-tenant repo's tenant_subdir child) rather than
+    from its root. Returns `(name, project)` or `None`.
+    """
+    cwd = Path(cwd)
+    for name, project in config.get('projects', {}).items():
+        project_dir = Path(project['dir']).expanduser()
+        if project_dir != cwd and project_dir in cwd.parents:
+            return name, project
+    return None
+
+
 def get_project_credentials(config, project):
     registry = config.get('credentials', {})
     return {name: registry[name] for name in project.get('creds', [])}
@@ -28,3 +44,11 @@ def get_project_credentials(config, project):
 def daemon_socket_path(workdir):
     digest = hashlib.sha256(str(workdir).encode()).hexdigest()[:12]
     return Path.home() / '.dax' / f'creds-{digest}.sock'
+
+
+def dir_basename(path):
+    """Final path component, robust to a trailing slash.
+
+    `os.path.basename` is not: `os.path.basename('/a/b/')` is `''`, not `'b'`.
+    """
+    return Path(str(path).rstrip('/')).name

--- a/dax_creds/config.py
+++ b/dax_creds/config.py
@@ -18,6 +18,7 @@ ENV_FIELDS = {
     'dir': 'absolute path to the project directory on the host',
     'image': 'docker image to run for this env',
     'creds': 'comma-separated credential names (replaces the whole list)',
+    'features': 'comma-separated features for this env, on top of the global list',
 }
 
 

--- a/dax_creds/config.py
+++ b/dax_creds/config.py
@@ -3,21 +3,119 @@ from pathlib import Path
 import yaml
 
 
+# Settable through `dax env set`. Deliberately not the full set of keys that
+# may appear on a registry entry: `multi_tenant`/`tenant_subdir` are slated for
+# deletion with the multi-tenant model (see the design doc's 2026-07-29
+# redesign) and are not worth teaching anyone to set. `features` is not here
+# either — it lives at the top level of ~/.dax.yaml or in a project-local
+# .dax.yaml, not on the registry entry.
+#
+# Lives here rather than in init.py so building the argument parser, which
+# needs the field names, does not pull in init.py's keyring/provider imports on
+# every single `dax` invocation.
+ENV_FIELDS = {
+    'tenant': 'grouping label used for state-tree paths and credential names',
+    'dir': 'absolute path to the project directory on the host',
+    'image': 'docker image to run for this env',
+    'creds': 'comma-separated credential names (replaces the whole list)',
+}
+
+
+def state_root():
+    return Path.home() / '.local' / 'state' / 'dax' / 'tenants'
+
+
+def state_tree_path(tenant, project):
+    return state_root() / tenant / project
+
+
+def state_trees():
+    """Every (tenant, project) Claude state tree that exists on disk.
+
+    Deliberately filesystem-driven, unlike the registry-driven listing it
+    replaces: a tree whose project was deregistered or whose tenant was renamed
+    is exactly what needs surfacing, and no amount of reading ~/.dax.yaml will
+    ever reveal one.
+    """
+    root = state_root()
+    if not root.is_dir():
+        return {}
+    return {
+        (tenant_dir.name, project_dir.name): project_dir
+        for tenant_dir in sorted(root.iterdir()) if tenant_dir.is_dir()
+        for project_dir in sorted(tenant_dir.iterdir()) if project_dir.is_dir()
+    }
+
+
+def env_field_help():
+    width = max(len(f) for f in ENV_FIELDS)
+    return 'fields:\n' + '\n'.join(
+        f'  {f:<{width}}  {desc}' for f, desc in ENV_FIELDS.items())
+
+
+def yaml_round_trip(required_by):
+    """A ruamel YAML handler that preserves comments, key order, and quoting.
+
+    pyyaml cannot do this: `safe_load` never sees comments, so `dump` cannot
+    put them back, and its default `sort_keys=True` alphabetises everything on
+    the way out. Rewriting ~/.dax.yaml through pyyaml therefore deletes every
+    comment in it — including commented-out feature lines like
+    `#- claude_tenant_state`, which are configuration, not decoration.
+
+    `required_by` names the caller in the error, since a missing dependency
+    here surfaces at `dax creds add` time rather than at import time.
+    """
+    try:
+        from ruamel.yaml import YAML
+    except ImportError:
+        raise ImportError(
+            f'{required_by} needs ruamel.yaml to rewrite ~/.dax.yaml without '
+            'destroying its comments and key order — `pip install ruamel.yaml` '
+            '(or reinstall dax, which now declares it)'
+        )
+    handler = YAML()  # typ='rt' (round-trip) is the default
+    handler.preserve_quotes = True
+    # ruamel wraps at 80 columns by default, which would reflow long values —
+    # absolute paths in `dir:` entries are routinely longer than that.
+    handler.width = 4096
+    return handler
+
+
 def load_dax_config():
+    """Load ~/.dax.yaml, preserving comments when ruamel is available.
+
+    Falls back to pyyaml if it is not: every caller here only reads, so a
+    missing dependency must not break `dax run`. The write path
+    (`dax_creds.init.save_config`) refuses instead of falling back, since
+    saving a pyyaml-loaded config is exactly what destroys the file.
+    """
     config_path = Path.home() / '.dax.yaml'
     try:
         with open(config_path) as f:
-            return yaml.safe_load(f)
+            try:
+                return yaml_round_trip('load_dax_config').load(f)
+            except ImportError:
+                f.seek(0)
+                return yaml.safe_load(f)
     except FileNotFoundError:
         raise FileNotFoundError('~/.dax.yaml not found — run `dax init` to create it')
 
 
-def find_project_by_dir(config, cwd):
+def find_named_project_by_dir(config, cwd):
+    """(name, project) for the env registered at exactly this directory.
+
+    The name matters now that credential names are derived from it, so callers
+    that need to resolve `creds:` want this rather than `find_project_by_dir`.
+    """
     cwd = Path(cwd)
     for name, project in config.get('projects', {}).items():
         if Path(project['dir']).expanduser() == cwd:
-            return project
+            return name, project
     raise KeyError(f'no project configured for {cwd} — run `dax init` first')
+
+
+def find_project_by_dir(config, cwd):
+    return find_named_project_by_dir(config, cwd)[1]
 
 
 def find_enclosing_project(config, cwd):
@@ -36,9 +134,122 @@ def find_enclosing_project(config, cwd):
     return None
 
 
-def get_project_credentials(config, project):
+# Providers whose credential name dax derives rather than the user naming it.
+# Listing a bare provider name in an env's `creds:` means "a credential of this
+# kind, scoped to this env" — dax builds `<provider>-<tenant>-<project>` from
+# the registry. Only claude is in here: its credentials are per tenant/project
+# by design (redesign decision C), while github/gmail/ssh are genuinely
+# user-level and shared, so naming those explicitly is correct.
+#
+# This exists because a hand-maintained convention is a convention users
+# typo — a real `claud-fre` entry sat unused in ~/.dax.yaml for weeks.
+BARE_PROVIDER_CREDS = ('claude',)
+
+
+def derived_credential_name(provider, tenant, project):
+    return f'{provider}-{tenant}-{project}'
+
+
+def resolve_credential_names(project, project_name):
+    """[(name, derived_provider)] for each entry in an env's `creds:` list.
+
+    `derived_provider` is the provider string when dax built the name, None
+    when the user named the credential explicitly.
+
+    An explicitly named credential always wins over the convention, which keeps
+    existing configs working and leaves an escape hatch for deliberately
+    sharing one credential across two envs.
+    """
+    resolved = []
+    for entry in project.get('creds', []) or []:
+        if entry not in BARE_PROVIDER_CREDS:
+            resolved.append((entry, None))
+            continue
+        tenant = project.get('tenant')
+        if not tenant:
+            raise ValueError(
+                f"env '{project_name}' asks for a '{entry}' credential by convention, "
+                f"but has no tenant — the name is derived as {entry}-<tenant>-<project>. "
+                f"Set one with `dax env set {project_name} tenant <tenant>`.")
+        resolved.append((derived_credential_name(entry, tenant, project_name), entry))
+    return resolved
+
+
+def synthesized_credential(config, provider):
+    """The definition dax uses for a derived credential.
+
+    Per-provider settings come from a top-level `credential_defaults:` block,
+    because a derived credential has no entry of its own to hold them:
+
+        credential_defaults:
+          claude:
+            browser: chrome
+            chrome_profile: Profile 2
+
+    Browser and profile are properties of the human doing the authenticating,
+    not of the env, so one setting covering every derived Claude credential is
+    the right shape — and without it every per-env login would silently open
+    the default browser instead of the profile the account lives in.
+    """
+    defaults = (config.get('credential_defaults') or {}).get(provider) or {}
+    return dict(defaults, provider=provider)
+
+
+def derived_credentials(config):
+    """{name: definition} for every credential an env's creds list derives.
+
+    These are real — they hold a Keychain secret once logged in — but they have
+    no entry in ~/.dax.yaml, so anything enumerating credentials has to rebuild
+    them the same way resolution does or they simply vanish from view.
+    """
     registry = config.get('credentials', {})
-    return {name: registry[name] for name in project.get('creds', [])}
+    found = {}
+    for project_name, project in (config.get('projects') or {}).items():
+        try:
+            resolved = resolve_credential_names(project, project_name)
+        except ValueError:
+            continue  # unresolvable; reported by `dax env show` and `dax run`
+        for name, provider in resolved:
+            if provider and name not in registry:
+                found[name] = synthesized_credential(config, provider)
+    return found
+
+
+def credential_users(config, name):
+    """Envs whose creds list resolves to this credential — derived or not."""
+    users = []
+    for project_name, project in (config.get('projects') or {}).items():
+        try:
+            resolved = resolve_credential_names(project, project_name)
+        except ValueError:
+            continue
+        if any(resolved_name == name for resolved_name, _ in resolved):
+            users.append(project_name)
+    return users
+
+
+def get_project_credentials(config, project, project_name=None):
+    """Map an env's `creds:` list to credential definitions.
+
+    `project_name` is required to expand bare provider tokens; without it the
+    list is taken literally, which is what the older call sites did.
+    """
+    registry = config.get('credentials', {})
+    if project_name is None:
+        return {name: registry[name] for name in project.get('creds', []) or []}
+
+    creds = {}
+    for name, provider in resolve_credential_names(project, project_name):
+        if name in registry:
+            creds[name] = registry[name]
+        elif provider:
+            # No entry of its own — synthesized rather than written to
+            # ~/.dax.yaml so this stays a pure read. Per-provider defaults are
+            # what carry browser/chrome_profile onto it.
+            creds[name] = synthesized_credential(config, provider)
+        else:
+            raise KeyError(name)
+    return creds
 
 
 def daemon_socket_path(workdir):

--- a/dax_creds/config.py
+++ b/dax_creds/config.py
@@ -364,11 +364,6 @@ def get_project_credentials(config, project, project_name=None):
     return creds
 
 
-def daemon_socket_path(workdir):
-    digest = hashlib.sha256(str(workdir).encode()).hexdigest()[:12]
-    return Path.home() / '.dax' / f'creds-{digest}.sock'
-
-
 def dir_basename(path):
     """Final path component, robust to a trailing slash.
 

--- a/dax_creds/config.py
+++ b/dax_creds/config.py
@@ -24,6 +24,8 @@ ENV_FIELDS = {
               'in the container (needs "mounts" in features too). A path may be '
               '<host>:<container_name> to mount under a name other than its own '
               'basename, e.g. ~/.claude:host-claude',
+    'substrate': 'host path to a virgil-style substrate repo, mounted read-write and '
+                 'exposed as $SUBSTRATE_ROOT (needs "substrate" in features too)',
 }
 
 

--- a/dax_creds/config.py
+++ b/dax_creds/config.py
@@ -21,7 +21,9 @@ ENV_FIELDS = {
     'creds': 'comma-separated credential names (replaces the whole list)',
     'features': 'comma-separated features for this env, on top of the global list',
     'mounts': 'comma-separated host paths, each mounted read-write at $HOME/<name> '
-              'in the container (needs "mounts" in features too)',
+              'in the container (needs "mounts" in features too). A path may be '
+              '<host>:<container_name> to mount under a name other than its own '
+              'basename, e.g. ~/.claude:host-claude',
 }
 
 

--- a/dax_creds/config.py
+++ b/dax_creds/config.py
@@ -215,6 +215,20 @@ def derived_credentials(config):
     return found
 
 
+def credential_names_for_provider(config, provider):
+    """Every credential name using this provider — registered and derived.
+
+    Used to enforce one-grant-per-name at import time: the check needs the full
+    set of names whose Keychain secrets could collide, and a derived name holds a
+    secret just as a registered one does.
+    """
+    names = {name for name, cred in (config.get('credentials') or {}).items()
+             if (cred or {}).get('provider') == provider}
+    names |= {name for name, cred in derived_credentials(config).items()
+              if cred.get('provider') == provider}
+    return names
+
+
 def credential_users(config, name):
     """Envs whose creds list resolves to this credential — derived or not."""
     users = []

--- a/dax_creds/config.py
+++ b/dax_creds/config.py
@@ -20,6 +20,8 @@ ENV_FIELDS = {
     'image': 'docker image to run for this env',
     'creds': 'comma-separated credential names (replaces the whole list)',
     'features': 'comma-separated features for this env, on top of the global list',
+    'mounts': 'comma-separated host paths, each mounted read-write at $HOME/<name> '
+              'in the container (needs "mounts" in features too)',
 }
 
 

--- a/dax_creds/config.py
+++ b/dax_creds/config.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 from pathlib import Path
 import yaml
 
@@ -46,6 +47,96 @@ def state_trees():
         for tenant_dir in sorted(root.iterdir()) if tenant_dir.is_dir()
         for project_dir in sorted(tenant_dir.iterdir()) if project_dir.is_dir()
     }
+
+
+# User-level files a `claude_tenant_state` tree mount replaces wholesale, taking
+# your global CLAUDE.md/settings with it. A nested read-only *file* bind mount
+# was tried first (2026-07-31) and abandoned within hours: unlike a nested
+# directory mount, it didn't deliver the host's content at all — the container
+# saw an empty file. This copies them in instead, at `dax run` time.
+CLAUDE_SHARED_FILES = ('CLAUDE.md', 'settings.json', 'settings.local.json')
+
+
+def _shared_files_manifest_path(tenant, project):
+    # A sibling of the tree, not inside it — anything under state_tree_path()
+    # is mounted straight into the container's ~/.claude, and this bookkeeping
+    # has no business showing up there.
+    return state_root() / tenant / '{}.shared-files.json'.format(project)
+
+
+def _load_shared_files_manifest(tenant, project):
+    path = _shared_files_manifest_path(tenant, project)
+    if not path.is_file():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_shared_files_manifest(tenant, project, manifest):
+    path = _shared_files_manifest_path(tenant, project)
+    path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + '\n')
+
+
+def _sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def sync_claude_shared_files(tenant, project, force=False):
+    """Copy the host's CLAUDE_SHARED_FILES into <tenant>/<project>'s state tree.
+
+    Three-way comparison against a small manifest (filename -> sha256 of what
+    was last synced in), because a plain host-vs-tree diff can't tell "host
+    moved on since last sync" (safe to overwrite) apart from "something changed
+    the tree's copy independently" (a container editing it directly, now that
+    it's a plain file and not a mount — exactly what should not be clobbered
+    silently). force=True (the `accept-shared-files` escape hatch) skips that
+    distinction and always takes the host's version.
+
+    Returns the list of filenames left alone because they'd drifted and
+    force was False — the caller's cue to warn.
+    """
+    host_claude = Path.home() / '.claude'
+    tree = state_tree_path(tenant, project)
+    manifest = _load_shared_files_manifest(tenant, project)
+    warnings = []
+    changed = False
+
+    for filename in CLAUDE_SHARED_FILES:
+        host_file = host_claude / filename
+        if not host_file.is_file():
+            continue
+        host_bytes = host_file.read_bytes()
+        host_hash = _sha256_bytes(host_bytes)
+        tree_file = tree / filename
+
+        if not tree_file.is_file():
+            tree.mkdir(parents=True, exist_ok=True)
+            tree_file.write_bytes(host_bytes)
+            manifest[filename] = host_hash
+            changed = True
+            continue
+
+        tree_bytes = tree_file.read_bytes()
+        tree_hash = _sha256_bytes(tree_bytes)
+        if tree_hash == host_hash:
+            if manifest.get(filename) != tree_hash:
+                manifest[filename] = tree_hash
+                changed = True
+            continue
+
+        if force or manifest.get(filename) == tree_hash:
+            tree_file.write_bytes(host_bytes)
+            manifest[filename] = host_hash
+            changed = True
+        else:
+            warnings.append(filename)
+
+    if changed:
+        _save_shared_files_manifest(tenant, project, manifest)
+
+    return warnings
 
 
 def env_field_help():

--- a/dax_creds/daemon.py
+++ b/dax_creds/daemon.py
@@ -113,12 +113,36 @@ class DispatchingExchanger:
         return self._passthrough.exchange(provider, refresh_token)
 
 
+_CLAUDE_DEVICE_FLOW_REDIRECT = 'https://platform.claude.com/oauth/code/callback'
+
+
+def _force_claude_device_flow_redirect(url):
+    # claude auth login binds a local listener inside the container and builds
+    # its primary authorize URL around that redirect_uri - but the browser
+    # opening it runs on the host (see handle_open_url below), so that port is
+    # unreachable and the redirect always fails. Claude Code separately prints
+    # a fallback URL with the same client_id/code_challenge/state but a
+    # redirect_uri that doesn't depend on a local listener - substituting it
+    # in here skips the guaranteed-to-fail hop instead of just working around
+    # it after the fact.
+    from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query)
+    redirect = query.get('redirect_uri', [''])[0]
+    if not redirect.startswith('http://localhost') and not redirect.startswith('http://127.0.0.1'):
+        return url
+    query['redirect_uri'] = [_CLAUDE_DEVICE_FLOW_REDIRECT]
+    return urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
+
+
 def handle_open_url(request, credentials, url_opener):
     url = request.get('url')
     if not url:
         return {'error': 'missing_url', 'message': 'url is required'}
     cred_name = request.get('credential', '')
     cred_def = credentials.get(cred_name, {})
+    if cred_def.get('provider') == 'claude':
+        url = _force_claude_device_flow_redirect(url)
     browser = cred_def.get('browser', 'default')
     chrome_profile = cred_def.get('chrome_profile')
     url_opener(url, browser, chrome_profile)
@@ -180,6 +204,14 @@ def _default_url_opener(url, browser, chrome_profile):
 def _make_handle(credentials, token_store, token_exchanger, cache, url_opener):
     async def handle(reader, writer):
         data = await reader.read(4096)
+        if not data:
+            # A bare connect-then-disconnect (e.g. _wait_for_tcp's readiness
+            # probe in dax.py) looks identical to a real client at this
+            # layer but never sends anything - not a malformed request, and
+            # there's nobody left to write a response to.
+            writer.close()
+            await writer.wait_closed()
+            return
         try:
             request = json.loads(data)
         except json.JSONDecodeError:

--- a/dax_creds/init.py
+++ b/dax_creds/init.py
@@ -737,6 +737,12 @@ def run_env_show(config, name):
     env_features = proj.get('features') or []
     print(f'  features {", ".join(env_features) or "(none beyond the global list)"}')
 
+    env_mounts = proj.get('mounts') or []
+    if env_mounts:
+        print(f'  mounts   {", ".join(env_mounts)}')
+        if 'mounts' not in env_features:
+            print('           note: "mounts" feature not in features list above — inactive')
+
     # A bare provider token in `creds:` is a request for a per-env credential
     # whose name dax derives. Showing the resolved name keeps the convention
     # visible rather than magic — and surfaces the "no tenant" error here,
@@ -810,6 +816,8 @@ def run_env_set(config, name, field, value, valid_features=None):
                 'not defined in ~/.dax.yaml credentials: {} (or use a bare provider '
                 'name for a per-env credential: {})'.format(
                     ', '.join(unknown), ', '.join(BARE_PROVIDER_CREDS)))
+    elif field == 'mounts':
+        new = [m.strip() for m in value.split(',') if m.strip()]
     else:
         new = value
 

--- a/dax_creds/init.py
+++ b/dax_creds/init.py
@@ -730,6 +730,12 @@ def run_env_show(config, name):
     print(f'  image    {proj.get("image", "?")}')
     print(f'  creds    {", ".join(creds) or "(none)"}')
 
+    # Shown even when empty: whether this env opted into claude_tenant_state is
+    # the difference between its Claude state being its own and being shared with
+    # every other env, and nothing else in this output would reveal it.
+    env_features = proj.get('features') or []
+    print(f'  features {", ".join(env_features) or "(none beyond the global list)"}')
+
     # A bare provider token in `creds:` is a request for a per-env credential
     # whose name dax derives. Showing the resolved name keeps the convention
     # visible rather than magic — and surfaces the "no tenant" error here,
@@ -767,8 +773,14 @@ def run_env_show(config, name):
     print()
 
 
-def run_env_set(config, name, field, value):
-    """Set a single field on one env's registry entry. Returns the new value."""
+def run_env_set(config, name, field, value, valid_features=None):
+    """Set a single field on one env's registry entry. Returns the new value.
+
+    `valid_features` is passed in by the caller rather than imported: the feature
+    functions live in dax.py, which imports this module, and validating against
+    them matters — a per-env feature list is silently ignored when misspelled,
+    the same failure mode a typo'd credential name had.
+    """
     projects = config.get('projects', {})
     if name not in projects:
         known = ', '.join(sorted(projects)) or '(none registered)'
@@ -777,7 +789,15 @@ def run_env_set(config, name, field, value):
         raise ValueError(
             f'unknown field {field!r}.\n' + env_field_help())
 
-    if field == 'creds':
+    if field == 'features':
+        new = [f.strip() for f in value.split(',') if f.strip()]
+        if valid_features is not None:
+            unknown = [f for f in new if f not in valid_features]
+            if unknown:
+                raise ValueError(
+                    'not a dax feature: {} (see `dax features`)'.format(
+                        ', '.join(unknown)))
+    elif field == 'creds':
         new = [c.strip() for c in value.split(',') if c.strip()]
         # A bare provider name is not a credential in the registry — it asks
         # dax to derive one per tenant/project (see BARE_PROVIDER_CREDS).

--- a/dax_creds/init.py
+++ b/dax_creds/init.py
@@ -7,6 +7,7 @@ from dax_creds.config import (
     BARE_PROVIDER_CREDS, ENV_FIELDS, credential_names_for_provider,
     credential_users, daemon_socket_path, derived_credentials, env_field_help,
     resolve_credential_names, state_tree_path, state_trees,
+    sync_claude_shared_files,
 )
 from dax_creds.providers.ssh import SshProvider
 
@@ -820,6 +821,30 @@ def run_env_set(config, name, field, value, valid_features=None):
     shown_new = ', '.join(new) if isinstance(new, list) else new
     print(f'  [{name}] {field}: {shown_old if old is not None else "(unset)"} -> {shown_new}')
     return new
+
+
+def run_env_accept_shared_files(config, name):
+    """Force-adopt the host's CLAUDE.md/settings.json/settings.local.json into
+    one env's state tree, resolving a `dax run`-time drift warning.
+
+    The deliberate escape hatch for `sync_claude_shared_files`'s drift check:
+    that check refuses to guess whether a tree's copy diverged because it's
+    stale or because something meant to change it, so resolving it is always
+    an explicit act, never automatic.
+    """
+    projects = config.get('projects', {})
+    if name not in projects:
+        known = ', '.join(sorted(projects)) or '(none registered)'
+        raise KeyError(f'no env named {name!r}. Known envs: {known}')
+
+    tenant = projects[name].get('tenant')
+    if not tenant:
+        raise ValueError(
+            f'{name!r} has no tenant declared, so it has no state tree — '
+            f'set one with `dax env set {name} tenant <name>`')
+
+    sync_claude_shared_files(tenant, name, force=True)
+    print(f'  [{name}] CLAUDE.md/settings.json/settings.local.json now match the host.')
 
 
 def run_envs_list(config):

--- a/dax_creds/init.py
+++ b/dax_creds/init.py
@@ -142,6 +142,12 @@ def _define_credential(cred_name, provider_name, browser_enumerator=None):
     return cred_def
 
 
+# Every _setup_* below returns True when the credential ends up with a usable
+# secret and False when it does not, so the caller can stop announcing "saved"
+# for a credential nothing was stored for. The YAML write really did happen in
+# that case — but "saved" answers a different question than the one the user is
+# asking, which is whether the credential works now.
+#
 # Every _setup_* below takes `replace`. It is False for ordinary setup, where
 # an existing secret means there is nothing to do, and True only when the user
 # has explicitly confirmed "Overwrite it?" in `dax creds add`. Without it the
@@ -152,13 +158,15 @@ def _setup_ssh_credential(cred_name, cred_def, replace=False):
     provider = SshProvider()
     if not replace and provider.check(cred_def):
         print(f'  [{cred_name}] already loaded in SSH agent.')
-        return
+        return True
     print(f'  [{cred_name}] loading {cred_def["key"]} into macOS Keychain...')
     try:
         provider.setup(cred_def)
         print(f'  [{cred_name}] done.')
+        return True
     except RuntimeError as e:
         print(f'  [{cred_name}] failed: {e}', file=sys.stderr)
+        return False
 
 
 def _setup_github_credential(cred_name, cred_def, config, replace=False):
@@ -167,20 +175,20 @@ def _setup_github_credential(cred_name, cred_def, config, replace=False):
 
     if not replace and provider.check(cred_def, cred_name):
         print(f'  [{cred_name}] token already in Keychain.')
-        return
+        return True
 
     token = provider.import_from_disk(cred_def, credential_name=cred_name)
     if token:
         print(f'  [{cred_name}] importing existing token from ~/.config/gh/hosts.yml')
         provider.store(cred_name, token)
         print(f'  [{cred_name}] done. Consider removing the token from hosts.yml.')
-        return
+        return True
 
     if not cred_def.get('client_id'):
         client_id = _prompt('GitHub OAuth App client_id')
         if not client_id:
             print(f'  [{cred_name}] skipped — no client_id provided.')
-            return
+            return False
         cred_def['client_id'] = client_id
         config.setdefault('credentials', {})[cred_name] = cred_def
 
@@ -198,8 +206,10 @@ def _setup_github_credential(cred_name, cred_def, config, replace=False):
 
     try:
         provider.acquire(cred_def, cred_name, opener=opener)
+        return True
     except RuntimeError as e:
         print(f'  [{cred_name}] failed: {e}', file=sys.stderr)
+        return False
 
 
 def _setup_claude_credential(cred_name, cred_def, replace=False, config=None):
@@ -208,7 +218,7 @@ def _setup_claude_credential(cred_name, cred_def, replace=False, config=None):
 
     if not replace and provider.check(cred_def, cred_name):
         print(f'  [{cred_name}] token already in Keychain.')
-        return
+        return True
 
     token = provider.import_from_disk(cred_def)
     if token:
@@ -225,13 +235,14 @@ def _setup_claude_credential(cred_name, cred_def, replace=False, config=None):
             print(f'  [{cred_name}] {lines[0]}')
             for line in lines[1:]:
                 print(f'  [{cred_name}] {line}')
-            return
+            return False
         print(f'  [{cred_name}] importing existing token from ~/.claude/.credentials.json')
         provider.store(cred_name, token)
         print(f'  [{cred_name}] done.')
-        return
+        return True
 
     _report_no_token(cred_name, provider, cred_def, replace)
+    return False
 
 
 def _setup_auggie_credential(cred_name, cred_def, replace=False):
@@ -240,16 +251,17 @@ def _setup_auggie_credential(cred_name, cred_def, replace=False):
 
     if not replace and provider.check(cred_def, cred_name):
         print(f'  [{cred_name}] token already in Keychain.')
-        return
+        return True
 
     token = provider.import_from_disk(cred_def)
     if token:
         print(f'  [{cred_name}] importing existing token from ~/.augment/session.json')
         provider.store(cred_name, token)
         print(f'  [{cred_name}] done.')
-        return
+        return True
 
     _report_no_token(cred_name, provider, cred_def, replace)
+    return False
 
 
 def _setup_google_credential(cred_name, cred_def, replace=False):
@@ -258,9 +270,10 @@ def _setup_google_credential(cred_name, cred_def, replace=False):
 
     if not replace and provider.check(cred_def, cred_name):
         print(f'  [{cred_name}] refresh token already in Keychain.')
-        return
+        return True
 
     _report_no_token(cred_name, provider, cred_def, replace)
+    return False
 
 
 def _report_no_token(cred_name, provider, cred_def, replace):
@@ -355,20 +368,38 @@ def _run_init(config, cwd):
     return config
 
 
-def run_creds_add(config):
+def run_creds_add(config, cwd=None):
+    """Returns (config, pending_login). See `_run_creds_add`."""
     print('\ndax creds add\n')
     try:
-        return _run_creds_add(config)
+        return _run_creds_add(config, cwd=cwd)
     except KeyboardInterrupt:
         print('\n\nCancelled. Nothing was saved.')
         sys.exit(0)
 
 
-def _run_creds_add(config):
+_CRED_PROVIDERS = ['ssh', 'github', 'claude', 'auggie', 'gmail', 'drive']
+
+
+def _run_creds_add(config, cwd=None):
+    """Returns (config, pending_login) — a credential name to log in, or None.
+
+    Provider is asked *first*, because the answer decides whether a name is even
+    a question. For a per-env provider (`BARE_PROVIDER_CREDS` — claude) dax
+    builds the name from the env, so prompting for one would invite exactly the
+    typo decision C2 exists to eliminate: a misspelled `claud-fre` sat unused in
+    ~/.dax.yaml for weeks, silently, because a name nothing matches is simply
+    never used.
+    """
+    provider_name = _q_select('Provider:', _CRED_PROVIDERS)
+
+    if provider_name in BARE_PROVIDER_CREDS:
+        return _add_per_env_credential(config, provider_name, cwd=cwd)
+
     cred_name = _prompt('Credential name (e.g. ssh-github, github-dfarrow)')
     if not cred_name:
         print('No name provided. Nothing saved.')
-        return config
+        return config, None
 
     existing = config.get('credentials', {}).get(cred_name)
     replace = False
@@ -376,28 +407,131 @@ def _run_creds_add(config):
         print(f'  "{cred_name}" already exists (provider: {existing.get("provider")}).')
         if not _q_confirm('Overwrite it?', default=False):
             print('Nothing changed.')
-            return config
+            return config, None
         # Carried into setup so the provider actually re-stores the secret.
         replace = True
 
-    provider_name = _q_select('Provider:', ['ssh', 'github', 'claude', 'auggie', 'gmail', 'drive'])
     cred_def = _define_credential(cred_name, provider_name)
     config.setdefault('credentials', {})[cred_name] = cred_def
 
     if provider_name == 'ssh':
-        _setup_ssh_credential(cred_name, cred_def, replace=replace)
+        stored = _setup_ssh_credential(cred_name, cred_def, replace=replace)
     elif provider_name == 'github':
-        _setup_github_credential(cred_name, cred_def, config, replace=replace)
-    elif provider_name == 'claude':
-        _setup_claude_credential(cred_name, cred_def, replace=replace, config=config)
+        stored = _setup_github_credential(cred_name, cred_def, config, replace=replace)
     elif provider_name == 'auggie':
-        _setup_auggie_credential(cred_name, cred_def, replace=replace)
-    elif provider_name in ('gmail', 'drive'):
-        _setup_google_credential(cred_name, cred_def, replace=replace)
+        stored = _setup_auggie_credential(cred_name, cred_def, replace=replace)
+    else:
+        stored = _setup_google_credential(cred_name, cred_def, replace=replace)
 
     save_config(config)
-    print(f'\nCredential "{cred_name}" saved.')
-    return config
+    if stored:
+        print(f'\nCredential "{cred_name}" saved.')
+    else:
+        print(f'\nCredential "{cred_name}" was written to ~/.dax.yaml, but no secret '
+              f'is stored for it yet.')
+        print(f'Run `dax creds login {cred_name}` to authenticate.')
+    return config, None
+
+
+def _env_choices(config, cwd=None):
+    """Env names, with the one containing cwd first so it is the default."""
+    from dax_creds.config import find_enclosing_project, find_named_project_by_dir
+
+    names = list((config.get('projects') or {}))
+    if cwd is None:
+        cwd = Path.cwd()
+    here = None
+    try:
+        here = find_named_project_by_dir(config, cwd)[0]
+    except KeyError:
+        enclosing = find_enclosing_project(config, cwd)
+        if enclosing:
+            here = enclosing[0]
+    if here in names:
+        names.remove(here)
+        names.insert(0, here)
+    return names
+
+
+def _add_per_env_credential(config, provider, cwd=None):
+    """Set up a per-env credential: dax derives the name, a login mints the secret.
+
+    Deliberately never imports a token from disk. That path copies whatever is
+    already in the provider's on-disk location — under a shared `~/.claude` mount,
+    some *other* env's credential — putting two names on one OAuth grant, which
+    is the isolation failure decision C exists to prevent. Grant collisions are
+    refused at store time too (decision C6), but not offering the copy at all is
+    better than refusing it after the fact.
+    """
+    from dax_creds.config import derived_credential_name
+
+    projects = config.get('projects') or {}
+    if not projects:
+        print(f'  no envs registered, so there is nothing to scope a {provider} '
+              f'credential to.\n  Run `dax init` first.')
+        return config, None
+
+    print(f'\n  {provider} credentials are per env, and dax builds the name from the '
+          f'env\'s\n  tenant and name rather than asking you to type it.\n')
+    env_name = _q_select('Env:', _env_choices(config, cwd=cwd))
+    project = projects[env_name]
+
+    tenant = project.get('tenant')
+    if not tenant:
+        # The one point where tenant genuinely is not known yet: the derived name
+        # cannot be built without it, and decision C2 refuses rather than falling
+        # back to a shared credential. Asked here rather than earlier because
+        # tenant belongs to the env, not to the credential — everywhere else the
+        # registry already knows the answer.
+        print(f'  env {env_name!r} has no tenant, and the credential name is built '
+              f'from it.')
+        tenant = _prompt('Tenant to group this env under')
+        if not tenant:
+            print('  no tenant given. Nothing saved.')
+            return config, None
+        project['tenant'] = tenant
+
+    cred_name = derived_credential_name(provider, tenant, env_name)
+    print(f'\n  -> {cred_name}')
+
+    creds = project.setdefault('creds', [])
+    if provider not in creds and cred_name not in creds:
+        print(f'  {env_name} does not use it yet.')
+        if _q_confirm(f'Add `{provider}` to {env_name}\'s creds list?', default=True):
+            creds.append(provider)
+        else:
+            print(f'  leaving {env_name}\'s creds list alone — the credential will '
+                  f'exist but go unused.')
+
+    # Browser and profile belong to the human authenticating, not to the env, so
+    # they live in one `credential_defaults` block covering every derived
+    # credential of this provider (decision C4) rather than being re-answered per
+    # env.
+    defaults = (config.get('credential_defaults') or {}).get(provider) or {}
+    if not defaults:
+        print(f'\n  no credential_defaults for {provider} yet — this applies to every '
+              f'derived\n  {provider} credential, not just this one.')
+        picked = _pick_browser()
+        entry = {'browser': picked['browser']}
+        if picked['chrome_profile']:
+            entry['chrome_profile'] = picked['chrome_profile']
+        config.setdefault('credential_defaults', {})[provider] = entry
+
+    save_config(config)
+
+    stored = bool(_keyring_module
+                  and _keyring_module.get_password(_KEYCHAIN_SERVICE, cred_name))
+    if stored:
+        print(f'\n  [{cred_name}] already has a secret in Keychain — nothing to mint.')
+        print(f'  [{cred_name}] to replace it: dax creds login {cred_name}')
+        return config, None
+
+    print(f'\n  [{cred_name}] no secret yet — it is minted by its own login,')
+    print(f'                so that each name is an independent OAuth grant.')
+    if _q_confirm(f'Run `dax creds login {cred_name}` now?', default=True):
+        return config, cred_name
+    print(f'  [{cred_name}] run it when ready: dax creds login {cred_name}')
+    return config, None
 
 
 def _cred_status(config, name, cred_def):

--- a/dax_creds/init.py
+++ b/dax_creds/init.py
@@ -1,8 +1,13 @@
+import os
 import sys
-import yaml
+import time
 from pathlib import Path
 
-from dax_creds.config import daemon_socket_path
+from dax_creds.config import (
+    BARE_PROVIDER_CREDS, ENV_FIELDS, credential_users, daemon_socket_path,
+    derived_credentials, env_field_help, resolve_credential_names,
+    state_tree_path, state_trees,
+)
 from dax_creds.providers.ssh import SshProvider
 
 try:
@@ -24,9 +29,29 @@ def register_project(config, name, project_dir, image, creds):
 
 
 def save_config(config):
+    """Rewrite ~/.dax.yaml, preserving comments, key order, and quoting.
+
+    Refuses rather than falling back to pyyaml when ruamel is missing: a
+    pyyaml rewrite silently deletes every comment in the file and alphabetises
+    the keys, which is worse than not saving at all. Reads still fall back —
+    see `dax_creds.config.load_dax_config`.
+
+    Serialises fully before opening the file so a dump that raises cannot
+    leave a truncated config behind. Deliberately an in-place write rather
+    than write-temp-plus-rename: ~/.dax.yaml is a single-file bind mount
+    inside a dax container, and single-file grpcfuse mounts are exactly where
+    atomic rename breaks (see docs/design/2026-07-27-tenant-isolation.md).
+    """
+    from io import StringIO
+    from dax_creds.config import yaml_round_trip
+
+    buf = StringIO()
+    yaml_round_trip('save_config').dump(config, buf)
+    rendered = buf.getvalue()
+
     config_path = Path.home() / '.dax.yaml'
     with open(config_path, 'w') as f:
-        yaml.dump(config, f, default_flow_style=False)
+        f.write(rendered)
 
 
 def _q_text(prompt, default=None):
@@ -117,9 +142,15 @@ def _define_credential(cred_name, provider_name, browser_enumerator=None):
     return cred_def
 
 
-def _setup_ssh_credential(cred_name, cred_def):
+# Every _setup_* below takes `replace`. It is False for ordinary setup, where
+# an existing secret means there is nothing to do, and True only when the user
+# has explicitly confirmed "Overwrite it?" in `dax creds add`. Without it the
+# early-exits made that confirmation a lie: the YAML metadata was rewritten
+# while the Keychain secret was left untouched, so a rotated credential could
+# not be re-imported without `dax creds remove` first.
+def _setup_ssh_credential(cred_name, cred_def, replace=False):
     provider = SshProvider()
-    if provider.check(cred_def):
+    if not replace and provider.check(cred_def):
         print(f'  [{cred_name}] already loaded in SSH agent.')
         return
     print(f'  [{cred_name}] loading {cred_def["key"]} into macOS Keychain...')
@@ -130,11 +161,11 @@ def _setup_ssh_credential(cred_name, cred_def):
         print(f'  [{cred_name}] failed: {e}', file=sys.stderr)
 
 
-def _setup_github_credential(cred_name, cred_def, config):
+def _setup_github_credential(cred_name, cred_def, config, replace=False):
     from dax_creds.providers.github import GitHubProvider
     provider = GitHubProvider()
 
-    if provider.check(cred_def, cred_name):
+    if not replace and provider.check(cred_def, cred_name):
         print(f'  [{cred_name}] token already in Keychain.')
         return
 
@@ -171,11 +202,11 @@ def _setup_github_credential(cred_name, cred_def, config):
         print(f'  [{cred_name}] failed: {e}', file=sys.stderr)
 
 
-def _setup_claude_credential(cred_name, cred_def):
+def _setup_claude_credential(cred_name, cred_def, replace=False):
     from dax_creds.providers.claude import ClaudeProvider
     provider = ClaudeProvider()
 
-    if provider.check(cred_def, cred_name):
+    if not replace and provider.check(cred_def, cred_name):
         print(f'  [{cred_name}] token already in Keychain.')
         return
 
@@ -186,14 +217,14 @@ def _setup_claude_credential(cred_name, cred_def):
         print(f'  [{cred_name}] done.')
         return
 
-    print(f'  [{cred_name}] no token found — run `dax creds login {cred_name}` to authenticate.')
+    _report_no_token(cred_name, provider, cred_def, replace)
 
 
-def _setup_auggie_credential(cred_name, cred_def):
+def _setup_auggie_credential(cred_name, cred_def, replace=False):
     from dax_creds.providers.auggie import AuggieProvider
     provider = AuggieProvider()
 
-    if provider.check(cred_def, cred_name):
+    if not replace and provider.check(cred_def, cred_name):
         print(f'  [{cred_name}] token already in Keychain.')
         return
 
@@ -204,18 +235,32 @@ def _setup_auggie_credential(cred_name, cred_def):
         print(f'  [{cred_name}] done.')
         return
 
-    print(f'  [{cred_name}] no token found — run `dax creds login {cred_name}` to authenticate.')
+    _report_no_token(cred_name, provider, cred_def, replace)
 
 
-def _setup_google_credential(cred_name, cred_def):
+def _setup_google_credential(cred_name, cred_def, replace=False):
     from dax_creds.providers.google import GoogleProvider
     provider = GoogleProvider(cred_def['provider'])
 
-    if provider.check(cred_def, cred_name):
+    if not replace and provider.check(cred_def, cred_name):
         print(f'  [{cred_name}] refresh token already in Keychain.')
         return
 
+    _report_no_token(cred_name, provider, cred_def, replace)
+
+
+def _report_no_token(cred_name, provider, cred_def, replace):
+    """Nothing was found to store. Say plainly whether the old secret survived.
+
+    On a confirmed overwrite this matters: the user asked for the secret to be
+    replaced and it was not, so silently printing the usual "no token found"
+    would leave them believing the old one is gone.
+    """
     print(f'  [{cred_name}] no token found — run `dax creds login {cred_name}` to authenticate.')
+    if replace and provider.check(cred_def, cred_name):
+        print(f'  [{cred_name}] the existing Keychain secret was left in place — '
+              f'nothing new was found to replace it.')
+        print(f'  [{cred_name}] to clear it anyway: dax creds remove {cred_name}')
 
 
 def run_init(config, cwd):
@@ -312,26 +357,29 @@ def _run_creds_add(config):
         return config
 
     existing = config.get('credentials', {}).get(cred_name)
+    replace = False
     if existing:
         print(f'  "{cred_name}" already exists (provider: {existing.get("provider")}).')
         if not _q_confirm('Overwrite it?', default=False):
             print('Nothing changed.')
             return config
+        # Carried into setup so the provider actually re-stores the secret.
+        replace = True
 
     provider_name = _q_select('Provider:', ['ssh', 'github', 'claude', 'auggie', 'gmail', 'drive'])
     cred_def = _define_credential(cred_name, provider_name)
     config.setdefault('credentials', {})[cred_name] = cred_def
 
     if provider_name == 'ssh':
-        _setup_ssh_credential(cred_name, cred_def)
+        _setup_ssh_credential(cred_name, cred_def, replace=replace)
     elif provider_name == 'github':
-        _setup_github_credential(cred_name, cred_def, config)
+        _setup_github_credential(cred_name, cred_def, config, replace=replace)
     elif provider_name == 'claude':
-        _setup_claude_credential(cred_name, cred_def)
+        _setup_claude_credential(cred_name, cred_def, replace=replace)
     elif provider_name == 'auggie':
-        _setup_auggie_credential(cred_name, cred_def)
+        _setup_auggie_credential(cred_name, cred_def, replace=replace)
     elif provider_name in ('gmail', 'drive'):
-        _setup_google_credential(cred_name, cred_def)
+        _setup_google_credential(cred_name, cred_def, replace=replace)
 
     save_config(config)
     print(f'\nCredential "{cred_name}" saved.')
@@ -342,10 +390,9 @@ def _cred_status(config, name, cred_def):
     """Return (stored, envs_list, warnings_list) for a credential."""
     stored = bool(_keyring_module and _keyring_module.get_password(_KEYCHAIN_SERVICE, name))
 
-    envs = []
-    for proj_name, proj in config.get('projects', {}).items():
-        if name in proj.get('creds', []):
-            envs.append(proj_name)
+    # Resolved rather than matched literally: an env listing a bare `claude`
+    # never matches the derived name it actually uses.
+    envs = credential_users(config, name)
 
     warnings = []
     provider = cred_def.get('provider', '?')
@@ -380,7 +427,13 @@ def _cred_status(config, name, cred_def):
 
 
 def run_creds_list(config):
-    credentials = config.get('credentials', {})
+    # Derived credentials have no entry in ~/.dax.yaml but do hold a Keychain
+    # secret once logged in. Omitting them made `dax creds list` on the host
+    # disagree with `dax-creds list` inside the container, which lists what the
+    # daemon was actually given.
+    derived = derived_credentials(config)
+    credentials = dict(config.get('credentials', {}))
+    credentials.update(derived)
     if not credentials:
         print('No credentials registered.')
         return
@@ -420,6 +473,8 @@ def run_creds_list(config):
             detail = browser_label(cred_def.get('browser', 'default'), cred_def.get('chrome_profile'))
         else:
             detail = ''
+        if name in derived:
+            warnings = warnings + ['(derived)']
         flags = '  '.join(warnings)
         if len(detail) > _DETAIL_MAX:
             detail = detail[:_DETAIL_MAX - 3] + '...'
@@ -453,39 +508,252 @@ def _is_container_running(container_name):
 _CREDS_MAX = 38
 
 
-def run_envs_list(config):
+def _tree_stats(path):
+    """(total bytes, newest mtime) for a state tree, in a single walk.
+
+    Size and recency answer different halves of "is this worth keeping": a
+    large tree nobody has opened in a year is a better deletion candidate than
+    a small one from this morning.
+
+    Newest-file mtime rather than the directory's own: a directory's mtime only
+    moves when entries are added or removed, so editing a transcript in place
+    would not register.
+    """
+    total = 0
+    newest = 0.0
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            try:
+                st = os.lstat(os.path.join(root, name))
+            except OSError:
+                continue  # vanished mid-walk or unreadable — not worth failing a listing over
+            total += st.st_size
+            newest = max(newest, st.st_mtime)
+    return total, newest
+
+
+def _human_size(n):
+    for unit in ('B', 'K', 'M'):
+        if n < 1024:
+            return f'{int(n)}{unit}'
+        n /= 1024
+    return f'{n:.1f}G'
+
+
+def _human_age(mtime, now=None):
+    """Compact relative age — the useful question is staleness, not the date."""
+    if not mtime:
+        return '-'
+    seconds = max(0.0, (time.time() if now is None else now) - mtime)
+    if seconds < 60:
+        return 'now'
+    for div, unit, limit in ((60, 'm', 3600), (3600, 'h', 86400),
+                             (86400, 'd', 7 * 86400), (7 * 86400, 'w', 365 * 86400)):
+        if seconds < limit:
+            return f'{int(seconds // div)}{unit}'
+    return f'{int(seconds // (365 * 86400))}y'
+
+
+def _home_relative(path):
+    """Shorten host paths for display. Returns the path unchanged when it isn't
+    under $HOME — which is the normal case inside a container, where registry
+    entries hold host paths like /Users/... that don't exist locally."""
+    try:
+        return '~/' + str(Path(path).relative_to(Path.home()))
+    except ValueError:
+        return str(path)
+
+def run_env_show(config, name):
+    """Print one env's full registry entry plus what it resolves to."""
     projects = config.get('projects', {})
-    if not projects:
-        print('No environments registered.')
-        return
+    if name not in projects:
+        known = ', '.join(sorted(projects)) or '(none registered)'
+        raise KeyError(f'no env named {name!r}. Known envs: {known}')
+
+    proj = projects[name]
+    dir_path = proj.get('dir', '')
+    tenant = proj.get('tenant')
+    creds = proj.get('creds', []) or []
+
+    print()
+    print(f'  env      {name}')
+    print(f'  tenant   {tenant or "(unset)"}')
+    print(f'  dir      {dir_path}{"" if Path(dir_path).exists() else "   [missing]"}')
+    print(f'  image    {proj.get("image", "?")}')
+    print(f'  creds    {", ".join(creds) or "(none)"}')
+
+    # A bare provider token in `creds:` is a request for a per-env credential
+    # whose name dax derives. Showing the resolved name keeps the convention
+    # visible rather than magic — and surfaces the "no tenant" error here,
+    # where it is cheap, rather than at launch.
+    if any(c in BARE_PROVIDER_CREDS for c in creds):
+        try:
+            for resolved, derived_provider in resolve_credential_names(proj, name):
+                if derived_provider:
+                    registered = '' if resolved in config.get('credentials', {}) else '   [not registered yet]'
+                    print(f'           -> {resolved}{registered}')
+        except ValueError as e:
+            print(f'           -> unresolved: {e.args[0]}')
+
+    container = _container_name_for(dir_path)
+    if container:
+        running = _is_container_running(container)
+        print(f'  container {container}   [{"running" if running else "stopped"}]')
+
+    if tenant:
+        state = state_tree_path(tenant, name)
+        if state.exists():
+            size, used = _tree_stats(state)
+            suffix = f'   [{_human_size(size)}, last used {_human_age(used)} ago]'
+        else:
+            suffix = '   [not created yet]'
+        print(f'  state    {state}{suffix}')
+
+    # Surfaced because these are being removed, so an entry still carrying them
+    # is a migration to-do rather than configuration.
+    legacy = [k for k in ('multi_tenant', 'tenant_subdir') if k in proj]
+    if legacy:
+        print()
+        print(f'  note: entry still carries {", ".join(legacy)} — '
+              'deprecated by the 2026-07-29 redesign')
+    print()
+
+
+def run_env_set(config, name, field, value):
+    """Set a single field on one env's registry entry. Returns the new value."""
+    projects = config.get('projects', {})
+    if name not in projects:
+        known = ', '.join(sorted(projects)) or '(none registered)'
+        raise KeyError(f'no env named {name!r}. Known envs: {known}')
+    if field not in ENV_FIELDS:
+        raise ValueError(
+            f'unknown field {field!r}.\n' + env_field_help())
+
+    if field == 'creds':
+        new = [c.strip() for c in value.split(',') if c.strip()]
+        # A bare provider name is not a credential in the registry — it asks
+        # dax to derive one per tenant/project (see BARE_PROVIDER_CREDS).
+        unknown = [c for c in new
+                   if c not in config.get('credentials', {})
+                   and c not in BARE_PROVIDER_CREDS]
+        if unknown:
+            raise ValueError(
+                'not defined in ~/.dax.yaml credentials: {} (or use a bare provider '
+                'name for a per-env credential: {})'.format(
+                    ', '.join(unknown), ', '.join(BARE_PROVIDER_CREDS)))
+    else:
+        new = value
+
+    old = projects[name].get(field)
+    projects[name][field] = new
+    save_config(config)
+
+    shown_old = ', '.join(old) if isinstance(old, list) else old
+    shown_new = ', '.join(new) if isinstance(new, list) else new
+    print(f'  [{name}] {field}: {shown_old if old is not None else "(unset)"} -> {shown_new}')
+    return new
+
+
+def run_envs_list(config):
+    # No early return on an empty registry: deregistering every project is
+    # precisely when every state tree becomes an orphan, and bailing here would
+    # hide them all.
+    projects = config.get('projects', {})
+    trees = state_trees()
 
     rows = []
     for name, proj in projects.items():
         dir_path = proj.get('dir', '')
-        image = proj.get('image', '?')
+        tenant = proj.get('tenant')
         creds_str = ', '.join(proj.get('creds', [])) or '(none)'
         dir_exists = Path(dir_path).exists() if dir_path else False
         running = _is_container_running(_container_name_for(dir_path)) if dir_exists else False
-        status = '*' if running else (' ' if dir_exists else '!')
-        rows.append((status, name, image, dir_path, creds_str))
 
-    nc = max(len(r[1]) for r in rows)
-    ic = max(len(r[2]) for r in rows)
-    dc = max(len(r[3]) for r in rows)
+        # Claiming the tree here is what makes whatever survives an orphan.
+        # Only a declared tenant can claim one: without it there is no path to
+        # look under, so any tree bearing this project's name stays unclaimed
+        # and shows up below — which is the honest reading, since the registry
+        # no longer says which tenant it belongs to.
+        tree = trees.pop((tenant, name), None) if tenant else None
+
+        size, used = _tree_stats(tree) if tree else (None, None)
+        status = '*' if running else (' ' if dir_exists else '!')
+        rows.append((status, tenant or '-', name, proj.get('image', '?'),
+                     _home_relative(dir_path) if dir_path else '-',
+                     creds_str,
+                     _human_size(size) if tree else '-',
+                     _human_age(used) if tree else '-'))
+
+    # Anything still on disk has no registry entry pointing at it: the project
+    # was deregistered or its tenant renamed, and its transcripts and memory
+    # are still there. Invisible to every other command.
+    for (tenant, name), tree in sorted(trees.items()):
+        size, used = _tree_stats(tree)
+        rows.append(('?', tenant, name, '-', '-', '-',
+                     _human_size(size), _human_age(used)))
+
+    if not rows:
+        print('No environments registered, and no state trees on disk.')
+        return
+
+    headers = ('', 'tenant', 'name', 'image', 'dir', 'creds', 'state', 'used')
+    ncols = len(headers)
+    widths = [max(len(headers[i]), max(len(r[i]) for r in rows)) for i in range(ncols)]
+    widths[5] = min(widths[5], _CREDS_MAX)
+
+    def _line(cells):
+        return '  [{}]  {}'.format(cells[0], '  '.join(
+            str(c)[:widths[i]].ljust(widths[i]) for i, c in enumerate(cells[1:], start=1)))
 
     print()
-    print(f"  {'':3}  {'name':<{nc}}  {'image':<{ic}}  {'dir':<{dc}}  creds")
-    print(f"  {'':3}  {'-'*nc}  {'-'*ic}  {'-'*dc}  {'-'*_CREDS_MAX}")
-    for status, name, image, dir_path, creds_str in rows:
+    print(_line((' ',) + headers[1:]).replace('[ ]', '   ', 1))
+    print(_line((' ',) + tuple('-' * widths[i] for i in range(1, ncols))).replace('[ ]', '   ', 1))
+    for row in rows:
+        creds_str = row[5]
         if len(creds_str) > _CREDS_MAX:
             creds_str = creds_str[:_CREDS_MAX - 3] + '...'
-        print(f"  [{status}]  {name:<{nc}}  {image:<{ic}}  {dir_path:<{dc}}  {creds_str}")
+        print(_line(row[:5] + (creds_str,) + row[6:]))
+
+    markers = {r[0] for r in rows}
+    legend = [(m, t) for m, t in (('*', 'running'),
+                                  ('!', 'directory missing'),
+                                  ('?', 'orphaned state tree — no registry entry'))
+              if m in markers]
+    if legend:
+        print()
+        for marker, text in legend:
+            print(f'  [{marker}] {text}')
     print()
 
 
 def run_creds_remove(config, name, keyring=None):
-    if name not in config.get('credentials', {}):
+    """Remove a credential from both Keychain and ~/.dax.yaml.
+
+    Used to clear only the Keychain secret, leaving the definition in the
+    config — so the credential kept appearing in `dax creds list` and a
+    fat-fingered name could never actually be got rid of.
+    """
+    registered = name in config.get('credentials', {})
+    # A derived credential holds a Keychain secret but has no config entry, so
+    # without this it could not be removed at all — `dax creds remove` reported
+    # it as unknown. Clearing one is a legitimate "re-authenticate this env"
+    # operation: the next `dax run` finds it missing and offers a fresh login.
+    is_derived = not registered and name in derived_credentials(config)
+    if not registered and not is_derived:
         raise KeyError(name)
+
+    if registered:
+        # Checked before anything is deleted, so a refusal leaves both the
+        # Keychain and the config untouched. Removing a referenced credential
+        # would strand the project pointing at it with no error until its next
+        # launch. Derived names are exempt — the reference is the *convention*,
+        # which survives removal and simply re-mints.
+        referenced = sorted(credential_users(config, name))
+        if referenced:
+            raise ValueError(
+                f'{name} is still used by: {", ".join(referenced)}. Detach it first, '
+                f'e.g. `dax env set {referenced[0]} creds <remaining,names>`.')
+
     kr = keyring or _keyring_module
     if kr is None:
         raise ImportError('keyring package required: pip install keyring')
@@ -494,6 +762,16 @@ def run_creds_remove(config, name, keyring=None):
         print(f'  [{name}] removed from Keychain.')
     except Exception:
         print(f'  [{name}] not found in Keychain (nothing to remove).')
+
+    if is_derived:
+        users = ', '.join(credential_users(config, name)) or 'no env'
+        print(f'  [{name}] derived credential — nothing to remove from ~/.dax.yaml.')
+        print(f'  [{name}] {users} will be offered a fresh login on the next `dax run`.')
+        return
+
+    del config['credentials'][name]
+    save_config(config)
+    print(f'  [{name}] removed from ~/.dax.yaml.')
 
 
 def ensure_project_credentials(config, project_creds, keyring=None):

--- a/dax_creds/init.py
+++ b/dax_creds/init.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from dax_creds.config import (
     BARE_PROVIDER_CREDS, ENV_FIELDS, credential_names_for_provider,
-    credential_users, daemon_socket_path, derived_credentials, env_field_help,
+    credential_users, derived_credentials, env_field_help,
     resolve_credential_names, state_tree_path, state_trees,
     sync_claude_shared_files,
 )

--- a/dax_creds/init.py
+++ b/dax_creds/init.py
@@ -4,9 +4,9 @@ import time
 from pathlib import Path
 
 from dax_creds.config import (
-    BARE_PROVIDER_CREDS, ENV_FIELDS, credential_users, daemon_socket_path,
-    derived_credentials, env_field_help, resolve_credential_names,
-    state_tree_path, state_trees,
+    BARE_PROVIDER_CREDS, ENV_FIELDS, credential_names_for_provider,
+    credential_users, daemon_socket_path, derived_credentials, env_field_help,
+    resolve_credential_names, state_tree_path, state_trees,
 )
 from dax_creds.providers.ssh import SshProvider
 
@@ -202,8 +202,8 @@ def _setup_github_credential(cred_name, cred_def, config, replace=False):
         print(f'  [{cred_name}] failed: {e}', file=sys.stderr)
 
 
-def _setup_claude_credential(cred_name, cred_def, replace=False):
-    from dax_creds.providers.claude import ClaudeProvider
+def _setup_claude_credential(cred_name, cred_def, replace=False, config=None):
+    from dax_creds.providers.claude import ClaudeProvider, grant_collision_message
     provider = ClaudeProvider()
 
     if not replace and provider.check(cred_def, cred_name):
@@ -212,6 +212,20 @@ def _setup_claude_credential(cred_name, cred_def, replace=False):
 
     token = provider.import_from_disk(cred_def)
     if token:
+        # This path copies whatever sits in ~/.claude/.credentials.json, which
+        # under a shared mount is some *other* env's credential — the sharing
+        # decision C exists to prevent, and the one door `dax creds login`'s
+        # before/after guard never covered. Refuse on a grant collision rather
+        # than storing a second name for one grant (decision C6).
+        candidates = (credential_names_for_provider(config, 'claude')
+                      if config is not None else set())
+        clash = provider.grant_collision(cred_name, token, candidates)
+        if clash:
+            lines = grant_collision_message(cred_name, clash)
+            print(f'  [{cred_name}] {lines[0]}')
+            for line in lines[1:]:
+                print(f'  [{cred_name}] {line}')
+            return
         print(f'  [{cred_name}] importing existing token from ~/.claude/.credentials.json')
         provider.store(cred_name, token)
         print(f'  [{cred_name}] done.')
@@ -327,7 +341,7 @@ def _run_init(config, cwd):
         elif provider_name == 'github':
             _setup_github_credential(cred_name, cred_def, config)
         elif provider_name == 'claude':
-            _setup_claude_credential(cred_name, cred_def)
+            _setup_claude_credential(cred_name, cred_def, config=config)
         elif provider_name == 'auggie':
             _setup_auggie_credential(cred_name, cred_def)
         elif provider_name in ('gmail', 'drive'):
@@ -375,7 +389,7 @@ def _run_creds_add(config):
     elif provider_name == 'github':
         _setup_github_credential(cred_name, cred_def, config, replace=replace)
     elif provider_name == 'claude':
-        _setup_claude_credential(cred_name, cred_def, replace=replace)
+        _setup_claude_credential(cred_name, cred_def, replace=replace, config=config)
     elif provider_name == 'auggie':
         _setup_auggie_credential(cred_name, cred_def, replace=replace)
     elif provider_name in ('gmail', 'drive'):

--- a/dax_creds/init.py
+++ b/dax_creds/init.py
@@ -743,6 +743,12 @@ def run_env_show(config, name):
         if 'mounts' not in env_features:
             print('           note: "mounts" feature not in features list above — inactive')
 
+    substrate = proj.get('substrate')
+    if substrate:
+        print(f'  substrate {substrate}')
+        if 'substrate' not in env_features:
+            print('           note: "substrate" feature not in features list above — inactive')
+
     # A bare provider token in `creds:` is a request for a per-env credential
     # whose name dax derives. Showing the resolved name keeps the convention
     # visible rather than magic — and surfaces the "no tenant" error here,

--- a/dax_creds/providers/claude.py
+++ b/dax_creds/providers/claude.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from pathlib import Path
 
@@ -49,9 +50,67 @@ def is_oauth_envelope(value):
     return isinstance(oauth, dict) and bool(oauth.get('refreshToken'))
 
 
+def grant_id(value):
+    """A stable identifier for the OAuth grant a credentials blob belongs to.
+
+    The blob carries no grant ID, so the refresh token stands in for one: two
+    blobs holding the same refresh token are the same grant. Hashed rather than
+    compared directly so callers can log and report it without handling the
+    secret. None when the value isn't a refreshable envelope.
+    """
+    if not is_oauth_envelope(value):
+        return None
+    token = json.loads(value)['claudeAiOauth']['refreshToken']
+    return hashlib.sha256(token.encode()).hexdigest()[:12]
+
+
+def grant_collision_message(credential_name, other_name):
+    """Why an import was refused, as lines a caller prefixes in its own style.
+
+    Shared so `dax creds login` and `dax creds add` explain it identically — the
+    two paths reached this failure by different routes and used to disagree about
+    everything else.
+    """
+    return [
+        f"refusing to import: this token is the same OAuth grant as "
+        f"'{other_name}'.",
+        f"Two names on one grant share a refresh-token chain, so a rotation on "
+        f"either invalidates both — and nothing looks wrong until it does.",
+        f"Run `dax creds login {credential_name}` and complete the browser flow "
+        f"to mint an independent grant.",
+    ]
+
+
 class ClaudeProvider:
     def __init__(self, keyring=None):
         self._keyring = keyring or _keyring
+
+    def grant_collision(self, credential_name, token, candidate_names):
+        """The already-stored credential `token` would share a grant with, if any.
+
+        Per-env credentials only isolate anything when each one is its own OAuth
+        grant: independent grants have independent refresh-token chains, so a
+        rotation in one project cannot invalidate another's. Two names backed by
+        one grant authenticate perfectly and look correct — and a rotation on
+        either kills both. That failure has happened for real (2026-07-30), which
+        is why this is enforced at the moment of storing rather than left to the
+        manual check.
+
+        `credential_name` is skipped, so re-importing a credential's own token
+        under its own name is not a collision — that is a no-op, not sharing.
+        Returns None when the grant cannot be determined, or when there is no
+        Keychain to compare against.
+        """
+        gid = grant_id(token)
+        if gid is None or self._keyring is None:
+            return None
+        for name in sorted(candidate_names):
+            if name == credential_name:
+                continue
+            stored = self._keyring.get_password(_KEYCHAIN_SERVICE, name)
+            if stored and grant_id(stored) == gid:
+                return name
+        return None
 
     def _require_keyring(self):
         if self._keyring is None:

--- a/dax_creds/tenant.py
+++ b/dax_creds/tenant.py
@@ -1,0 +1,304 @@
+"""Resolve which tenant (customer) a directory belongs to.
+
+Implements the design doc's resolution table
+(docs/design/2026-07-27-tenant-isolation.md, decisions 7-9), revised
+2026-07-28 to drop `unattributed` as an automatic fallback:
+
+    single-tenant repo, at the root, declared     -> starts, state -> its tenant
+    single-tenant repo, at the root, undeclared   -> refuse
+    single-tenant repo, in a subdirectory         -> refuse (root is the sandbox)
+    multi-tenant repo, at the root, declared      -> starts, state -> its tenant
+    multi-tenant repo, at the root, undeclared    -> refuse
+    multi-tenant repo, mapped subdir              -> starts, state -> that tenant
+    multi-tenant repo, tenant_subdir base itself  -> refuse (no single answer)
+    multi-tenant repo, unmapped subdir            -> refuse
+
+(A row for project creds spanning multiple tenant labels is a separate,
+deferred check; see CLAUDE.md Backlog. Not implemented here.)
+
+There is no silent `unattributed/<reponame>` fallback anywhere in this table
+- an undeclared directory always refuses rather than pooling into a default
+tenant. That is a deliberate choice, not an oversight: cleaning up a tenant
+assigned after the fact is real, avoidable friction, so `dax run` (Gate A,
+`_ensure_tenants_classified` in `dax.py`) interactively leads the user
+through declaring anything undeclared *before* a container ever launches -
+by the time this module is asked to resolve anything, it should already be
+declared. Refusing here instead of falling back is the safety net for
+whatever reaches this module without having gone through that step (a
+brand-new subdirectory created mid-session, or a manual/bypassed invocation).
+
+Both single- and multi-tenant repos now let claude start **at the repo root
+itself**, treated as its own project - working on discernment's own tooling
+(its `CLAUDE.md`, skills library, bootstrap scripts) is not the same as
+working a specific customer engagement under it, and needs its own tenant
+and its own isolated state, distinct from any of the engagements below it.
+This replaced an earlier, since-revised rule where a multi-tenant repo's
+root always refused - discovered too narrow once real use turned up a
+genuine need to work on the repo independent of any one engagement.
+
+Whether a repo is multi-tenant is never inferred from what `.dax-tenant`
+files happen to exist - it is an explicit `multi_tenant` flag every caller
+must supply (sourced from `projects.<name>.multi_tenant` in `~/.dax.yaml`,
+defaulting to False when unset). That flag draws a hard line between where
+claude may even be started, not just where a tenant may be declared:
+
+    multi_tenant=False   claude may start at the repo root (only) - that IS
+                          the sandbox. A child directory refuses outright,
+                          even if it happens to carry its own .dax-tenant
+                          file.
+    multi_tenant=True     claude may start at the repo root (its own
+                          project, per above) or at an immediate child of
+                          `tenant_subdir` (or the root, if `tenant_subdir`
+                          isn't set) that carries its own .dax-tenant file.
+                          The `tenant_subdir` base itself (e.g. `processes/`)
+                          never resolves - there is no single answer for
+                          "all engagements collectively".
+
+Claude may only ever be started at a project's mount root or exactly one
+directory below it - never deeper - as an outer bound ahead of either branch
+above.
+
+Two entry points, sharing the same logic, so Gate A and Gate B can never
+disagree about what a repo resolves to:
+
+    all_tenant_projects(repo_root, multi_tenant)   Gate A (`dax run`, host):
+                                      every tenant/project pair the repo
+                                      could resolve to, for mount-scoping.
+    resolve_for_cwd(cwd, home, multi_tenant)   Gate B (`claude` wrapper,
+                                      in-container): resolve one cwd,
+                                      self-determining the repo root from
+                                      decision 2's mount convention (a
+                                      project always mounts as a single
+                                      directory directly under $HOME).
+"""
+from pathlib import Path
+
+from dax_creds.config import dir_basename
+
+TENANT_FILE = '.dax-tenant'
+
+# Never treated as a candidate tenant subdirectory, even if it happens to
+# contain a .dax-tenant file - these are tooling/vendor directories, not
+# project subdirectories a user would `cd` into and start claude from.
+_NOT_A_PROJECT_SUBDIR = {
+    '.git', 'node_modules', '__pycache__', '.venv', 'venv-2.7', 'venv-3',
+    '.pytest_cache',
+}
+
+
+class Resolution:
+    """One resolution-table outcome.
+
+    tenant: resolved tenant label, or None if refused.
+    project: basename of the directory whose .dax-tenant governs this
+        resolution (the repo root, whether single- or multi-tenant; or the
+        matched immediate child in multi-tenant mode) - the <project>
+        segment of ~/.local/state/dax/tenants/<tenant>/<project>/.
+    refuse: True when there is no safe resolution - too deep, undeclared
+        (root or subdirectory, either mode), the tenant_subdir base itself,
+        or outside any mounted project. There is no automatic fallback
+        anywhere in this table; see the module docstring for why.
+    detail: human-readable explanation, for wrapper/CLI messages.
+    """
+
+    def __init__(self, tenant, project, refuse, detail):
+        self.tenant = tenant
+        self.project = project
+        self.refuse = refuse
+        self.detail = detail
+
+    def __repr__(self):
+        return (
+            'Resolution(tenant={!r}, project={!r}, refuse={!r}, '
+            'detail={!r})'.format(
+                self.tenant, self.project, self.refuse, self.detail)
+        )
+
+    def __eq__(self, other):
+        return isinstance(other, Resolution) and vars(self) == vars(other)
+
+
+def _read_tenant_label(path):
+    """Tenant name declared in a .dax-tenant file.
+
+    None if the file is absent, empty, or whitespace-only - an accidental
+    empty file is treated as "not declared" rather than minting a tenant
+    literally named "".
+    """
+    try:
+        text = path.read_text()
+    except (FileNotFoundError, IsADirectoryError):
+        return None
+    return text.strip() or None
+
+
+def _too_deep(cwd, repo_root):
+    return cwd != repo_root and cwd.parent != repo_root
+
+
+def _too_deep_resolution(cwd, repo_root):
+    return Resolution(
+        tenant=None, project=None, refuse=True,
+        detail=(
+            '{} is more than one level below the mounted project root {}; '
+            'start claude at the project root or in a direct subdirectory '
+            'of it, not deeper'.format(cwd, repo_root)))
+
+
+def _undeclared_refusal(subdir, reponame):
+    return Resolution(
+        tenant=None, project=None, refuse=True,
+        detail='{} has no {}; run `dax tenant set {} <tenant>` (or `dax tenant '
+               'classify` to be led through it) before starting claude '
+               'here'.format(subdir, TENANT_FILE, subdir))
+
+
+def resolve_tenant(cwd, repo_root, multi_tenant, tenant_subdir=''):
+    """Apply the resolution table for `cwd` within a repo rooted at `repo_root`.
+
+    `tenant_subdir` (multi-tenant only): some repos keep their labeled
+    directories one level further in than the root - discernment's actual
+    tenant subdirectories sit under `processes/`, not directly under the
+    repo root, and restructuring the repo or splitting it into two projects
+    both cost more than this is worth for what is, today, a single project
+    with this shape. When set, labeled subdirectories are looked for under
+    `repo_root/tenant_subdir` instead of `repo_root` directly; nothing else
+    about the resolution table changes. Not generalized to more than one
+    fixed subdirectory name - no second project needs that yet.
+    """
+    cwd = Path(cwd)
+    repo_root = Path(repo_root)
+    reponame = dir_basename(repo_root)
+
+    if not multi_tenant:
+        if _too_deep(cwd, repo_root):
+            return _too_deep_resolution(cwd, repo_root)
+        if cwd != repo_root:
+            return Resolution(
+                tenant=None, project=None, refuse=True,
+                detail='{} is a single-tenant project; claude may only start '
+                       'at the project root {}, not a subdirectory'.format(
+                           reponame, repo_root))
+        tenant = _read_tenant_label(repo_root / TENANT_FILE)
+        if tenant is None:
+            return _undeclared_refusal(repo_root, reponame)
+        return Resolution(
+            tenant=tenant, project=reponame, refuse=False,
+            detail="single tenant '{}' declared at the root of {}".format(tenant, reponame))
+
+    # multi_tenant=True. The repo root is its own project (decided 2026-07-28:
+    # working on the repo itself - its tooling, skills, bootstrap scripts -
+    # isn't the same as working a specific engagement under it, and deserves
+    # its own tenant and isolated state). The tenant_subdir base (e.g.
+    # processes/ itself, when it differs from the root) never resolves -
+    # there is no single answer for "all engagements collectively" - and
+    # only its own immediate children are ever consulted beyond that.
+    if cwd == repo_root:
+        tenant = _read_tenant_label(repo_root / TENANT_FILE)
+        if tenant is None:
+            return _undeclared_refusal(repo_root, reponame)
+        return Resolution(
+            tenant=tenant, project=reponame, refuse=False,
+            detail="tenant '{}' declared at the root of {}".format(tenant, reponame))
+
+    tenant_base = (repo_root / tenant_subdir) if tenant_subdir else repo_root
+
+    if cwd == tenant_base:
+        if tenant_subdir:
+            detail = ('{} is a multi-tenant project; start claude in a labeled '
+                       'subdirectory under {}, not {} itself'.format(
+                           reponame, tenant_base, tenant_base))
+        else:
+            detail = ('{} is a multi-tenant project; start claude in a labeled '
+                       'subdirectory, not the repo root'.format(reponame))
+        return Resolution(tenant=None, project=None, refuse=True, detail=detail)
+
+    if cwd.parent != tenant_base:
+        return Resolution(
+            tenant=None, project=None, refuse=True,
+            detail='{} is not a direct subdirectory of {}; claude may only '
+                   'start in a labeled subdirectory there'.format(cwd, tenant_base))
+
+    tenant = _read_tenant_label(cwd / TENANT_FILE)
+    if tenant is None:
+        return _undeclared_refusal(cwd, reponame)
+    return Resolution(
+        tenant=tenant, project=dir_basename(cwd), refuse=False,
+        detail='resolved via {}/{}'.format(cwd, TENANT_FILE))
+
+
+def all_tenant_projects(repo_root, multi_tenant, tenant_subdir=''):
+    """Every (tenant, project) pair this repo could resolve to.
+
+    Gate A's (`dax run`) mount-scoping question: which
+    tenants/<tenant>/<project>/ subtrees must be mounted so that wherever a
+    user `cd`s to during the session (root or one level down - see module
+    docstring), Gate B's resolution has already been made available.
+    `tenant_subdir` mirrors `resolve_tenant`'s parameter of the same name.
+
+    Returns an empty set for anything undeclared - by the time this runs
+    (Gate A, before a container's mounts are computed), `dax run` should
+    already have led the user through declaring everything relevant via
+    `_ensure_tenants_classified`; an empty result here means that step was
+    skipped or bypassed, not that pooling into some default is the fallback.
+    """
+    repo_root = Path(repo_root)
+    reponame = dir_basename(repo_root)
+    root_tenant = _read_tenant_label(repo_root / TENANT_FILE)
+
+    if not multi_tenant:
+        if root_tenant is None:
+            return set()
+        return {(root_tenant, reponame)}
+
+    pairs = set()
+    if root_tenant:
+        pairs.add((root_tenant, reponame))
+
+    tenant_base = (repo_root / tenant_subdir) if tenant_subdir else repo_root
+    if tenant_base.is_dir():
+        for child in tenant_base.iterdir():
+            if not child.is_dir() or child.name in _NOT_A_PROJECT_SUBDIR:
+                continue
+            tenant = _read_tenant_label(child / TENANT_FILE)
+            if tenant:
+                pairs.add((tenant, dir_basename(child)))
+    return pairs
+
+
+def resolve_for_cwd(cwd, home, multi_tenant, project_name, tenant_subdir=''):
+    """Gate B entry point: resolve a tenant from a cwd inside a container.
+
+    `home` is the container's $HOME. `project_name` is the mount name Gate A
+    (`dax run`) actually used for this container's project (its
+    `workdir_name`, decision 2) - handed down explicitly, not inferred from
+    whatever cwd's top-level directory happens to be. That distinction
+    matters: `$HOME` legitimately has other directory-level mounts sitting
+    right alongside a project's own (`~/.claude`, `~/.augment`, `~/.aws`).
+    Without checking `project_name`, a user who `cd`s into one of those and
+    runs `claude` there would have it treated as if it were the project root
+    - undeclared, so it would refuse for the wrong reason instead of the
+    right one. Checking the expected name first closes that off before any
+    `.dax-tenant` lookup happens at all.
+    `tenant_subdir` mirrors `resolve_tenant`'s parameter of the same name.
+    """
+    cwd = Path(cwd).resolve()
+    home = Path(home).resolve()
+    try:
+        rel = cwd.relative_to(home)
+    except ValueError:
+        return Resolution(
+            tenant=None, project=None, refuse=True,
+            detail='{} is not inside {}'.format(cwd, home))
+    if not rel.parts:
+        return Resolution(
+            tenant=None, project=None, refuse=True,
+            detail='{} is $HOME itself, not inside a mounted project'.format(cwd))
+    if rel.parts[0] != project_name:
+        return Resolution(
+            tenant=None, project=None, refuse=True,
+            detail='{} is not inside the mounted project {}/{}'.format(
+                cwd, home, project_name))
+
+    repo_root = home / project_name
+    return resolve_tenant(cwd, repo_root, multi_tenant, tenant_subdir)

--- a/dax_creds/wrappers/claude
+++ b/dax_creds/wrappers/claude
@@ -5,6 +5,25 @@
 # Failures are reported, never swallowed. A silent failure here went unnoticed
 # for a month because auth was quietly riding a host bind mount instead.
 
+# Gate B of docs/design/2026-07-27-tenant-isolation.md: resolve cwd -> tenant
+# -> CLAUDE_CONFIG_DIR. DAX_TENANT_STATE is the master switch, set by `dax run`
+# (Gate A) only for projects that have opted into the claude_tenant_state
+# feature (not yet built - see design doc Sequencing step 6). Unset, none of
+# this runs and the wrapper behaves exactly as it does today - landing this
+# gate must not change behavior for any project that hasn't opted in, since
+# Gate A isn't mounting the per-tenant state trees this points at yet.
+if [ -n "$DAX_TENANT_STATE" ]; then
+    if ! _resolved=$(dax-creds resolve-tenant); then
+        # dax-creds already printed the refusal reason to stderr. Refusal
+        # means claude must not start at all - unlike a bad credential below,
+        # which still lets claude start degraded.
+        exit 1
+    fi
+    _tenant=$(printf '%s\n' "$_resolved" | sed -n 's/^TENANT=//p')
+    _project=$(printf '%s\n' "$_resolved" | sed -n 's/^PROJECT=//p')
+    export CLAUDE_CONFIG_DIR="$HOME/.local/state/dax/tenants/$_tenant/$_project"
+fi
+
 # Claude Code reads its state from CLAUDE_CONFIG_DIR when that is set and from
 # ~/.claude otherwise. The two layouts disagree about .claude.json: it lives
 # *inside* CLAUDE_CONFIG_DIR, but at ~/.claude.json — not ~/.claude/.claude.json
@@ -48,7 +67,12 @@ fi
 #
 # Only the onboarding flag is seeded. Folder trust is deliberately not set here:
 # accepting it silently activates .claude/settings.local.json permissions, which
-# is the user's call to make, not the wrapper's.
+# is the user's call to make, not the wrapper's. `theme` and `oauthAccount`/
+# `userID` (also listed in the design doc's seed-key table) were tried and
+# dropped: probing v2.1.220 showed the onboarding flag alone already reaches a
+# normal prompt with no theme picker, and oauthAccount/userID need real account
+# data nothing currently plumbs from the daemon/host into the wrapper — see
+# CLAUDE.md Backlog.
 if [ ! -e "$_dax_state_file" ]; then
     mkdir -p "$(dirname "$_dax_state_file")"
     ( umask 077; printf '%s' '{"hasCompletedOnboarding": true}' > "$_dax_state_file" )

--- a/dax_creds/wrappers/claude
+++ b/dax_creds/wrappers/claude
@@ -5,24 +5,17 @@
 # Failures are reported, never swallowed. A silent failure here went unnoticed
 # for a month because auth was quietly riding a host bind mount instead.
 
-# Gate B of docs/design/2026-07-27-tenant-isolation.md: resolve cwd -> tenant
-# -> CLAUDE_CONFIG_DIR. DAX_TENANT_STATE is the master switch, set by `dax run`
-# (Gate A) only for projects that have opted into the claude_tenant_state
-# feature (not yet built - see design doc Sequencing step 6). Unset, none of
-# this runs and the wrapper behaves exactly as it does today - landing this
-# gate must not change behavior for any project that hasn't opted in, since
-# Gate A isn't mounting the per-tenant state trees this points at yet.
-if [ -n "$DAX_TENANT_STATE" ]; then
-    if ! _resolved=$(dax-creds resolve-tenant); then
-        # dax-creds already printed the refusal reason to stderr. Refusal
-        # means claude must not start at all - unlike a bad credential below,
-        # which still lets claude start degraded.
-        exit 1
-    fi
-    _tenant=$(printf '%s\n' "$_resolved" | sed -n 's/^TENANT=//p')
-    _project=$(printf '%s\n' "$_resolved" | sed -n 's/^PROJECT=//p')
-    export CLAUDE_CONFIG_DIR="$HOME/.local/state/dax/tenants/$_tenant/$_project"
-fi
+# CLAUDE_CONFIG_DIR is set by `dax run` (decision B of
+# docs/design/2026-07-27-tenant-isolation.md) and simply honoured here. It used to
+# be computed in this script: Gate B resolved cwd -> tenant -> path via
+# `dax-creds resolve-tenant`, gated on DAX_TENANT_STATE. That went with the
+# multi-tenant model — one repo could hold several tenants, so the path depended
+# on where in the tree the user was standing. Each env is single-tenant now, so
+# the path is knowable before launch and belongs to whoever computes the mount.
+#
+# Consequence worth keeping in mind: a refusal can no longer happen here, because
+# there is nothing left to resolve. `dax run` refuses instead, before the
+# container starts, when an env opting into claude_tenant_state has no tenant.
 
 # Claude Code reads its state from CLAUDE_CONFIG_DIR when that is set and from
 # ~/.claude otherwise. The two layouts disagree about .claude.json: it lives

--- a/dax_creds/wrappers/claude
+++ b/dax_creds/wrappers/claude
@@ -90,4 +90,43 @@ if [ ! -e "$_dax_state_file" ]; then
     ( umask 077; printf '%s' '{"hasCompletedOnboarding": true}' > "$_dax_state_file" )
 fi
 
+# --- substrate gate + settings delivery (docs/design/VALIDATION.md) --------
+#
+# `--check` only, never a bare `wire.sh`: the self-heal already ran once at
+# container boot (dax-entrypoint.sh). Re-running it here would let a `claude`
+# restart silently repair wiring broken mid-session, defeating the Part 4
+# failure-mode tests, which restart a Claude session specifically *without*
+# restarting the container to prove the PreToolUse guard fires on its own.
+#
+# No SUBSTRATE_ROOT means this env never opted into the `substrate` feature —
+# identical behavior to before this gate existed.
+if [ -n "$SUBSTRATE_ROOT" ]; then
+    "$SUBSTRATE_ROOT/shared/wire.sh" --check
+    _substrate_rc=$?
+    case "$_substrate_rc" in
+        0)
+            _substrate_settings="$_dax_cfg_dir/substrate-settings.json"
+            # Never clobber a caller-supplied --settings.
+            case " $* " in
+                *' --settings '*) ;;
+                *)
+                    if [ -f "$_substrate_settings" ]; then
+                        set -- --settings "$_substrate_settings" "$@"
+                    fi
+                    ;;
+            esac
+            ;;
+        127)
+            echo "dax: substrate not mounted at $SUBSTRATE_ROOT — refusing to start claude" >&2
+            echo "dax: check the env's mounts (dax env show), then restart the container" >&2
+            exit 127
+            ;;
+        *)
+            echo "dax: substrate at $SUBSTRATE_ROOT is not correctly wired — refusing to start claude" >&2
+            echo "dax: run \`$SUBSTRATE_ROOT/shared/wire.sh\` from a container shell to repair" >&2
+            exit 1
+            ;;
+    esac
+fi
+
 exec "${DAX_CLAUDE_REAL:-/usr/bin/claude-real}" "$@"

--- a/dax_creds/wrappers/claude
+++ b/dax_creds/wrappers/claude
@@ -36,12 +36,31 @@ else
     _dax_state_file="$HOME/.claude.json"
 fi
 
-if [ -n "$DAX_CREDS_SOCK" ] && [ -n "$DAX_CREDS_CLAUDE" ]; then
+_dax_creds_file="$_dax_cfg_dir/.credentials.json"
+
+# Inject from Keychain only when the state tree has no credential yet. Claude
+# Code owns and refreshes this file from first launch onward; the daemon copy is
+# a *bootstrap*, not the running source of truth.
+#
+# Overwriting on every launch was harmless while ~/.claude was a shared mount
+# that Claude Code refreshed in place — the daemon snapshot and the file stayed
+# in step. Under a persistent per-tenant/project state tree they diverge: the
+# session refreshes the token into its own tree, nothing propagates back to
+# Keychain, and the next launch would clobber the good token with the stale
+# snapshot. If Anthropic rotates refresh tokens on use, that snapshot is already
+# dead, so every project would independently break on its second start.
+#
+# `-s` rather than `-e`: a zero-byte file left by an interrupted write counts as
+# no credential. To force a re-fetch, delete the file and relaunch.
+#
+# Teardown write-back to Keychain is deliberately not built yet — see decision C
+# of docs/design/2026-07-27-tenant-isolation.md.
+if [ -n "$DAX_CREDS_SOCK" ] && [ -n "$DAX_CREDS_CLAUDE" ] && [ ! -s "$_dax_creds_file" ]; then
     if _creds=$(dax-creds get "$DAX_CREDS_CLAUDE"); then
         case "$_creds" in
             *'"claudeAiOauth"'*)
                 mkdir -p "$_dax_cfg_dir"
-                ( umask 077; printf '%s' "$_creds" > "$_dax_cfg_dir/.credentials.json" )
+                ( umask 077; printf '%s' "$_creds" > "$_dax_creds_file" )
                 ;;
             *)
                 echo "dax: credential '$DAX_CREDS_CLAUDE' is not a Claude credentials blob" >&2

--- a/dax_creds/wrappers/dax-creds-open-url
+++ b/dax_creds/wrappers/dax-creds-open-url
@@ -1,2 +1,3 @@
 #!/bin/bash
+printf '%s\n' "$1" >> ~/.dax-debug/open-url.log
 exec dax-creds open-url "$1"

--- a/dax_creds/wrappers/entrypoint.sh
+++ b/dax_creds/wrappers/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Runs `wire.sh --quiet` once per container start, before the shell (or
+# whatever CMD-override a feature set) is exec'd. Deliberately here rather than
+# in the `claude` wrapper or a per-feature `_shell_cmd` string: wire.sh's
+# self-heal must be scoped to container-boot, not to every `claude` launch —
+# docs/design/VALIDATION.md's Part 4 failure-mode tests restart a Claude
+# session without restarting the container specifically to prove the
+# PreToolUse guard blocks a broken substrate, and re-running wire.sh on every
+# `claude` launch would silently repair the breakage before that guard could
+# be exercised. The `claude` wrapper only ever runs `wire.sh --check`.
+#
+# A complete no-op for envs without SUBSTRATE_ROOT set (every env not opted
+# into the `substrate` feature).
+#
+# Never exits on failure: VALIDATION.md Part 4.3 requires the container shell
+# to still start even when substrate wiring is broken, so repair is possible
+# from inside it.
+if [ -n "$SUBSTRATE_ROOT" ]; then
+    if [ -x "$SUBSTRATE_ROOT/shared/wire.sh" ]; then
+        "$SUBSTRATE_ROOT/shared/wire.sh" --quiet \
+            || echo "dax: wire.sh failed — substrate wiring is broken, repair from this shell" >&2
+    else
+        echo "dax: SUBSTRATE_ROOT=$SUBSTRATE_ROOT but shared/wire.sh is missing — is the mount up?" >&2
+    fi
+fi
+
+exec "$@"

--- a/docs/design/2026-07-27-tenant-isolation.md
+++ b/docs/design/2026-07-27-tenant-isolation.md
@@ -1,0 +1,591 @@
+# Tenant Isolation for Claude Code State
+
+**Status:** designed, not implemented
+**Date:** 2026-07-27
+**Motivation:** hygiene today; anticipated contractual obligation later; existing
+obligation to delete customer data when a relationship ends
+
+## Problem
+
+`~/.dax.yaml` sets `workdir.container: work`, so every project — whatever its host
+path — mounts at `/home/dfarrow/work` inside the container. Claude Code keys its
+per-project state on the *container* cwd. Every project therefore resolves to one
+identity: `-home-dfarrow-work`.
+
+Combined with `~/.claude` and `~/.claude.json` being bind-mounted read-write into
+every container, all projects for all customers share one pool of state.
+
+Observed on 2026-07-27:
+
+- `~/.claude/projects/-home-dfarrow-work/` held 31 session transcripts and 27
+  memory files spanning at least six distinct engagements — `dax`,
+  `project_ysecurity_comp_model`, `project_hydraulic_controls_it`,
+  `project_seans_new_gig_context`, `project_symlink_disclosure`,
+  `project_bedrock_decision`.
+- `~/.claude/history.jsonl` held 2066 prompt lines from all of them.
+- A session opened to discuss a git branch in the `dax` repo was preloaded with
+  another customer's candidate slate and a third party's compensation model. That
+  is the system working as designed, on a directory that describes six
+  engagements as one project.
+
+Nothing crosses at the model level. Concurrent sessions do not share a context
+window and there is no server-side state joining them. Every bleed path is
+on-disk state read at session start, which means the fix is entirely a
+filesystem and mount concern.
+
+### Partial isolation that already worked
+
+`projects/` also contained `-home-dfarrow-work-processes-augmentcode`,
+`-processes-self-employment-setup`, and `-processes-a-priest-and-an-imam`.
+Separate slugs, separate memory — because those sessions were started from a
+subdirectory. The `cd` convention adopted for ccusage attribution was
+incidentally the only working isolation mechanism in the system.
+
+## Verified findings
+
+Established by inspection on 2026-07-27, recorded because the design depends on
+them.
+
+**`CLAUDE_CONFIG_DIR` relocates the entire config root, including
+`~/.claude.json`.** Run with a fake `HOME` and `CLAUDE_CONFIG_DIR` set, Claude
+Code wrote `$CLAUDE_CONFIG_DIR/.claude.json` and
+`$CLAUDE_CONFIG_DIR/backups/`; the fake `HOME` received nothing. One environment
+variable is sufficient to relocate all state. Corollary: a shared `.claude.json`
+alongside per-tenant state trees is not achievable through this mechanism.
+
+**dax-creds' Claude injection is a no-op and has been since at least
+2026-06-27.** The wrapper at `/usr/bin/claude` writes
+`~/.claude/credentials.json`. Claude Code reads `~/.claude/.credentials.json`,
+with a leading dot. On disk: `.credentials.json` was 463 bytes of valid
+`claudeAiOauth` envelope; `credentials.json` was 108 bytes of invalid JSON,
+apparently a bare token. Two faults — wrong filename, wrong content shape.
+
+Consequence: container Claude auth currently rides the `~/.claude` bind mount,
+which is the mount this design removes. See Sequencing.
+
+**`~/.claude.json` is mounted separately** via `dotfiles.rw`, not via
+`claudedir`. It is rewritten wholesale and frequently — five 43K backups
+appeared in a twenty-minute window.
+
+**Multi-tenancy is already declared in the config.** `projects.discernment.creds`
+lists `gmail-personal`, `gmail-ysecurity`, and `gmail-augment`. The credential
+list broadcast the repo's multi-tenancy before it was stated.
+
+## Decisions
+
+### 1. Terminology: `tenant`
+
+Not `scope` — `.dax.yaml` already uses `scopes:` for OAuth scopes under
+`credentials`. Values are customer names plus `personal`.
+
+### 2. Mount the host repo at `~/<hostdirname>`
+
+Replaces `workdir.container: work`. Solves the ergonomic problem of not knowing
+which project a container is serving, and gives distinct Claude project
+identities as a side effect — which is what makes `--continue` and `/resume`
+safe to use again.
+
+### 3. State lives at `~/.local/state/dax/tenants/<tenant>/<project>/`
+
+Selected per session via `CLAUDE_CONFIG_DIR`. The tenant directory is the
+deletion boundary; the project directory beneath it is the isolation and
+concurrency unit.
+
+Deliberately not `~/.config/dax/`. What is stored is state, not configuration —
+transcripts, memory, history, paste cache — and it grows without bound.
+`~/.config` is also what dotfile managers and `dax backup` sweep, and customer
+transcripts landing in a synced repo is a bad interaction with a deletion
+obligation. `~/.config/dax/` remains available for genuine dax configuration.
+
+### 4. Tenant is the outer key, not project
+
+Deletion is the deciding constraint. Ending an engagement must be one verifiable
+operation on one tree, not a hunt across N project directories where correctness
+depends on remembering which projects belonged to whom.
+
+Per-project separation still happens automatically inside a tenant tree, via
+Claude Code's own cwd keying, at no cost.
+
+### 5. Cross-project recall within a tenant does not happen
+
+Memory stays keyed by cwd, so two repos for the same customer have separate
+memory directories. This is intended. The problem being solved is context
+arriving unbidden; re-introducing that within a tenant would recreate the same
+failure at smaller blast radius.
+
+This rule is why state is per tenant/project rather than per tenant. Arrow-up
+history is recall too, and a tenant-wide `history.jsonl` would have contradicted
+this decision — one customer project surfacing another's prompts.
+
+Where standing customer context is genuinely wanted, it belongs in a curated
+tenant-level `CLAUDE.md` — explicit and reviewable — not emergent recall.
+
+### 6. Two gates, only one of which refuses
+
+| | Gate A: `dax run` | Gate B: `claude` launch |
+| --- | --- | --- |
+| Where | host, container start | in container, `/usr/bin/claude` wrapper |
+| Sees | the repo | the **cwd** |
+| Job | mount repo at `~/<reponame>` | resolve cwd → tenant → `CLAUDE_CONFIG_DIR` |
+| Refuses | never | when resolution yields no tenant |
+
+Gate A always succeeds. A multi-tenant repo's root is a legitimate work
+directory — git, builds, and moving files between processes all need it.
+
+Gate B refusal is not a bolted-on check. The wrapper must resolve cwd → tenant
+regardless, because that is how it learns which `CLAUDE_CONFIG_DIR` to export.
+Refusal is the empty-resolution branch of work it performs anyway.
+
+### 7. Resolution table
+
+| Situation | Result |
+| --- | --- |
+| single-tenant repo | starts anywhere in tree |
+| multi-tenant repo, mapped subdir | starts, state → that tenant |
+| multi-tenant repo, root or unmapped subdir | refuse |
+| undeclared repo | `unattributed/<reponame>/`, warn, proceed |
+| project creds span multiple tenant labels | refuse regardless |
+
+Guiding principle: **fail toward over-isolation.** Where tenancy is ambiguous,
+pick the narrower tenant. Over-isolation costs convenience; under-isolation
+costs confidentiality. Those are not symmetric, and the 27-file pile is what
+under-isolation looks like after a few months.
+
+### 8. Undeclared repos go to `unattributed/<reponame>/`
+
+Not to a tenant derived from the repo name. Repo-name derivation partitions
+correctly — tested against `dax`, `fabric`, `iandidit`, and `ys-augmentcode`, it
+never merges two tenants, only over-isolates. But as an *identifier* it is a
+guess, and a tree labelled `ys-augmentcode` does not announce itself as
+unverified at deletion time. Confident-wrong is worse than visibly-unknown.
+
+`unattributed/<reponame>/` gives per-repo separation (nothing pools), does not
+block work, is enumerable via `dax tenants`, and makes later attribution a
+directory move rather than archaeology.
+
+### 9. Declaration: gitignored `.dax-tenant` per subdir
+
+One tenant name per file, with `.dax-tenant` in `.gitignore`.
+
+Chosen over a central map in `~/.dax.yaml`, which does not follow a subdirectory
+through a rename, and over a committed repo-root map, which would write the full
+customer roster into the history of the repo containing all of their work.
+
+Requires `dax tenant set <subdir> <tenant>`, and refusal messages that print
+that command with arguments filled in.
+
+Accepted cost: cloning a multi-tenant repo on a new machine leaves every subdir
+unlabelled until relabelled. Arguably correct — forced re-attribution is the
+right default when the point is knowing whose data is where.
+
+Accepted cost: the file puts a customer name in plaintext inside a subdirectory
+whose process name deliberately does not reveal one. It stays out of git
+history, but it is new plaintext on disk.
+
+### 10. Global `CLAUDE.md` stays global and general
+
+With an enforced rule that no project- or customer-specific content ever lands
+in it.
+
+The same rule extends to discernment's telos and process skills. That layer is a
+deliberate shared spine: every process subdir reads it, and working a customer's
+process refines it, so there is an intentional write path from a tenant-scoped
+session into material that reaches every other tenant. **The telos is a bleed
+channel by design.** Isolation is the wrong control there; hygiene rules are the
+right one.
+
+This discipline is already being practised by hand —
+`feedback_interview_grounding_discipline` and `feedback_billing_lumpiness` both
+generalised out of specific engagements with no customer detail retained. It is
+unenforced convention, not an enforced rule.
+
+### 11. Shared vs isolated
+
+Shared into every tenant: `plugins/`, `skills/`, `commands/`, update and
+experiment caches.
+
+Isolated per tenant/project: `projects/` (transcripts and memory),
+`history.jsonl`, `paste-cache/`, `file-history/`, `backups/`, `sessions/`,
+`session-env/`, `tasks/`, and `.claude.json`.
+
+History and paste cache are **persistent, not per dax session** — they survive
+container restarts — but they are scoped to the project, not shared across a
+tenant's projects. The requirement was durability across restarts, not sharing
+between projects; those are separable and only durability was wanted.
+
+Practical effect: arrow-up history contains only this project's prompts, and
+`/resume` lists only this project's sessions.
+
+Caveat on `skills/`: it is shared because skills are tooling rather than content.
+The moment a customer-specific skill is written, that stops being true, and rule
+10 must cover `skills/` too.
+
+### 12. Credential files are never mounted
+
+Credentials come from the dax-creds daemon. Requires the auth bug fixed first.
+
+## Accepted costs of per-tenant/project `.claude.json`
+
+Forced by finding 1 rather than chosen — `CLAUDE_CONFIG_DIR` relocates
+`.claude.json` along with everything else, so its granularity is whatever the
+config dir's granularity is. Every loss is re-consent or cosmetic friction on
+first launch in a new tenant/project; nothing functional is lost. The costs
+multiply by project rather than by tenant, which the seed template below is what
+makes tolerable.
+
+| Lost | Effect |
+| --- | --- |
+| `hasCompletedOnboarding`, `hasTrustDialogAccepted`, `hasClaudeMdExternalIncludesApproved` | dialogs re-run per tenant/project |
+| `tipsHistory` (40), `tipLifetimeShownCounts` (36), upsell counters, `lastReleaseNotesSeen` | tips and notices replay |
+| `cachedGrowthBookFeatures` (441 entries) | re-fetched per tree; slight first-run latency |
+| `numStartups` (113), `skillUsage`, `promptQueueUseCount` | counters fragment; beginner tips may reappear |
+| `enabledMcpjsonServers`, `claudeAiMcpEverConnected` | MCP approvals per tree — arguably correct |
+| `migrationVersion`, `opusProMigrationComplete` | may re-evaluate per tree; assumed idempotent, **unverified** |
+| `allowedTools` | fragments per tree |
+
+Mitigation, and it is load-bearing at this granularity: seed each new tree from a
+template `.claude.json` holding only UX, onboarding, and trust flags and no
+`projects{}` block. That reduces most of the above to zero. Without it, every new
+project starts with a round of dialogs.
+
+Gained: `exampleFiles` caches project filenames, so customer filenames never
+pool. Deletion takes the file with the tree. And no concurrent writers in the
+common case — see below.
+
+## Concurrency
+
+Per tenant/project, the ordinary case has **no contention at all**. Two
+containers working two projects for the same customer get two config dirs, so
+nothing is shared: not `.claude.json`, not `history.jsonl`, not the caches.
+
+Contention returns only when two containers run against the *same* project for
+the same tenant — two terminals on one repo. There:
+
+| State | Keyed by | Risk |
+| --- | --- | --- |
+| `projects/<slug>/*.jsonl` transcripts | session id | none |
+| `projects/<slug>/memory/` | filename per fact | last writer wins on the same file |
+| `paste-cache/`, `backups/` | per-item filenames | none |
+| `sessions/`, `session-env/`, `tasks/`, `file-history/` | per session id | none *(assumed, not verified)* |
+| `history.jsonl` | appended | interleaving; grpcfuse append atomicity unguaranteed, so torn lines possible |
+| `.claude.json` | single file, full rewrite | lost updates, last writer wins |
+
+That residual case is the one where sharing is *wanted* — same project, same
+work, so a shared history is a feature rather than a leak. The tradeoff lines up
+with the grain of the work instead of against it.
+
+`.claude.json` lost updates mean a permission granted in one session can be
+silently dropped when the other writes, and tip counters bounce. Annoying, not
+corrupting, recoverable by re-granting, with rolling backups as a floor.
+
+**Strictly better than the status quo**, which is every container across every
+tenant writing one `.claude.json` and one `history.jsonl`. This narrows the
+concurrent-writer set from "all containers" to "containers on the same project."
+The defect is pre-existing and upstream; its blast radius shrinks to near
+nothing.
+
+Also improved: `.claude.json` stops being a single-file grpcfuse bind mount and
+becomes a file inside a directory mount, which is the configuration where
+write-temp-plus-rename works. Single-file grpcfuse mounts are what break git's
+atomic rename on this setup.
+
+## Sequencing
+
+1. **Fix the dax-creds Claude wrapper** — correct filename `.credentials.json`
+   and the `{"claudeAiOauth": {...}}` envelope.
+2. **Verify auth works with `~/.claude` unmounted.** Non-negotiable before step 3.
+   Reversed, every container loses Claude simultaneously. Then keep watching for
+   several days — see the refresh-token rotation gap under Known limits. A pass
+   on day one does not clear that risk.
+3. Change `workdir.container` to the host directory basename.
+4. **Seed template for new trees.** A template `.claude.json` holding only UX,
+   onboarding, and trust flags — no `projects{}` block — copied into each tree on
+   first use. Must land before step 5, not after: at tenant/project granularity
+   every new project would otherwise open with a round of onboarding and trust
+   dialogs, which is the difference between the cutover being unnoticeable and
+   being irritating enough to abandon.
+5. Replace the wholesale `~/.claude` mount and the `~/.claude.json` dotfile mount
+   with per-tenant/project trees under `~/.local/state/dax/tenants/`, plus shared
+   mounts for `plugins/`, `skills/`, `commands/`. For a multi-tenant repo, mount
+   only `tenants/*/<project>/` — the repo's own subtree from each tenant the
+   subdir map references, never a whole tenant tree.
+6. Tenant resolution and refusal in the `claude` wrapper; `dax tenant set`;
+   `dax tenants` enumeration.
+7. Credential-span escalation check.
+
+## Verification log — paused 2026-07-27
+
+### Done
+
+Steps 1 and 2 of Sequencing, plus the code they require. All in the working tree,
+**uncommitted**.
+
+- `dax_creds/providers/claude.py` — `.credentials.json` default, legacy name as
+  import fallback, `is_oauth_envelope()` requiring a `refreshToken`, `store()`
+  refuses anything else.
+- `dax_creds/wrappers/claude` — writes `.credentials.json` under `umask 077`,
+  validates shape, reports failures on stderr instead of swallowing them, still
+  execs Claude so a bad credential cannot lock you out. `DAX_CLAUDE_REAL`
+  override added for testability.
+- `dax_creds/init.py` — corrected the path in the import message.
+- `tests/test_dax_creds_claude.py` — tests that exercise *defaults*, which is the
+  gap that let the original bug ship.
+- `tests/test_dax_creds_claude_wrapper.py` — new; the wrapper had no coverage.
+
+Added after the onboarding diagnosis below:
+
+- `dax_creds/wrappers/claude` — seeds `{"hasCompletedOnboarding": true}` into
+  `.claude.json` when absent, create-if-absent only, and now honours
+  `CLAUDE_CONFIG_DIR` for both the credential and the state file. Folder trust is
+  deliberately **not** seeded.
+- `tests/test_dax_creds_claude_wrapper.py` — 9 more tests covering the seed
+  (created, never overwritten, not overwritten when zero-byte, written even with
+  no credential configured, owner-only, no trust key) and the `CLAUDE_CONFIG_DIR`
+  layout split.
+- `tests/manual/interactive_launch_probe.py` — new; drives the interactive launch
+  path under a pty, which is the blind spot that made this bug hard to see.
+- 149 tests pass.
+
+Confirmed working in a container: the wrapper correctly rejected the 108-byte
+bare token with the expected message, and `dax creds remove` + `dax creds add`
+re-imported a full envelope from `~/.claude/.credentials.json` into Keychain.
+
+### Resolved 2026-07-27 — the login prompt was onboarding, not auth
+
+**Root cause: Claude Code's interactive first-run wizard is gated on
+`.claude.json`, and it runs *ahead of* the credential check.** With
+`~/.claude.json` unmounted, a launch shows the theme picker, then **"Select login
+method"**, then opens a browser — while a perfectly valid `.credentials.json` sits
+unread beside it. The credential was landing correctly the whole time.
+
+Reproduced deterministically: a config dir containing *only* a valid
+`.credentials.json`, launched interactively under a pty, walks theme picker →
+`Select login method` → `Opening browser to sign in…`. The same directory in
+headless `-p` mode authenticates and answers normally.
+
+**Why the earlier experiment ruled this out incorrectly.** `claude auth status`
+does not exercise the launch path — it reads the credential directly. So does
+`-p`. Both report `loggedIn: true` against a config dir that would prompt for
+login the moment it is started interactively. The prior test could not observe
+the failure mode it was aiming at. Any future gate on this must be an
+**interactive** launch.
+
+**Both prior hypotheses are disproven for this incident:**
+
+- *Refresh-token rotation* — no. `dax-creds get claude-fre` and the container's
+  `~/.claude/.credentials.json` hash identical on `accessToken`, `refreshToken`,
+  and `expiresAt`. Nothing rotated. (The rotation gap under Known limits remains
+  real and still unverified; it just was not what happened here.)
+- *Daemon cache serving the stale bare token* — no. The daemon returns a
+  well-formed `{"claudeAiOauth": {...}}` envelope with a `refreshToken`, and no
+  `dax:` error lines were produced.
+
+Also confirmed healthy during diagnosis, so none of these need re-testing:
+`DAX_CREDS_SOCK` and `DAX_CREDS_CLAUDE` are exported, the socket is live, the
+installed `/usr/bin/claude` is the fixed wrapper, and it wrote a valid
+dot-prefixed `.credentials.json` at container start.
+
+**Not a factor: dropping `claude` from `features`.** `feature_claude` (dax.py:119)
+only mounts `~/.claude`. The credential daemon wiring (dax.py:452-467) keys off
+the project's `creds` list and is independent of `features`. Removing the feature
+disables the mount without touching credential delivery — which is exactly what
+the mount change needs.
+
+### Consequence for the design: the wrapper must seed `.claude.json`
+
+Sequencing step 2 is not "stop mounting `~/.claude`". It is "stop mounting
+`~/.claude` **and** seed a minimal `.claude.json` into the per-tenant config
+dir" — otherwise every newly created tenant/project tree drops the user into
+onboarding and a browser OAuth round trip.
+
+One key is sufficient to suppress the login prompt:
+
+```json
+{"hasCompletedOnboarding": true}
+```
+
+Verified: with that plus `.credentials.json`, Claude boots to `Welcome back
+Dave!` and is authenticated. For a zero-prompt launch, seed:
+
+| Key | Effect if absent |
+| --- | --- |
+| `hasCompletedOnboarding` | theme picker, then **login prompt**, then browser OAuth |
+| `projects.<cwd>.hasTrustDialogAccepted` | trust dialog; `settings.local.json` permissions silently ignored |
+| `theme` | theme picker on first launch |
+| `oauthAccount`, `userID` | cosmetic only — banner omits org name; triggers a profile fetch |
+
+`oauthAccount` is **not** required for auth. It is copied host state, so whether
+to seed it is a tenant-isolation question in its own right: it carries
+`emailAddress`, `organizationName`, and `accountUuid` into every tenant tree.
+Since the account is the same across tenants either way, seeding it leaks nothing
+new — but it should be a deliberate choice, not a copy-everything default.
+
+The trust key is the one most likely to be missed. Its failure is silent: the
+session starts fine and simply ignores `.claude/settings.local.json` with a
+single line of warning text.
+
+#### Verified mechanics of the seed
+
+All observed against Claude Code **v2.1.220** — this is launch-flow behaviour and
+is not contractual, so re-check it after major version bumps.
+
+- **`CLAUDE_CONFIG_DIR` relocates `.claude.json` too.** It lands at
+  `$CLAUDE_CONFIG_DIR/.claude.json`, not `~/.claude.json`. One variable moves both
+  the credential and the config, which is what makes the per-tenant state tree in
+  decision 3 workable without additional plumbing.
+- **The seed must be create-if-absent, never rewritten.** A 33-byte seed becomes
+  ~32 KB and 23 top-level keys after a *single* run. Claude Code treats this file
+  as its own mutable state; a wrapper that rewrites it each launch would destroy
+  per-tenant history, permissions, and project entries on every start.
+- **`projects` is keyed by absolute path**, e.g. `/home/dfarrow/work`. Under
+  decision 2 the repo mounts at `~/<hostdirname>`, so the seeded trust key must be
+  built from that mount path and differs per project. A hardcoded path silently
+  produces the ignored-permissions warning.
+- **`oauthAccount` is fetched over the network if absent.** It appeared in the
+  file after one run without being seeded. Seeding it saves a profile fetch;
+  omitting it costs nothing but a round trip and the org name in the first banner.
+
+### Environment state
+
+`~/.dax.yaml` has been **restored** — `claude` is back in `features` and
+`~/.claude.json` back in `dotfiles.rw`. Note that the edits were made by
+commenting the lines out, but `dax creds add` rewrote the file via `yaml.dump`
+and deleted the comments outright (see Backlog in `CLAUDE.md`); the restore was
+by hand.
+
+Still present and worth deleting: `~/.claude/credentials.json` and
+`~/.claude/credentials.json-`, mode 644, containing a stale bare OAuth access
+token.
+
+### Resume procedure
+
+The gate is an **interactive** launch. `claude auth status` and `claude -p` both
+bypass onboarding and will report success against a config that prompts.
+
+The wrapper now seeds `.claude.json` itself, but **the installed image predates
+that change** (built 17:08). Pick a path before starting:
+
+- **Path A — no rebuild.** Seed by hand in the container. Validates that the
+  mechanism is right; does not exercise the wrapper's own seeding.
+- **Path B — rebuild first.** Exercises the real fix end-to-end. Preferred if a
+  rebuild is cheap, since Path A leaves the wrapper's seed path untested outside
+  of unit tests.
+
+Steps:
+
+1. Shut down **every** dax container — including the one this diagnosis ran in.
+   Any live session holding the `~/.claude` mount can refresh the shared
+   credential mid-test and reintroduce the confound the last attempt hit.
+2. Confirm Keychain is current: `dax-creds get claude-fre` should match the host
+   `~/.claude/.credentials.json`. Re-import only if it does not — and note that
+   `dax creds add` rewrites `~/.dax.yaml` and strips its comments.
+3. Path B only: rebuild the image so the seeding wrapper is installed.
+4. Start one container with `claude` absent from `features` and `~/.claude.json`
+   absent from `dotfiles.rw`. Configuring the mounts out is preferable to
+   deleting host files — it also puts the stale mode-644
+   `~/.claude/credentials.json` out of the container's reach without touching it.
+5. Path A only, **before** launching Claude:
+   `echo '{"hasCompletedOnboarding": true}' > ~/.claude.json`. The wrapper only
+   writes credentials when `claude` is invoked, so launching first means hitting
+   the wizard and backing out.
+6. Run `claude` **interactively**. Pass condition: it reaches the prompt showing
+   `Welcome back`, with no login method screen.
+
+`tests/manual/interactive_launch_probe.py` automates step 6's classification and
+can be run inside the container:
+
+```
+python3 tests/manual/interactive_launch_probe.py          # bare credential
+python3 tests/manual/interactive_launch_probe.py --seed   # with onboarding flag
+```
+
+It probes an isolated temp config dir rather than the live one, so it is safe to
+run against a working session; it reports `login`/`ready`/`onboarding`/`trust`
+and exits non-zero on a login prompt. Verified to produce FAIL without `--seed`
+and PASS with it.
+
+**Rotation remains untested.** It was never reached, because the run failed at
+onboarding before any refresh could occur. Verifying it needs a container left
+running across an `expiresAt` boundary with `~/.claude` unmounted, then a
+comparison of the container's refresh token against Keychain.
+
+## Deferred
+
+- **Migrating the existing pile** — 27 memory files and 31 transcripts to correct
+  tenants. Cheaper than it first appears: the naming convention already encodes
+  the split, with `feedback_*` and `user_*` as tenant-neutral spine material and
+  `project_*` as tenant-specific. Deferred, not skipped; it is deletion-readiness
+  debt that grows.
+- **Splitting multi-tenant repos.** Deleting a subdirectory does not remove it
+  from git history. Should deletion become contractual, multi-tenant repos are
+  what blocks an attestation, and the fix is per-tenant repos — submodules or
+  siblings — not anything in dax. Submodules give independent history with one
+  checkout at the cost of the usual friction; sibling repos give the same history
+  independence without it.
+- **Per-tenant permissions** beyond what per-tenant `.claude.json` provides
+  incidentally.
+- **Credential/tenant consistency check** as a warning: flag `tenant: personal`
+  sitting next to `gmail-ysecurity`. The data already exists.
+
+## Known limits
+
+**This isolates state, not filesystem reach.** In a multi-tenant repo the whole
+repo is mounted. Gate B controls where a session *starts*; it does not prevent an
+agent from reading a sibling tenant's subdirectory mid-session. Fixing that means
+per-tenant mounts or separate containers — a substantially larger change.
+
+**A multi-tenant repo's container necessarily holds more than one tenant's state
+tree.** Because the user moves between process subdirectories within one dax
+session, the container must have every tenant tree the subdir map references.
+Per-tenant/project granularity bounds this usefully: mount
+`tenants/ysecurity/discernment/` rather than `tenants/ysecurity/`, so the
+container sees only that tenant's *discernment* state and not their other
+projects. Narrower than per-tenant granularity would allow, but still more than
+one tenant per container.
+
+**Deletion of Claude state is not deletion of customer data.** The deletable
+surface also includes Keychain entries via dax-creds, host repository
+directories, `dax backup` output, and git history. A per-tenant state tree makes
+one part of that enumerable; it does not make the whole obligation
+self-executing.
+
+### Open gap: Claude refresh-token rotation
+
+Removing the shared `~/.claude` mount breaks the mechanism that currently keeps
+Claude credentials fresh, and nothing in this design replaces it.
+
+Today every container reads *and writes* the same
+`~/.claude/.credentials.json`. When Claude Code refreshes, the new credential is
+immediately visible to every other container and to the host. Observed
+2026-07-27: that file's mtime tracks recent activity, so in-place refresh is
+demonstrably happening.
+
+Under per-tenant/project state, that stops:
+
+1. The daemon hands out a **snapshot** of what is in Keychain.
+2. Each container refreshes into its own per-tenant `.credentials.json`.
+3. Nothing propagates back to Keychain.
+
+If the refresh token rotates on use, the Keychain copy dies at the first
+rotation and every subsequent container starts from a dead credential. **Whether
+Anthropic rotates Claude Code refresh tokens on use is unverified** — that is
+the crux, and it determines whether this is a latent break or a non-issue.
+
+Symptom to watch for: auth works immediately after cutover and fails days later
+across all containers at once.
+
+Two remedies, in preference order:
+
+- **Daemon-side refresh**, mirroring `GoogleTokenExchanger`, which already holds
+  a refresh token and exchanges it for access tokens for `gmail` and `drive`.
+  Requires Anthropic's token endpoint and client_id. This is the pattern the
+  codebase already establishes, and it keeps Keychain authoritative.
+- **A `dax-creds put` action** letting a container push a rotated credential back
+  to Keychain. Simpler, but inverts the trust direction — the container becomes a
+  writer of credential material rather than only a reader.
+
+Related smaller gap: there is no command to re-import an existing credential from
+disk. `dax creds add` prompts for the name, warns the credential already exists,
+and on overwrite re-runs `_define_credential`, so recovering a credential means
+re-answering the provider and browser prompts. A `dax creds import <name>` would
+be the natural home for both this and any rotation recovery.

--- a/docs/design/2026-07-27-tenant-isolation.md
+++ b/docs/design/2026-07-27-tenant-isolation.md
@@ -798,6 +798,9 @@ them" is loose: the flow stores a secret, it registers nothing.
 
 ### C7. `dax creds add` rebuilds the definition, dropping unprompted fields
 
+*Partly superseded by C8, which reorders the flow so a per-env name is never
+typed. The lossy rebuild still applies to explicitly named credentials.*
+
 Found by inspection 2026-07-30 while scoping the manual step 6.
 
 `_define_credential` starts from `{'provider': provider_name}` (`init.py:113`) and
@@ -823,6 +826,63 @@ reachable by accident while testing something else.
 All three `replace=` behaviors are unit-tested
 (`tests/test_dax_creds_init.py:281–320`), so the manual step was downgraded to
 optional rather than made safe.
+
+### C8. `dax creds add` asks the provider first and never asks for a per-env name
+
+Built 2026-07-30, replacing C7's confirmation-prompt idea with a reordering that
+makes the problem structural rather than something to warn about.
+
+The old flow asked for a **name** first, then the provider. Two consequences:
+
+- A per-env credential's name is dax's to build (C2), so asking for it invites
+  exactly the typo C2 exists to eliminate — a misspelled `claud-fre` sat unused
+  for weeks, silently, because a name nothing resolves to is never matched.
+- Typing a derived name converted it to an explicitly registered one, with no
+  "Overwrite it?" prompt (it has no registry entry to collide with), which
+  silently stopped it inheriting `credential_defaults` (C4).
+
+Provider first dissolves both: once the answer is a provider in
+`BARE_PROVIDER_CREDS`, dax knows the name is derived and never asks.
+
+The claude path is now:
+
+1. `Provider:` → `claude`
+2. `Env:` — the registry's envs, with the one containing cwd offered first
+   (`find_named_project_by_dir`, falling back to `find_enclosing_project`, so a
+   subdirectory resolves too)
+3. `tenant` **only if that env has none** — the one point where it genuinely is
+   not known, and where C2 refuses rather than falling back to a shared
+   credential. Asked here rather than earlier because tenant belongs to the env,
+   not the credential; everywhere else the registry already knows it, and a
+   separate prompt would let the answer disagree with the env.
+4. the derived name is printed, not requested
+5. offer to add the bare `claude` token to that env's `creds:` list when absent —
+   otherwise the credential would exist and go unused
+6. `credential_defaults.<provider>` is written **only if missing**, since browser
+   and profile belong to the human authenticating, not the env (C4)
+7. **no token is ever imported from disk.** `add` hands off to
+   `dax creds login <derived-name>`, offering to run it immediately
+
+Point 7 is the substantive change, and it is what closes the last route to a
+shared grant by construction rather than by refusal. C6 still refuses collisions
+at store time, but not offering the copy is better than rejecting it afterward.
+`_run_creds_add` returns `(config, pending_login)`; `cmd_creds` runs the login
+when the user accepts.
+
+Related fix in the same pass: every `_setup_*` now returns whether a usable
+secret ended up stored, so the flow stops printing `Credential "X" saved.` for a
+credential nothing was stored for. That message was not false — the YAML write
+did happen — but it answered a different question than the one being asked,
+which is whether the credential works now.
+
+**Still carrying the old shape: `dax init`'s inline creds loop** (`init.py`,
+~line 325) has its own copy of name → provider → define → setup, so a claude
+credential registered during `dax init` is still hand-named. It is safe rather
+than correct: `_setup_claude_credential` keeps C6's collision guard, so the worst
+case is a badly named credential, not a shared grant. Folding it into this flow
+belongs with the already-backlogged work to prompt for `tenant` during `dax init`.
+
+18 tests in `tests/test_dax_creds_add_flow.py`; suite at 385.
 
 ### D. Discernment becomes a sidecar, not a multi-tenant repo
 

--- a/docs/design/2026-07-27-tenant-isolation.md
+++ b/docs/design/2026-07-27-tenant-isolation.md
@@ -259,8 +259,25 @@ Per tenant/project, the ordinary case has **no contention at all**. Two
 containers working two projects for the same customer get two config dirs, so
 nothing is shared: not `.claude.json`, not `history.jsonl`, not the caches.
 
-Contention returns only when two containers run against the *same* project for
-the same tenant — two terminals on one repo. There:
+The "two containers on the same project" case this section originally analyzed
+**cannot happen under current dax behavior**, verified 2026-07-27. Container
+names are derived deterministically from the launch directory (`dax.py:75`,
+`envname` = cwd relative to `$HOME` with `/` → `-`) and passed explicitly as
+`docker run --name` (`dax.py:393-398`), with `--rm` and no collision handling
+anywhere in the file. A second `dax run` from the same project directory
+computes the same name and fails outright with Docker's "name already in use"
+error — it does not attach, reuse, or race the first container. So per-project
+state never actually has two containers writing to it concurrently; not a
+Docker mount restriction (plain bind mounts don't have one), a dax one.
+
+Residual, not currently in play: dax has no `attach`/`exec` subcommand — the
+only `docker exec` reference in the codebase is a debug hint for port
+forwarding, not a workflow. Manually running `docker exec -it <container> bash`
+against an already-running container would sidestep the naming guard entirely
+(same container, two shells) and reproduce the contention below. Worth knowing
+if that pattern ever gets adopted; not a reason to design against it today.
+
+Recorded for that hypothetical, since the analysis is already done:
 
 | State | Keyed by | Risk |
 | --- | --- | --- |
@@ -271,19 +288,16 @@ the same tenant — two terminals on one repo. There:
 | `history.jsonl` | appended | interleaving; grpcfuse append atomicity unguaranteed, so torn lines possible |
 | `.claude.json` | single file, full rewrite | lost updates, last writer wins |
 
-That residual case is the one where sharing is *wanted* — same project, same
-work, so a shared history is a feature rather than a leak. The tradeoff lines up
-with the grain of the work instead of against it.
-
 `.claude.json` lost updates mean a permission granted in one session can be
 silently dropped when the other writes, and tip counters bounce. Annoying, not
 corrupting, recoverable by re-granting, with rolling backups as a floor.
 
-**Strictly better than the status quo**, which is every container across every
-tenant writing one `.claude.json` and one `history.jsonl`. This narrows the
-concurrent-writer set from "all containers" to "containers on the same project."
-The defect is pre-existing and upstream; its blast radius shrinks to near
-nothing.
+**Strictly better than the status quo regardless**, which is every container
+across every tenant writing one shared `.claude.json` and one `history.jsonl`.
+Even in the residual `docker exec` case, this narrows the concurrent-writer set
+from "all containers, all tenants" to "two shells in one container on one
+project." The defect is pre-existing and upstream; its blast radius shrinks to
+near nothing.
 
 Also improved: `.claude.json` stops being a single-file grpcfuse bind mount and
 becomes a file inside a directory mount, which is the configuration where

--- a/docs/design/2026-07-27-tenant-isolation.md
+++ b/docs/design/2026-07-27-tenant-isolation.md
@@ -521,6 +521,55 @@ Note this was a regression being fixed, not just a new capability: `.claude.json
 has been discarded on every teardown since the step-2 diagnostic removed it from
 `dotfiles.rw` on 2026-07-27 (see Environment state).
 
+### B2. No `shared/` tree — mount the host's own directories, decided 2026-07-30
+
+Supersedes decision 11's shared-directory list and the "shared
+plugins/commands/cache migration" work item, which is **deleted rather than
+built**.
+
+`shared/` was never multi-tenant machinery, so abandoning multi-tenancy does not
+remove its rationale by itself: it solved "install once, use in every tree", and
+that multiplicity is *per project*, which survives the redesign intact — four
+envs means four trees. What changes is the membership, and then whether a copy
+step is warranted at all.
+
+Membership, checked against the real host directories rather than assumed:
+
+| Dir | Actual contents | Verdict |
+| --- | --- | --- |
+| `commands` | 132K, 11 commands in active use (`tdd.md`, `pr-review.md`, `refactor.md`, …), all mtime Feb 19 | **mount** — real user state, lost per project otherwise |
+| `plugins` | 6.3M, and *nothing installed*: only the official marketplace catalog, which Claude Code auto-installs itself (`officialMarketplaceAutoInstalled: true`, no `enabledPlugins` key, `lastUpdated` moving on its own) | **mount, weakly** — no state to preserve; avoids four independent catalog clones and refetches. Pure optimization |
+| `skills` | discernment's own skills (`Council`, `FirstPrinciples`, `discernment.md`, …) | **drop** — arrives via decision D's sidecar mount at `~/.claude/skills/`. A `shared/skills` would be a stale copy of the repo |
+| `cache` | 472K: a generic `changelog.md` plus a 2-byte `my-closed-issues.json` | **drop** — derived, generic, cheap to refetch, adds write contention, and is the only one of the four where fetched content can turn account-specific |
+
+The `plugins` finding inverts the original justification. "Install once" was the
+argument for sharing, and nothing is installed — so what would be shared is a
+self-healing catalog, not user state.
+
+**And with the list down to two, the copy step is not worth its cost.** The
+original plan was a one-time host-wide copy into
+`~/.local/state/dax/shared/{...}`, seeded on first use. Mounting the host's
+`~/.claude/commands` and `~/.claude/plugins` directly — nested inside the tree
+mount, which Docker orders by destination depth — achieves the same thing with no
+seeding code, one source of truth, and no divergence class where a command
+authored on the host is invisible in containers or vice versa. It is also
+*strictly less* container write access than today, narrowing a wholesale rw
+`~/.claude` mount to two subdirectories.
+
+Mounted **rw**: authoring a command inside a container and having it persist is
+worth more than insulating the host directory, which is already fully writable
+from every container today. Read-only remains a cheap change if that stops being
+true.
+
+Accepted cost: an env wanting a *different* command set — a customer container
+with none of the personal tooling — needs an opt-out. That is a per-env flag if it
+ever comes up, not a reason to maintain a copy.
+
+Retires decision 11's open caveat that `skills/` stops being shareable "the
+moment a customer-specific skill is written": D resolves it differently, with
+shared skills versioned in the discernment repo and project-specific ones in the
+project's own `.claude/skills/`.
+
 ### C. One credential per tenant/project, each from its own fresh login
 
 Credentials are named `claude-<tenant>-<project>`. Expect N Anthropic accounts

--- a/docs/design/2026-07-27-tenant-isolation.md
+++ b/docs/design/2026-07-27-tenant-isolation.md
@@ -1611,6 +1611,76 @@ Steps 5–8 not run: step 5 is moot (step 3 found no sharing to repair, and step
 effectively re-minted fabric), step 6 is pending, and steps 7–8 are gated on
 decision B, without which per-env credentials remain inert at runtime.
 
+### Confirmed 2026-07-31 — decision B steps 1-3 live on `fabric`
+
+Built and verified against the real env, in this order: the feature rewritten to
+mount at `~/.claude`, Gate B stripped from the wrapper, and `claude` /
+`claude_tenant_state` made mutually exclusive. Deletions (E) deliberately left
+until after this ran.
+
+`dax -t run` from `~/fatsec/fabric` emitted exactly the shape B specifies —
+`adding claude_tenant_state` rather than `adding claude`,
+`CLAUDE_CONFIG_DIR=/home/dfarrow/.claude`, the tree at
+`~/.local/state/dax/tenants/personal/fabric` mounted **at** `~/.claude`, the two
+host directories nested inside it, no wholesale `~/.claude` mount, and none of
+`DAX_TENANT_STATE`/`DAX_PROJECT_NAME`/`DAX_MULTI_TENANT`.
+
+**No image rebuild was needed, by design.** The image still carried a wrapper
+containing Gate B, which is gated on `DAX_TENANT_STATE` — so `dax run` not
+setting that variable leaves the old gate dormant and the handed-down
+`CLAUDE_CONFIG_DIR` honoured. Confirmed live: the credential landed in the tree,
+not at a `~/.local/state/dax/...` path computed in-container.
+
+**Persistence across teardown confirmed.** The container was destroyed and
+recreated and the session history survived — which is the whole point of B, and
+closes the regression it records: `.claude.json` had been discarded on every
+teardown since the step-2 diagnostic removed it from `dotfiles.rw` on 2026-07-27.
+
+Two things found on the way:
+
+- **The per-env feature opt-in was never wired up.** Features came only from the
+  global `features:` list, a `.dax.yaml` in cwd, and `-f`. An env's own
+  `features:` list — named by this doc, CLAUDE.md, and the feature's own docstring
+  as *the* way to switch `claude_tenant_state` on for one project — was read by
+  nothing. Fixed, with dedupe, since a duplicate emits the same mount twice and
+  Docker rejects it. `features` also became a `dax env set` field, validated
+  against the real feature list because a misspelled feature is silently ignored
+  at launch — the same failure mode a typo'd credential name had.
+- **Per-env features are additive only**, so an env cannot decline a globally
+  inherited feature. Switching one env therefore takes four writes. Deferred
+  fit-and-polish: let `claude_tenant_state` *supersede* an inherited `claude`
+  with a printed note, while still refusing when both are listed explicitly on
+  the same env. See CLAUDE.md Backlog.
+
+### An orphan grant was sitting in the state tree
+
+Found while pre-flighting the above, and it is the reason to keep the pre-flight
+step. `~/.local/state/dax/tenants/personal/fabric/.credentials.json` existed with
+an mtime of 2026-07-28, left by the multi-tenant testing. Its grant —
+`4e6854d7062f` — matched **none** of the four credentials in Keychain.
+
+Access token three days expired, refresh token valid until 2026-08-24. So
+inject-if-absent would have left it in place (correctly, by its own rule: the
+file was non-empty), Claude Code would have refreshed it, and `fabric` would have
+run indefinitely on a live OAuth grant that:
+
+- no Keychain entry backs, so nothing could re-bootstrap it if the file were lost
+- `DAX_CREDS_CLAUDE` does not name
+- `tests/manual/check_claude_grants.py` cannot see
+
+Removed; the wrapper then injected `56b0ef07fcbe` from Keychain, verified
+byte-identical to `dax-creds get claude-personal-fabric` inside the container.
+
+**Consequence — the grant audit has a blind spot.** `check_claude_grants.py`
+enumerates names derivable from `~/.dax.yaml` and reads Keychain. It never looks
+in the state trees, which under B is exactly where every env's working credential
+now lives. Two trees could hold the same grant, or an orphan grant could persist
+for months, and it would still report PASS. It should also scan
+`~/.local/state/dax/tenants/*/*/.credentials.json`, report each tree's grant, and
+flag any that match no Keychain entry or that duplicate another tree's — the same
+one-grant-per-name invariant (C6), applied where the credentials actually live.
+Not yet built.
+
 ## Deferred
 
 - **Migrating the existing pile** — 27 memory files and 31 transcripts to correct

--- a/docs/design/2026-07-27-tenant-isolation.md
+++ b/docs/design/2026-07-27-tenant-isolation.md
@@ -718,9 +718,10 @@ refusal prevented a harmless self-copy; the dangerous case is the disk holding a
 token before and after and never inspects whose grant it is — so this exercised
 the same code path with the same shape of input.
 
-### C6. The abandoned-login guard compares the file, not the grant
+### C6. Enforce one-grant-per-name at import time — built 2026-07-30
 
-Residual hole in C3, found by inspection 2026-07-30 while confirming the fix.
+Residual hole in C3, found by inspection 2026-07-30 while confirming the fix,
+and closed the same day.
 
 `_disk_token_for` returns the whole re-serialized envelope
 (`providers/claude.py:77`), so `after == before` answers "is the file
@@ -734,16 +735,47 @@ C3's silent-success signature.
 Requires a refresh inside a window of minutes, and access tokens live hours, so
 the probability is low but not negligible.
 
-The tighter form is to enforce the invariant directly rather than proxy it:
-before storing a Claude credential, hash its `refreshToken` and compare against
-every *other* stored Claude credential's. Refuse on collision. That is
-`tests/manual/check_claude_grants.py`'s logic applied at import time, which turns
-the manual script into a redundant safety net instead of the only detector.
-Comparing refresh tokens rather than whole envelopes would also close the
-access-token-refresh case on its own, though not a refresh that rotates the
-refresh token too.
+**What was built.** Rather than tightening the proxy, the invariant is now
+enforced directly: before storing a Claude credential, hash its `refreshToken`
+and compare against every *other* stored Claude credential. Refuse on collision.
+This is `tests/manual/check_claude_grants.py`'s logic applied at the moment of
+storing, which demotes the manual script from sole detector to redundant safety
+net.
 
-Unit tests cover the current guard (`tests/test_dax_cmd_creds_login.py`).
+- `grant_id(blob)` (`providers/claude.py`) — sha256 of the refresh token,
+  truncated. The blob carries no grant ID, so the refresh token stands in for
+  one; hashing means callers can report and log it without handling the secret.
+  None for anything that isn't a refreshable envelope.
+- `ClaudeProvider.grant_collision(name, token, candidates)` — the already-stored
+  credential this token would share a grant with, or None. Skips `name` itself,
+  since re-importing a credential's own token is a no-op rather than sharing —
+  and refusing it would block re-importing after a `dax creds remove`.
+- `credential_names_for_provider(config, provider)` (`config.py`) — registered
+  **and derived** names. Enumerating only the registry would have made the check
+  pass by seeing nothing, since the colliding name is normally derived.
+- `grant_collision_message()` — shared, so `login` and `add` explain the refusal
+  identically.
+
+Wired into **both** doors: `_post_login_import`'s claude branch (`dax.py`), and
+`_setup_claude_credential` (`init.py`), which never had the before/after guard at
+all and was the outstanding item under "Outstanding after this redesign". Its
+`config` parameter is optional, so callers without one still work and the check
+simply doesn't run.
+
+Deliberately claude-only. Sharing a grant is a problem because decision C makes
+per-env Claude credentials load-bearing for isolation; github/gmail/ssh are
+genuinely user-level, where one credential under one name is the intent.
+
+Where it is still inert: inside a container there is no Keychain to compare
+against, so `grant_collision` returns None. Nothing to check is not the same as
+a collision, so the import proceeds — but the enforcement is a host-side
+property, and the manual script remains the only way to audit sharing that
+already exists.
+
+20 tests in `tests/test_dax_claude_grant_collision.py`; suite at 367. Verified
+that `grant_id` on the live shared `~/.claude/.credentials.json` returns
+`56b0ef07fcbe`, matching what the manual script computed independently for
+`claude-personal-fabric`.
 
 **Side effect of any Claude login, worth knowing before running one:**
 `_LOGIN_PROVIDERS['claude']` mounts the host's `~/.claude` (`dax.py:644`), so the

--- a/docs/design/2026-07-27-tenant-isolation.md
+++ b/docs/design/2026-07-27-tenant-isolation.md
@@ -1,11 +1,22 @@
 # Tenant Isolation for Claude Code State
 
+> **⚠ SUBSTANTIALLY REVISED 2026-07-29 — read
+> "[Redesign 2026-07-29](#redesign-2026-07-29--multi-tenant-abandoned)" first.**
+> The multi-tenant model is abandoned. Decisions 4, 6 (Gate B), 7, 8, and 12
+> below are superseded in whole or in part, and the implemented code they
+> describe is slated for deletion. The decisions are left in place rather than
+> rewritten because the reasoning that produced them — especially decision 4's
+> deletion argument — is what the replacement had to answer, and a reader who
+> only sees the conclusion will re-derive the old model.
+
 **Status:** Sequencing steps 1–2 implemented and merged (PR #4, 2026-07-27);
 steps 3–6 implemented, unit-tested (259 tests), and confirmed on the two real
 target repos (2026-07-28) — see Verification log; step 7 dropped (see
-Sequencing). Outstanding before this is trusted as the default: the shared
-`plugins`/`skills`/`commands`/`cache` migration and the multi-day
-refresh-token rotation soak.
+Sequencing). **Superseded by the 2026-07-29 redesign:** multi-tenant support is
+being removed, and the outstanding work list is restated there. Still
+outstanding from the original list: the shared
+`plugins`/`skills`/`commands`/`cache` migration (reshaped — it becomes a nested
+mount) and the multi-day refresh-token rotation soak.
 **Date:** 2026-07-27
 **Motivation:** hygiene today; anticipated contractual obligation later; existing
 obligation to delete customer data when a relationship ends
@@ -104,6 +115,11 @@ obligation. `~/.config/dax/` remains available for genuine dax configuration.
 
 ### 4. Tenant is the outer key, not project
 
+> **Partly superseded (redesign A).** The conclusion survives — tenant is still
+> the outer directory, for exactly the deletion reason below. What changed is
+> that tenant is now a *declared grouping label* rather than something resolved
+> from a repo's structure.
+
 Deletion is the deciding constraint. Ending an engagement must be one verifiable
 operation on one tree, not a hunt across N project directories where correctness
 depends on remembering which projects belonged to whom.
@@ -126,6 +142,11 @@ Where standing customer context is genuinely wanted, it belongs in a curated
 tenant-level `CLAUDE.md` — explicit and reviewable — not emergent recall.
 
 ### 6. Two gates, only one of which refuses
+
+> **Partly superseded (redesign E).** Gate B is deleted: with one project per
+> container and a single state mount, there is nothing to mis-resolve and
+> nothing to refuse. Gate A survives, as does the separate "Gate 0" note below
+> about `dax run` from a subdirectory.
 
 | | Gate A: `dax run` | Gate B: `claude` launch |
 | --- | --- | --- |
@@ -176,6 +197,9 @@ already-running container, Gate B resolves it) never goes through `cmd_run`
 at all.
 
 ### 7. Resolution table
+
+> **Superseded (redesign A/E).** The table enumerates cwd→tenant outcomes that
+> no longer arise once a container holds exactly one project.
 
 **Revised 2026-07-28 — the `unattributed` fallback is gone.** See decision 8
 below for why, and Sequencing step 6 for the classification mechanism that
@@ -291,6 +315,10 @@ one fixed subdirectory name — there is exactly one project shaped like this
 today, and YAGNI argues against building for a second that may never exist.
 
 ### 8. Undeclared locations are classified before launch, never pooled
+
+> **Superseded (redesign A/E).** Interactive classification existed to resolve
+> undeclared subdirectories inside a multi-tenant repo. With one project per
+> repo there are none, and this machinery is slated for deletion.
 
 **Superseded 2026-07-28.** The original design routed anything undeclared to
 `unattributed/<reponame>/` — a real tenant slot, warn, proceed. Rejected once
@@ -421,6 +449,539 @@ The moment a customer-specific skill is written, that stops being true, and rule
 ### 12. Credential files are never mounted
 
 Credentials come from the dax-creds daemon. Requires the auth bug fixed first.
+
+> **Wording superseded (redesign C).** Still true that no *host* credential file
+> is bind-mounted in. But the credential now lives on host disk for the
+> session's duration, as `.credentials.json` inside the bind-mounted state tree,
+> written there by the wrapper on first launch and thereafter owned and
+> refreshed by Claude Code. The intended end state removes it on teardown; that
+> write-back is not built yet.
+
+## Redesign 2026-07-29 — multi-tenant abandoned
+
+**Provenance:** the conversation in which the decision to abandon multi-tenant
+was originally reached is **lost**. The Anthropic outage of 2026-07-28/29 left
+sessions hanging; they were killed, and neither `~/.claude/projects/` nor
+`history.jsonl` contains anything between 2026-07-27 18:55 and 2026-07-29
+21:14 — the entire two days that produced commit `4c8fb6c`. The decisions below
+were reconstructed from scratch on 2026-07-29 by walking the open questions one
+at a time. **That loss is the reason this section exists and the reason the
+memory directory is now populated.** Write decisions down when they are made.
+
+### A. Multi-tenant is abandoned; `tenant` survives only as a grouping label
+
+The only multi-tenant repo was discernment. It is being reworked so that each
+process becomes its own repository (see D), which removes the sole justification
+for the model. With one project per repo, tenant resolution becomes trivial.
+
+`tenant` is **not** dropped, because decision 4's argument still holds for
+*grouping* even though it no longer holds for *resolution*: a customer with two
+repos still needs "end the engagement" to be one operation. So:
+
+- `tenant:` becomes a declared field on the project's `~/.dax.yaml` entry. One
+  value, no inference.
+- State stays at `~/.local/state/dax/tenants/<tenant>/<project>/`, keeping
+  tenant as the outer directory so `rm -rf .../tenants/<tenant>/` remains a
+  complete deletion for that customer's Claude state.
+- `.dax-tenant` files go away entirely. They labelled subdirectories inside a
+  multi-tenant repo; there are none.
+
+### B. The state tree mounts at `~/.claude`, and `CLAUDE_CONFIG_DIR` is a constant
+
+```
+host:       ~/.local/state/dax/tenants/<tenant>/<project>/
+container:  ~/.claude
+env:        CLAUDE_CONFIG_DIR=$HOME/.claude
+```
+
+The variable is kept **only** because of finding 1 (`CLAUDE_CONFIG_DIR`
+relocates `.claude.json` too). It is no longer a selector — no cwd resolution,
+no per-session computation — just a constant `dax run` sets.
+
+Dropping it entirely was considered and rejected. Unset, Claude Code reads
+`~/.claude.json`, a *sibling* of `~/.claude` rather than a child, so the file
+falls outside the tree mount: container-local, discarded on teardown, taking
+per-project trust, permissions, and the `projects{}` block with it. The symptom
+is the first-run wizard reappearing, not an error. Two workarounds were
+rejected:
+
+- **Single-file bind mount** of `.claude.json` — reintroduces exactly what this
+  design was pleased to escape (see the end of Concurrency): single-file
+  grpcfuse mounts are where write-temp-plus-rename breaks.
+- **Symlink** `~/.claude.json` → `~/.claude/.claude.json` — fails silently.
+  Claude Code writes temp-then-rename; the rename *replaces the symlink* with a
+  regular file and state quietly stops persisting.
+
+Accepted cost: the "Accepted costs" table below applies per project. The seed
+template mitigates most of it, but the wrapper currently seeds only
+`hasCompletedOnboarding` — folder trust is deliberately not seeded — so expect a
+trust dialog and replayed tips on each project's first launch.
+
+Note this was a regression being fixed, not just a new capability: `.claude.json`
+has been discarded on every teardown since the step-2 diagnostic removed it from
+`dotfiles.rw` on 2026-07-27 (see Environment state).
+
+### C. One credential per tenant/project, each from its own fresh login
+
+Credentials are named `claude-<tenant>-<project>`. Expect N Anthropic accounts
+under M Keychain entries, where N is usually 1.
+
+**Each entry must be minted by its own login flow.** This is load-bearing, not
+incidental. Independent authorization grants have independent refresh-token
+chains, so rotation in one project cannot invalidate another's credential — even
+when every entry authenticates the same account. If a second project's entry is
+instead created by *copying* an existing credential blob, the two share one
+grant and the first rotation kills the other.
+
+That copy path is live in the code today: both `_setup_claude_credential`
+(`init.py`) and `_post_login_import` (`dax.py`) call
+`ClaudeProvider.import_from_disk()`. Minting a per-project credential must not
+go through it.
+
+Intended lifecycle, once teardown is built:
+
+```
+dax run   → inject from Keychain into the project's state tree, if absent
+session   → Claude Code owns the file and refreshes it in place
+teardown  → write the current file back to Keychain, remove it from disk
+```
+
+**Implemented as of 2026-07-29: inject-if-absent only.** The wrapper previously
+overwrote `.credentials.json` from the Keychain snapshot on *every* launch,
+which under a persistent state tree would clobber a refreshed token with a stale
+one on the next start — turning the rotation gap from "one shared copy might go
+stale" into "every project independently walks into it." Create-if-absent lets
+Claude Code own rotation from first launch onward and makes Keychain a
+*bootstrap* rather than the running source of truth.
+
+Teardown write-back is deliberately **not** built yet, and the gap is accepted:
+a `kill -9`, host reboot, or Docker Desktop crash skips it, leaving the
+refreshed credential in the tree and a stale one in Keychain. Because injection
+is now create-if-absent, that stale copy is never forced back over the good one
+— the tree's file simply persists and continues to work. A later sweep can
+hoover up or re-import stray files.
+
+Residual unknown, unchanged: whether Anthropic caps concurrent grants per
+account or invalidates older grants for the same `client_id`. Cheap to test —
+log in for two projects, use the first, confirm the second still works.
+
+### C2. The per-env credential name is derived, not typed — built 2026-07-30
+
+Listing a bare provider name in an env's `creds:` asks dax to build the name:
+
+```yaml
+projects:
+  fabric:
+    tenant: personal
+    creds: [claude, github-dbfarrow, ssh-id-rsa]   # -> claude-personal-fabric
+```
+
+`BARE_PROVIDER_CREDS` (`dax_creds/config.py`) holds the providers this applies
+to, and contains **only claude**: its credentials are per tenant/project by
+decision C, while github/gmail/ssh are genuinely user-level, so naming those
+explicitly stays correct.
+
+Rationale: decision C makes correct naming load-bearing for isolation, and a
+hand-maintained convention is one users typo. A real `claud-fre` entry sat
+unused in `~/.dax.yaml` for weeks — silently, because a misspelled credential
+is simply never matched.
+
+- **An explicit name always wins**, keeping existing configs working and
+  leaving an escape hatch for deliberately sharing one credential across two
+  envs.
+- **A bare token with no `tenant` is refused**, and `cmd_run` exits. Falling
+  back to a shared credential would be the exact isolation failure the
+  convention exists to prevent, so this fails loudly. It also makes declaring
+  `tenant` load-bearing rather than optional.
+- **Unregistered derived names are synthesized in memory**, not written to
+  `~/.dax.yaml`. Resolution stays a pure read; the caller reports the
+  credential missing from Keychain and offers the login that registers it.
+- `dax env show` prints the resolved name, so the convention is visible rather
+  than magic.
+- `find_named_project_by_dir()` is new — returning `(name, project)` — because
+  a derived name needs the registry name, which `find_project_by_dir` discarded.
+
+Ambiguity to guard: a credential named literally `claude` would collide with
+the bare token. Not yet blocked in `dax creds add`.
+
+### C3. An abandoned login must not import the credential already on disk
+
+**Found in live testing 2026-07-30, and it is the sharing failure C exists to
+prevent — presenting as success.**
+
+`dax creds login claude-personal-discernment` was cancelled at the browser step
+(it opened the wrong Chrome profile — see C4). `_post_login_import` nevertheless
+ran, because `cmd_creds_login` called it unconditionally after
+`subprocess.run()` with no check that the flow succeeded. Its claude branch
+reads `~/.claude/.credentials.json` — which, with `claude` back in `features`,
+holds the *existing shared* credential. That token was stored under the new
+per-env name.
+
+The result authenticates perfectly, which is exactly the problem: two Keychain
+entries backed by one OAuth grant, no isolation, and a rotation on either kills
+both. Nothing in the output suggested anything had gone wrong.
+
+Fix: snapshot what the provider's on-disk location holds *before* launching the
+flow, compare after, and refuse to import when unchanged. Provider-agnostic —
+`_disk_token_for()` covers github, claude, and auggie, all of which import from
+disk and had the same hole. A real login always replaces the file, so a
+before/after match means the flow wrote nothing.
+
+Corollary fixed in the same pass: a derived credential could not be *removed*.
+`dax creds remove` rejected it as unknown, since it has no `credentials:` entry,
+leaving no way to clear a bad one. It now clears the Keychain secret, writes no
+config, and reports that the env will be offered a fresh login next run —
+exempt from the still-referenced refusal, because for a derived name the
+reference is the convention, which survives removal and simply re-mints.
+
+### C4. Derived credentials inherit browser settings from `credential_defaults`
+
+Also found in the same test: the login opened the wrong browser. A derived
+credential is synthesized as `{'provider': ...}` and has no entry to carry
+`browser`/`chrome_profile`, so every per-env login fell back to the default
+browser rather than the Chrome profile the account lives in.
+
+```yaml
+credential_defaults:
+  claude:
+    browser: chrome
+    chrome_profile: Profile 2
+```
+
+Merged into every synthesized definition. This is the right shape rather than a
+patch: browser and profile are properties of the human authenticating, not of
+the env, so one setting covering all derived Claude credentials is correct.
+Defaults never override `provider`, and an explicitly registered credential
+ignores them entirely.
+
+Related fix: `dax creds list` omitted derived credentials, so the host
+disagreed with `dax-creds list` inside the container about which credentials
+exist. It now unions the registry with `derived_credentials()` and tags them
+`(derived)`. The "used by" column was matching names literally, so an env
+listing a bare `claude` matched nothing — `credential_users()` resolves now,
+which also correctly shows a superseded explicit credential as unused.
+
+### C5. `dax creds login` refuses derived names — found 2026-07-30, step 4
+
+**Blocking, and it means no sanctioned way to mint a per-env Claude credential
+currently exists.**
+
+`dax creds login claude-personal-fabric` answers `Unknown credential` while
+`dax creds list` displays that same name as `(derived)`, `stored: yes`.
+`cmd_creds_login` (`dax.py:698`) resolves against `config['credentials']` only.
+`derived_credentials()` was wired into `creds list` (`init.py:434`), `creds
+remove` (`init.py:741`), and `env show` (`init.py:591`) in the C2/C3/C4 pass —
+login was missed.
+
+Consequence: `login` refuses derived names, and `add`'s claude path is the
+unguarded one C3 warns against, so **neither door works**. C3's guard is
+unreachable for the case it was written for, and C2's promise that the caller
+"offers the login that registers it" leads to a command that fails.
+
+Fix (small — C4 comes free, since `derived_credentials()` builds definitions
+through `synthesized_credential()`, which already merges `credential_defaults`):
+
+```python
+cred_def = config.get('credentials', {}).get(cred_name)
+if cred_def is None:
+    from dax_creds.config import derived_credentials
+    cred_def = derived_credentials(config).get(cred_name)
+if cred_def is None:
+    raise KeyError(cred_name)
+```
+
+How the three existing derived secrets came to exist, by inference: they were
+minted while those names were still *explicitly* registered in `credentials:`,
+and C2's migration to bare `claude` tokens dropped those entries — Keychain
+secrets are keyed by name and survived. Consistent with C3's record of a
+`claude-personal-discernment` login opening a browser on 2026-07-30, and with
+step 3's staggered mint dates. `backup/.dax.yaml`'s git history can't confirm
+it: only one version exists and it predates per-env credentials.
+
+**Fixed and confirmed live 2026-07-30.** `_login_credential_def()` now resolves
+registered-then-derived, and `cmd_creds_login` calls it; 5 tests added, suite at
+347. `dax creds login claude-personal-fabric` launched for real: Chrome on
+Profile 2 (C4, reachable for a derived name for the first time), the device-flow
+`redirect_uri` rewritten to `platform.claude.com/oauth/code/callback` (so
+`_force_claude_device_flow_redirect` works), and a token imported to Keychain.
+The grant hash changed `49a03025bda2` → `56b0ef07fcbe`, which is **direct**
+proof the flow minted a new grant rather than copying an existing one — a copy
+would have shown dax's or discernment's hash. Step 3 re-run: still PASS, 4
+distinct grants.
+
+**C3's refusal path confirmed live 2026-07-30**, on a second run cancelled at
+the paste-code prompt: the refusal printed, and Keychain was untouched
+(`claude-personal-fabric` still `56b0ef07fcbe`, unchanged from the completed
+login). Note the disk happened to hold fabric's *own* grant at the time, so the
+refusal prevented a harmless self-copy; the dangerous case is the disk holding a
+*different* env's grant. The guard is name-agnostic — it compares the on-disk
+token before and after and never inspects whose grant it is — so this exercised
+the same code path with the same shape of input.
+
+### C6. The abandoned-login guard compares the file, not the grant
+
+Residual hole in C3, found by inspection 2026-07-30 while confirming the fix.
+
+`_disk_token_for` returns the whole re-serialized envelope
+(`providers/claude.py:77`), so `after == before` answers "is the file
+byte-identical", not "is this the same OAuth grant". Under `feature_claude`'s
+shared `~/.claude` mount, a container running Claude Code can refresh
+`.credentials.json` *during* the login window. An abandoned login then sees a
+changed file, concludes the flow wrote it, and imports another env's refreshed
+token under the new name — C3's failure again, through a narrower door, and with
+C3's silent-success signature.
+
+Requires a refresh inside a window of minutes, and access tokens live hours, so
+the probability is low but not negligible.
+
+The tighter form is to enforce the invariant directly rather than proxy it:
+before storing a Claude credential, hash its `refreshToken` and compare against
+every *other* stored Claude credential's. Refuse on collision. That is
+`tests/manual/check_claude_grants.py`'s logic applied at import time, which turns
+the manual script into a redundant safety net instead of the only detector.
+Comparing refresh tokens rather than whole envelopes would also close the
+access-token-refresh case on its own, though not a refresh that rotates the
+refresh token too.
+
+Unit tests cover the current guard (`tests/test_dax_cmd_creds_login.py`).
+
+**Side effect of any Claude login, worth knowing before running one:**
+`_LOGIN_PROVIDERS['claude']` mounts the host's `~/.claude` (`dax.py:644`), so the
+flow writes its new credential into the **shared** `.credentials.json`. The
+verification script's "matches" line moved from `claude-personal-dax` to
+`claude-personal-fabric` accordingly. While `feature_claude`'s wholesale mount is
+still in play, that repoints *every* container — inject-if-absent skips a
+non-empty file, so each one authenticates on whichever env logged in last,
+regardless of its own `DAX_CREDS_CLAUDE`. Logging in for one env silently
+changes the grant every other env runs on. It is also exactly why C3's
+before/after guard functions: the flow writes to the same file the guard
+snapshots.
+
+Corollary sharpening the step-2 presentation finding: `_post_login_import`
+stores to Keychain and never writes a `credentials:` entry, so a derived name
+stays derived **permanently**. `env show`'s `[not registered yet]` will therefore
+never stop saying "yet" no matter how many successful logins run — the label is
+wrong, not merely ambiguous. And C2's phrase "the login flow is what registers
+them" is loose: the flow stores a secret, it registers nothing.
+
+### C7. `dax creds add` rebuilds the definition, dropping unprompted fields
+
+Found by inspection 2026-07-30 while scoping the manual step 6.
+
+`_define_credential` starts from `{'provider': provider_name}` (`init.py:113`) and
+`_run_creds_add` assigns the result wholesale (`init.py:369`), so re-running
+`dax creds add` on an existing credential **silently drops every field its prompts
+do not ask for**. `dax creds update` is the non-lossy path for metadata.
+
+This makes the "Overwrite it?" confirmation misleading in a second, opposite
+direction from the bug fixed on 2026-07-30: the *definition* is always
+overwritten by reconstruction, whether or not the user is thinking about it,
+while the *secret* was the thing that used to survive.
+
+Consequence for testing the `replace=` plumbing live: the safe-looking target is
+the wrong one. `github-dbfarrow` rebuilds losslessly but, having no `client_id`,
+exits at "skipped" before `_report_no_token` runs, so it never demonstrates the
+message. `gmail-personal` does reach it but requires retyping `client_id`,
+`client_secret`, and `scopes` exactly. `claude-fre` rebuilds cleanly and must
+*not* be used at all: claude's replace path calls `import_from_disk`, which would
+copy the shared `~/.claude/.credentials.json` under that name and manufacture the
+very shared grant C3 exists to prevent — the still-open `dax creds add` gap,
+reachable by accident while testing something else.
+
+All three `replace=` behaviors are unit-tested
+(`tests/test_dax_creds_init.py:281–320`), so the manual step was downgraded to
+optional rather than made safe.
+
+### D. Discernment becomes a sidecar, not a multi-tenant repo
+
+Discernment exists to give a set of processes a shared spine of context (telos)
+and skills. Reworked shape:
+
+- Each process moves to **its own repository**, with **history split, not
+  `git mv`** — deleting a directory does not remove it from git history, and a
+  wholesale sidecar mount would otherwise put every customer's historical
+  process data in every other customer's container. Out of scope for dax; the
+  combined repo is to be distributed into per-process repos and then deleted.
+- Discernment mounts **wholesale** at `~/discernment` (rw), a sibling of the
+  process repo at `~/<processname>`. Any process session can update telos and
+  skills directly.
+- Its `skills/` mounts a **second time** at `~/.claude/skills/` (rw, same host
+  directory). This is required: Claude Code discovers skills by scanning
+  `~/.claude/skills/`, project `.claude/skills/`, and plugins. A CLAUDE.md
+  *pointing* at `~/discernment/skills/` registers nothing — the files would be
+  readable as prose but not invokable, losing progressive disclosure. Edits
+  through either path land in the same working tree.
+- Telos lives as **repo files** and is reached from each process's CLAUDE.md by
+  `@`-import, not by prose reference. Prose is advisory and may not be acted on;
+  `@`-imports are inlined at load.
+- Memory stays per-project and isolated. `feedback_*`/`user_*` spine material
+  belongs in the discernment repo as telos; `project_*` stays with its process
+  and dies with it. Some existing process memory is lost in the move —
+  acceptable, possibly worth a migration pass.
+
+Decision 10 already anticipated this: *"The telos is a bleed channel by design.
+Isolation is the wrong control there; hygiene rules are the right one."* The
+sidecar is the mechanism decision 10 assumed but never built.
+
+Concurrency: the sidecar is rw in every process container, so two process
+sessions can write telos concurrently — dax's container-naming guard does not
+help, since these are different projects. Accepted. It is strictly better than
+the status quo, which is multiple Claude instances inside *one* container
+writing the same discernment artifacts.
+
+### E. What gets deleted
+
+Delete: `_ensure_tenants_classified()`, `_prompt_tenant()`, `dax tenant
+classify`, `dax tenant set`'s `.dax-tenant` writing, `.dax-tenant` files,
+`DAX_MULTI_TENANT`/`DAX_TENANT_SUBDIR`, `multi_tenant`/`tenant_subdir` registry
+fields, `resolve_for_cwd()`, `dax-creds resolve-tenant`, and **Gate B in the
+`claude` wrapper**. Gate B's refusal existed to stop a session starting
+somewhere that would pool state; with one project per container and one mount,
+there is nothing to mis-resolve and nothing to refuse.
+
+Keep: `find_enclosing_project()` and Gate 0 — not tenant machinery; it stops
+`dax run` from a subdirectory silently auto-registering a new project, which is
+an independent bug. `dax tenants` stays as a flat enumeration.
+`all_tenant_projects()` collapses to reading the registry.
+
+Roughly 68 tests across `test_dax_creds_tenant.py` and `test_dax_tenant_cmds.py`
+go with the deletions.
+
+### F. `claude_tenant_state` stays opt-in for now
+
+Not flipped to default-on. The 2026-07-28/29 outage forced a fallback to the old
+shared-mount model to get a session running at all, and that escape hatch is
+worth keeping until the new path has been exercised. Also still gated on the
+shared `plugins`/`commands` migration, without which an opting-in project loses
+access to already-installed plugins.
+
+### G. `tenant` is set through `dax env set`, not `dax tenant set`
+
+**Revised 2026-07-30.** The original plan routed tenant-setting through
+`dax init` plus a surviving `dax tenant set`. Both parts changed once the
+command surface was looked at directly:
+
+- **`dax init` is the wrong tool for changing one field.** `_run_init` does
+  detect an existing project and offer "Update it?", but then walks image →
+  credential checkbox → new-credential loop before reaching anything else. That
+  is a lot of confirmation for a one-string edit, and every pass is a chance to
+  disturb something unrelated. A tenant prompt still belongs in `init` for
+  *registration*; it is not the path for *editing*.
+- **`dax tenant set` is retired rather than repointed.** It wrote `.dax-tenant`
+  files, which no longer exist. Reusing the name for a different mechanism would
+  preserve nothing but muscle memory.
+
+**Built 2026-07-30** — singular `env` acts on one environment, matching the
+existing `tenant`/`tenants` singular/plural split:
+
+- `dax env show [name]` — full registry entry, plus the resolved container name
+  and running state, the state-tree path and whether it exists, and a warning
+  when the entry still carries deprecated `multi_tenant`/`tenant_subdir` keys.
+- `dax env set [name] <field> <value>` — one field, no wizard. Fields are
+  `tenant`, `dir`, `image`, `creds` (comma-separated, replaces the list, and
+  validated against `~/.dax.yaml`'s `credentials` before writing). `--help`
+  lists every field with a description, and an unknown field error reprints the
+  same table.
+
+`name` is optional in both and defaults to the env containing the cwd, falling
+back to the *enclosing* project so it also works from a subdirectory — where
+`dax run` itself refuses (Gate 0). `ENV_FIELDS`/`env_field_help()` live in
+`dax_creds/config.py` rather than `init.py` so building the argument parser
+does not import keyring on every `dax` invocation.
+
+Deliberately not settable: `multi_tenant`/`tenant_subdir` (being deleted — not
+worth teaching), and `features` (top-level in `~/.dax.yaml` or in a
+project-local `.dax.yaml`, not a registry field).
+
+**Prerequisite, now met:** `save_config` used pyyaml, so every write deleted all
+comments and alphabetised all keys — including the commented-out
+`#- claude_tenant_state` toggle, which is configuration rather than decoration.
+`dax env set` is a routinely-invoked writer, which would have made that much
+worse. Fixed 2026-07-29 with ruamel round-trip loading and saving; `save_config`
+now refuses outright when ruamel is unavailable rather than falling back and
+trampling, while reads still fall back so `dax run` never breaks.
+
+### G2. `dax envs list` absorbs the tenant view — built 2026-07-30
+
+`dax tenants` was registry-driven by design, deriving its rows from
+`~/.dax.yaml` plus `.dax-tenant` files. Once tenant is a declared field, its
+rows become 1:1 with `dax envs list`, which is already the richer view (it also
+knows about running containers). Keeping both means answering the same question
+twice.
+
+The merged `dax envs list` walks **both** the registry and
+`~/.local/state/dax/tenants/`, as an outer join, because an env can be orphaned
+from either direction:
+
+| condition | meaning |
+| --- | --- |
+| registry entry, no state tree | declared but never launched, or its state was deleted |
+| state tree, no registry entry | true orphan — deregistered or renamed, transcripts and memory still on disk |
+| both, `dir` missing | repo moved or deleted, state stranded |
+
+That second row is what no previous command could show, and it is exactly what
+decision A's deletion-grouping rationale needs. TENANT, STATE, and USED columns
+added — STATE the tree's size on disk, USED a compact relative age (`now`, `3d`,
+`5w`, `1y`). Size and recency answer different halves of "is this worth
+keeping": a large tree nobody has opened in a year is a better deletion
+candidate than a small one from this morning. Both come from a single walk
+(`_tree_stats`), so recency is effectively free.
+
+USED is the newest *file* mtime, not the directory's own — a directory's mtime
+only moves when entries are added or removed, so editing a transcript in place
+would otherwise read as ancient.
+
+Status markers: `*` running, `!` directory missing, `?` orphaned tree, with a
+legend printed for whichever markers appear.
+
+A registry row **claims** its matching tree, so whatever survives the join is by
+definition an orphan. Only a *declared* tenant can claim one — with `tenant`
+unset there is no path to look under, so a tree bearing that project's name
+stays unclaimed and is reported. That is the honest reading: the registry no
+longer says which tenant it belongs to.
+
+`state_trees()` / `state_tree_path()` live in `dax_creds/config.py` and are
+filesystem-driven by design, unlike the registry-driven listing they replace.
+
+Caught while testing: the original `run_envs_list` returned early on an empty
+registry, which would have hidden every orphan in exactly the case where
+*everything* is one — deregistering all projects. The empty check now runs after
+the join instead of before it.
+
+Naming settled: **env and tenant are different cardinalities, not synonyms.** An
+env is one repo, one container, one state tree — the row. A tenant is a grouping
+label that can span several envs — a column, plus a `--tenant` filter. So the
+command stays `envs`.
+
+Related, unfixed: `_run_init` finds an existing project by exact `dir == cwd`
+match, the same blind spot `find_enclosing_project` closed for `cmd_run`, so
+`dax init` from a subdirectory still registers a duplicate.
+
+### Outstanding after this redesign
+
+- Reinstall dax on the host and rebuild the image — gates both the ruamel fix
+  and the still-pending classification-flow retest on the real repos.
+- Enforce fresh-login-per-project. **Login path fixed 2026-07-30 (see C3);
+  `dax creds add` still outstanding** — its claude path imports from
+  `~/.claude/.credentials.json` with no such guard, so minting a *derived* name
+  that way would still share a grant.
+- Teardown write-back to Keychain (deferred by choice — see C).
+- ~~`dax creds add`'s overwrite early-return~~ — **fixed 2026-07-30.** Every
+  `_setup_*_credential` takes `replace=`, set only on a confirmed "Overwrite
+  it?", so the provider's store is actually reached. A confirmed replace that
+  finds nothing new now says the old secret survived, rather than printing the
+  ordinary "no token found" and leaving the user believing it was cleared.
+  `dax creds remove` was fixed in the same pass to drop the config entry as
+  well as the Keychain secret, refusing if any project still references it.
+- Remove the debug scaffolding: `~/.dax-debug/open-url.log` in the
+  `dax-creds-open-url` wrapper and the `~/.dax-debug` mount in `_LOGIN_PROVIDERS`.
+- Retire `dax tenants` and `dax tenant classify`, now that the merged
+  `dax envs list` (G2) supersedes them.
+- Prompt for `tenant` during `dax init` registration (editing is now covered by
+  `dax env set`).
+- Shared `plugins`/`commands`/`cache` migration — reshaped by B into nested
+  mounts inside the `~/.claude` tree mount.
+- Execute the deletions in E.
 
 ## Accepted costs of per-tenant/project `.claude.json`
 
@@ -810,6 +1371,104 @@ root. Now branches on whether `project == reponame`.
 fabric/discernment containers since this change — that would require an
 image rebuild (`dax_creds` is a frozen, non-editable install) and a fresh
 round of manual verification, not yet done.
+
+### Confirmed 2026-07-30 — post-rebuild manual pass, steps 0–2
+
+Sequence and full expectations in
+`docs/testing/2026-07-30-cred-management-test-sequence.md`.
+
+**Step 0 (container), passed twice in separate containers.** 342 tests pass;
+installed `dax_creds` byte-identical to the repo; `/usr/bin/claude` identical to
+`dax_creds/wrappers/claude`, so inject-if-absent shipped; `ruamel.yaml`
+importable; and `DAX_CREDS_CLAUDE=claude-personal-dax` in a live container —
+C2's derived naming resolves end to end, from `~/.dax.yaml` through `dax run`
+into the container environment.
+
+**Step 1 (host), passed.** Editable reinstall picked up ruamel 0.19.1 (host is
+Python 3.9; the container is 3.14). `dax env set dax tenant personal` rewrote
+`~/.dax.yaml` byte-identically — empty diff, comments and the commented-out
+`#- claude_tenant_state` toggle intact. This is a real round-trip proof rather
+than a short-circuit: `run_env_set` calls `save_config` unconditionally
+(`init.py:649`), so a same-value set still serializes and rewrites the whole
+file while leaving its content unchanged. Any diff would therefore be pure
+round-trip damage.
+
+**Step 2 (host), passed, with findings.** `stored: yes` for all three derived
+Claude names; `claude-fre` shows used by **nothing**, so the resolving "used by"
+column does read the typo'd credential as dead; `dax env show` prints the
+resolved name; `dax envs list` reports orphans.
+
+- **All three derived credentials already exist in Keychain, minted before the
+  C3 fix.** The likeliest provenance is the abandoned-login import path, which
+  copies `~/.claude/.credentials.json` under the new name. Step 3 therefore has
+  a high prior of failing, and that is exactly what it is for.
+- **8 orphaned state trees, all recognizable as discernment processes** —
+  `a-priest-and-an-imam`, `seans-new-gig`, `self-employment-setup`,
+  `ysecurity-onboard`, `american-binary-soc2`, `augmentcode`,
+  `symlink-disclosure`, `hydraulic-controls-it`, under tenants `hci` and
+  `ysecurity` that no project declares. These are artifacts of the abandoned
+  multi-tenant classification (decision 8). Most are 0B shells; two hold real
+  data (`ysecurity-onboard` 1020K, `hydraulic-controls-it` 393K). G2 was built
+  to make exactly this visible, and did — every one of them was invisible to
+  every previous command.
+- **`dax`'s own state tree exists (122K, last used 21h) but is not in use.**
+  `claude_tenant_state` is commented out and the running container has
+  `.claude.json` at `$HOME`, outside the tree. Tree existence is not evidence of
+  activation, in this doc's own test output as much as anywhere.
+
+Two presentation defects, both in the same family as C4's related fix — two
+views disagreeing about what exists:
+
+- `dax env show` prints `[not registered yet]` (no `credentials:` entry) for a
+  name that `dax creds list` reports as `stored: yes` (Keychain holds a secret).
+  Both are true of different stores, but "not registered yet" reads as "you must
+  log in". Worth distinguishing registered-in-config from stored-in-Keychain.
+- `[!] key on disk` tests the single global `~/.claude/.credentials.json`
+  (`ClaudeProvider().has_disk_copy()`), so it repeats identically on every
+  claude row — a per-provider condition rendered in a per-credential column,
+  saying nothing about which credential the disk copy is.
+
+Unrelated, noticed in passing: `ssh-id-rsa` reports `stored: no` on both host
+and container. Worth checking whether `~/.ssh/id_rsa` is still the right path.
+
+**Step 3 (host), PASSED — and the step-2 prediction above was wrong.** 4
+distinct grants across 4 credentials, no sharing, despite all three derived
+credentials having been minted before the C3 fix landed. Refresh expiries are
+staggered 08-27 (`claude-fre`), 08-28 (`dax`), 08-29 (`discernment`), 08-28
+(`fabric`) — spread across the days the logins actually happened, which is what
+separate mints look like. `~/.claude/.credentials.json` matched
+`claude-personal-dax`, so every non-tenant-state container is currently riding
+dax's grant.
+
+Limit of this result, now recorded in the script's docstring: the refresh token
+is a **proxy** for grant identity, since the blob carries no grant ID. A copy is
+caught only while both entries still hold the same token. If each side then
+refreshes independently, each gets a new token while still descending from one
+grant, and the check reports PASS. These credentials predate the fix and have
+been used since (access tokens now expiring 07-31), so rotation was possible.
+The staggered refresh expiries are what make this PASS read as genuine rather
+than a rotation artifact — inference, not proof. Consequence for the sequence:
+run step 3 **immediately after** minting in step 5, where the signal is
+strongest, not only on the multi-day soak.
+
+**Correction, from step 4's mint (recorded in C5 above): the staggering inference
+is weaker than stated here.** A `claude-personal-fabric` grant minted on 2026-07-30
+reported `refreshTokenExpiresAt` of **2026-08-27** — *earlier* than grants
+already in Keychain (08-28, 08-29), where a fixed ~30-day window would have put
+a same-day mint near 08-29. So that field does not reliably encode mint date and
+cannot corroborate separate mints. What does carry the claim is a grant hash
+**changing across a known-good login**, which step 4 observed directly.
+
+**Step 4 (host), passed — recorded in C5 and C6 rather than here**, since it
+produced a code change and a new finding rather than only a result. In short: it
+found C5 (login refused every derived name), the fix was made and confirmed live,
+C4's Chrome profile and the device-flow redirect were both verified, a real mint
+produced a new grant, the abandoned-login refusal was confirmed on a second
+cancelled run, and inspection turned up C6.
+
+Steps 5–8 not run: step 5 is moot (step 3 found no sharing to repair, and step 4
+effectively re-minted fabric), step 6 is pending, and steps 7–8 are gated on
+decision B, without which per-env credentials remain inert at runtime.
 
 ## Deferred
 

--- a/docs/design/2026-07-27-tenant-isolation.md
+++ b/docs/design/2026-07-27-tenant-isolation.md
@@ -1,6 +1,7 @@
 # Tenant Isolation for Claude Code State
 
-**Status:** designed, not implemented
+**Status:** Sequencing steps 1–2 implemented and merged (PR #4, 2026-07-27);
+steps 3–7 designed, not implemented
 **Date:** 2026-07-27
 **Motivation:** hygiene today; anticipated contractual obligation later; existing
 obligation to delete customer data when a relationship ends
@@ -317,8 +318,8 @@ atomic rename on this setup.
 
 ### Done
 
-Steps 1 and 2 of Sequencing, plus the code they require. All in the working tree,
-**uncommitted**.
+Steps 1 and 2 of Sequencing, plus the code they require. Merged via PR #4 into
+`master` on 2026-07-27 (commit `1c54050`).
 
 - `dax_creds/providers/claude.py` — `.credentials.json` default, legacy name as
   import fallback, `is_oauth_envelope()` requiring a `refreshToken`, `store()`
@@ -447,67 +448,46 @@ is not contractual, so re-check it after major version bumps.
 
 ### Environment state
 
-`~/.dax.yaml` has been **restored** — `claude` is back in `features` and
-`~/.claude.json` back in `dotfiles.rw`. Note that the edits were made by
-commenting the lines out, but `dax creds add` rewrote the file via `yaml.dump`
-and deleted the comments outright (see Backlog in `CLAUDE.md`); the restore was
-by hand.
+`~/.dax.yaml` is **deliberately left unrestored**: `claude` stays out of
+`features`, `~/.claude.json` stays out of `dotfiles.rw`. These were originally
+just the diagnostic session's test edits, but since the fix merged with them
+still in place, every container started since — including the one this design
+work is happening in — has been running the merged wrapper with `~/.claude`
+genuinely unmounted. That's an unplanned, ongoing run of Sequencing step 2's
+gate; see Confirmed below. Restore only if a dax session is needed before steps
+3–7 land — the intent is to finish the feature first and never need to.
 
-Still present and worth deleting: `~/.claude/credentials.json` and
-`~/.claude/credentials.json-`, mode 644, containing a stale bare OAuth access
-token.
+The stale `~/.claude/credentials.json` / `~/.claude/credentials.json-` bare
+tokens noted earlier are gone from this container's `~/.claude` — no longer
+worth tracking as cleanup.
 
-### Resume procedure
+### Confirmed 2026-07-27 — step 2 passed, live and unplanned
 
-The gate is an **interactive** launch. `claude auth status` and `claude -p` both
-bypass onboarding and will report success against a config that prompts.
+Checked directly in a running session: no `claude` entry in `mount`;
+`/usr/bin/claude` is the fixed wrapper; `DAX_CREDS_CLAUDE=claude-fre` and
+`DAX_CREDS_SOCK` are set; `~/.claude.json` shows `hasCompletedOnboarding: true`
+with exactly one project key (`/home/dfarrow/work`) — clean, no cross-tenant
+data; `~/.claude` holds only a fresh `.credentials.json` written by the
+wrapper, no bind-mounted host files. The session launched and ran normally
+throughout — no theme picker, no login prompt.
 
-The wrapper now seeds `.claude.json` itself, but **the installed image predates
-that change** (built 17:08). Pick a path before starting:
-
-- **Path A — no rebuild.** Seed by hand in the container. Validates that the
-  mechanism is right; does not exercise the wrapper's own seeding.
-- **Path B — rebuild first.** Exercises the real fix end-to-end. Preferred if a
-  rebuild is cheap, since Path A leaves the wrapper's seed path untested outside
-  of unit tests.
-
-Steps:
-
-1. Shut down **every** dax container — including the one this diagnosis ran in.
-   Any live session holding the `~/.claude` mount can refresh the shared
-   credential mid-test and reintroduce the confound the last attempt hit.
-2. Confirm Keychain is current: `dax-creds get claude-fre` should match the host
-   `~/.claude/.credentials.json`. Re-import only if it does not — and note that
-   `dax creds add` rewrites `~/.dax.yaml` and strips its comments.
-3. Path B only: rebuild the image so the seeding wrapper is installed.
-4. Start one container with `claude` absent from `features` and `~/.claude.json`
-   absent from `dotfiles.rw`. Configuring the mounts out is preferable to
-   deleting host files — it also puts the stale mode-644
-   `~/.claude/credentials.json` out of the container's reach without touching it.
-5. Path A only, **before** launching Claude:
-   `echo '{"hasCompletedOnboarding": true}' > ~/.claude.json`. The wrapper only
-   writes credentials when `claude` is invoked, so launching first means hitting
-   the wizard and backing out.
-6. Run `claude` **interactively**. Pass condition: it reaches the prompt showing
-   `Welcome back`, with no login method screen.
-
-`tests/manual/interactive_launch_probe.py` automates step 6's classification and
-can be run inside the container:
+This is the same pass condition `tests/manual/interactive_launch_probe.py`
+checks for (`Welcome back`, no login screen), observed directly rather than via
+the probe:
 
 ```
 python3 tests/manual/interactive_launch_probe.py          # bare credential
 python3 tests/manual/interactive_launch_probe.py --seed   # with onboarding flag
 ```
 
-It probes an isolated temp config dir rather than the live one, so it is safe to
-run against a working session; it reports `login`/`ready`/`onboarding`/`trust`
-and exits non-zero on a login prompt. Verified to produce FAIL without `--seed`
-and PASS with it.
+It probes an isolated temp config dir rather than the live one, so it remains
+safe to run against a working session if a second opinion is wanted; verified
+to produce FAIL without `--seed` and PASS with it.
 
-**Rotation remains untested.** It was never reached, because the run failed at
-onboarding before any refresh could occur. Verifying it needs a container left
-running across an `expiresAt` boundary with `~/.claude` unmounted, then a
-comparison of the container's refresh token against Keychain.
+**Still open: rotation.** This confirmation is hours old, not the "several
+days" Known Limits calls for before trusting refresh-token rotation under an
+unmounted `~/.claude`. Leaving `~/.dax.yaml` unrestored (above) keeps extending
+this observation window for as long as steps 3–7 take to build.
 
 ## Deferred
 

--- a/docs/design/2026-07-27-tenant-isolation.md
+++ b/docs/design/2026-07-27-tenant-isolation.md
@@ -1,7 +1,11 @@
 # Tenant Isolation for Claude Code State
 
 **Status:** Sequencing steps 1–2 implemented and merged (PR #4, 2026-07-27);
-steps 3–7 designed, not implemented
+steps 3–6 implemented, unit-tested (259 tests), and confirmed on the two real
+target repos (2026-07-28) — see Verification log; step 7 dropped (see
+Sequencing). Outstanding before this is trusted as the default: the shared
+`plugins`/`skills`/`commands`/`cache` migration and the multi-day
+refresh-token rotation soak.
 **Date:** 2026-07-27
 **Motivation:** hygiene today; anticipated contractual obligation later; existing
 obligation to delete customer data when a relationship ends
@@ -126,25 +130,64 @@ tenant-level `CLAUDE.md` — explicit and reviewable — not emergent recall.
 | | Gate A: `dax run` | Gate B: `claude` launch |
 | --- | --- | --- |
 | Where | host, container start | in container, `/usr/bin/claude` wrapper |
-| Sees | the repo | the **cwd** |
+| Sees | the repo | the **cwd**, plus `multi_tenant` and `project_name` handed down from Gate A |
 | Job | mount repo at `~/<reponame>` | resolve cwd → tenant → `CLAUDE_CONFIG_DIR` |
 | Refuses | never | when resolution yields no tenant |
 
-Gate A always succeeds. A multi-tenant repo's root is a legitimate work
+Gate A always succeeds — *once it has correctly identified which registered
+project it's mounting.* A multi-tenant repo's root is a legitimate work
 directory — git, builds, and moving files between processes all need it.
 
 Gate B refusal is not a bolted-on check. The wrapper must resolve cwd → tenant
 regardless, because that is how it learns which `CLAUDE_CONFIG_DIR` to export.
 Refusal is the empty-resolution branch of work it performs anyway.
 
+**Gate 0, added 2026-07-28: `cmd_run`'s project lookup, ahead of Gate A.**
+Found via a real usage mistake on `discernment`: its intended flow is
+`dax run` once from the repo root, then `cd` to a `processes/<name>/`
+subdirectory *inside* the running container for Gate B to resolve. Nothing
+stopped the same `cd` happening **on the host** instead, followed by
+`dax run` from there directly. `find_project_by_dir` (`dax_creds/config.py`)
+only matches by exact equality against a registered `dir:`, so a subdirectory
+cwd matches nothing, and `cmd_run`'s `except KeyError` branch fell through to
+`run_init`, silently auto-registering the *subdirectory* as a brand-new,
+unrelated project. `feature_workdir` then mounted only that subdirectory —
+the true repo root, and everything that exists only there (`.git`,
+`.claude/skills/`, repo-root config), was never mounted, with no error to
+signal why. Worse, because the subdirectory already had its own
+`.dax-tenant` (written earlier under the correct flow), the bogus new
+project resolved to the *same* tenant and state directory the correct flow
+would have used — credentials and history looked continuous, so the failure
+had no visible symptom beyond silently-missing repo-root content.
+
+Same principle as decisions 7/8 (no silent fallback — refuse rather than
+guess), applied one layer earlier: `find_enclosing_project`
+(`dax_creds/config.py`) checks whether cwd is nested *inside* — not equal
+to — any already-registered project's `dir` before falling through to
+`run_init`. If so, `cmd_run` refuses with the enclosing project's name and
+root, and the exact command to run instead, rather than auto-registering.
+`run_init` still fires exactly as before for a cwd that isn't nested under
+any known project at all — the genuinely-new-project case. This generalizes
+past `multi_tenant`/`tenant_subdir` repos: no single- or multi-tenant dax
+project has a legitimate reason for `cmd_run` to see a cwd that's a strict
+subdirectory of an already-registered project's `dir`. Unaffected: the actual
+in-container multi-tenant flow (`cd` to `processes/<name>/` inside an
+already-running container, Gate B resolves it) never goes through `cmd_run`
+at all.
+
 ### 7. Resolution table
+
+**Revised 2026-07-28 — the `unattributed` fallback is gone.** See decision 8
+below for why, and Sequencing step 6 for the classification mechanism that
+replaces it.
 
 | Situation | Result |
 | --- | --- |
-| single-tenant repo | starts anywhere in tree |
-| multi-tenant repo, mapped subdir | starts, state → that tenant |
-| multi-tenant repo, root or unmapped subdir | refuse |
-| undeclared repo | `unattributed/<reponame>/`, warn, proceed |
+| single-tenant repo, root declared | starts anywhere in tree, state → that tenant |
+| single-tenant repo, root undeclared | refuse — `dax tenant set`/`dax tenant classify` |
+| multi-tenant repo, root itself | its own project/tenant if declared; refuse if not (see decision 8) |
+| multi-tenant repo, mapped immediate child (or child of `tenant_subdir`) | starts, state → that tenant |
+| multi-tenant repo, unmapped child, or more than one level deep | refuse |
 | project creds span multiple tenant labels | refuse regardless |
 
 Guiding principle: **fail toward over-isolation.** Where tenancy is ambiguous,
@@ -152,17 +195,171 @@ pick the narrower tenant. Over-isolation costs convenience; under-isolation
 costs confidentiality. Those are not symmetric, and the 27-file pile is what
 under-isolation looks like after a few months.
 
-### 8. Undeclared repos go to `unattributed/<reponame>/`
+**"tree" means at most one level deep.** Claude may only ever be started at a
+project's mount root or exactly one directory below it — never deeper. That
+outer bound is enforced first, ahead of any `.dax-tenant` lookup and ahead of
+either mode's own rule below: a cwd more than one level below the root
+refuses outright regardless of what the repo declares. Implemented in
+`dax_creds/tenant.py` as a plain root-plus-immediate-children check — no
+arbitrary-depth directory walk, and so no walk-depth/symlink concerns to
+design around either.
 
-Not to a tenant derived from the repo name. Repo-name derivation partitions
-correctly — tested against `dax`, `fabric`, `iandidit`, and `ys-augmentcode`, it
-never merges two tenants, only over-isolates. But as an *identifier* it is a
-guess, and a tree labelled `ys-augmentcode` does not announce itself as
-unverified at deletion time. Confident-wrong is worse than visibly-unknown.
+**`multi_tenant` is an explicit flag, not inferred.** Whether a repo has more
+than one tenant is never determined by counting how many distinct
+`.dax-tenant` labels happen to exist in it. It is declared explicitly, once,
+as `multi_tenant: true` on the project's own entry in `~/.dax.yaml`
+(`projects.<name>.multi_tenant`) — the same file that already holds that
+project's `dir` and `creds`. This does not conflict with decision 9's
+rejection of a central `~/.dax.yaml` tenant *map*: a project-level boolean
+carries no customer name and is not tied to a specific subdirectory that
+could be renamed out from under it, so none of that decision's reasoning
+applies here.
 
-`unattributed/<reponame>/` gives per-repo separation (nothing pools), does not
-block work, is enumerable via `dax tenants`, and makes later attribution a
-directory move rather than archaeology.
+The flag draws a hard line on where claude may even be started, not just on
+where a tenant may be declared — a strict, non-overlapping split:
+
+- `multi_tenant: false` (default) — the repo root **is** the sandbox: claude
+  may only start there, full stop. A child directory refuses outright, even
+  one level down, even if it happens to carry its own `.dax-tenant` file —
+  that grants nothing in this mode. The tenant comes from the root's own
+  `.dax-tenant`; if the root has none, `dax run`'s classification step (see
+  decision 8 and Sequencing step 6) prompts for one before the container ever
+  launches, so a wrapper invocation never finds the root genuinely
+  undeclared in ordinary use. This is the point of how a project gets set up
+  in the first place: `cd` to the project root, `dax run`, configure the
+  environment — sandboxed claude, nothing more to decide.
+- `multi_tenant: true` — claude may start either at the repo root itself or
+  at an immediate child (or a child of `tenant_subdir`) that carries its own
+  `.dax-tenant` file. **Revised 2026-07-28:** the root is no longer a
+  permanent refusal — a multi-tenant repo's own top-level tooling is
+  sometimes worked on independent of any one engagement subdirectory, so the
+  root resolves as its own project/tenant when declared, exactly like any
+  other node in the tree. What doesn't change: there is still no silent
+  pooling anywhere. `dax run`'s classification step walks the root and every
+  undeclared immediate child (see decision 8), so an unmapped node is a
+  transient state to be resolved before launch, not a standing fallback
+  destination.
+
+Resolved: Gate B gets `multi_tenant` via an env var, not by reading
+`~/.dax.yaml` itself. `~/.dax.yaml` is bind-mounted into every container
+today (`dotfiles.rw`), so the wrapper technically *could* read it — but doing
+so would mean re-deriving which `projects.<name>` entry it's looking at,
+matching the container-side repo root's basename back against the (host-path)
+`dir` field, duplicating logic Gate A already ran to get there. Gate A already
+knows the answer with certainty at the moment it decides to mount the
+container at all (`find_project_by_dir` already found the exact entry, and
+already handles the unregistered-project case by falling into `dax init`), so
+it hands that one bit down directly: `-e DAX_MULTI_TENANT=1` (absent/unset
+for false), the same mechanism `cmd_run()` already uses for
+`DAX_CREDS_CLAUDE` and friends (`dax.py:453-476`) and for `DAX_PREVIEW_PORT`/
+`DAX_PREVIEW_DIR`. One value, handed down once, no second implementation of
+the lookup to drift from the first.
+
+**A second value is required alongside it: `DAX_PROJECT_NAME`.** Found while
+building Gate B (`resolve_for_cwd` in `dax_creds/tenant.py`): `$HOME`
+legitimately has other directory-level mounts sitting right alongside a
+project's own — `~/.claude`, `~/.augment`, `~/.aws` (see
+`.dax.yaml.example`'s `claudedir`/`auggiedir`/`awsdir`). Without knowing the
+*actual* project name, Gate B can only infer "the repo root" structurally, as
+whatever cwd's top-level directory under `$HOME` happens to be — so a user who
+`cd`s into `~/.claude` and runs `claude` there would have it treated as if
+`~/.claude` *were* the project root, found undeclared, and silently resolved
+to `unattributed/.claude` instead of refusing. `DAX_PROJECT_NAME=<workdir_name>`
+closes that: Gate A already computed this value in stage 3's `load_config()`
+work, so handing it down is free, and Gate B refuses immediately if cwd's
+top-level directory doesn't match it, before any `.dax-tenant` lookup happens
+at all.
+
+**A third value, `DAX_TENANT_SUBDIR`, exists for exactly one project.** Found
+while actually assigning discernment's real tenants: its tenant subdirectories
+don't sit directly under the repo root — they're one level further in, under
+`processes/`. Discovered too late to design around cleanly; the two structural
+alternatives (register `processes/` itself as a separate project; restructure
+discernment's actual layout to remove the `processes/` indirection) were both
+rejected — the agent needs everything in the repo visible from one project,
+and the layout isn't something to reshuffle for this. So `resolve_tenant`
+and `all_tenant_projects` (`dax_creds/tenant.py`) both take an optional
+`tenant_subdir` parameter: when set, labeled subdirectories are looked for
+under `repo_root/tenant_subdir` instead of `repo_root` directly, and
+everything else about the resolution table — root/subdir-base never
+resolves, unmapped children refuse, no `unattributed/` fallback — is
+unchanged. Configured via `projects.discernment.tenant_subdir: processes` in
+`~/.dax.yaml` (read into `config['tenant_subdir']` in `cmd_run()`, same place
+`multi_tenant` is read), handed down to Gate B as `DAX_TENANT_SUBDIR`, same
+mechanism as the two env vars above. Deliberately not generalized further than
+one fixed subdirectory name — there is exactly one project shaped like this
+today, and YAGNI argues against building for a second that may never exist.
+
+### 8. Undeclared locations are classified before launch, never pooled
+
+**Superseded 2026-07-28.** The original design routed anything undeclared to
+`unattributed/<reponame>/` — a real tenant slot, warn, proceed. Rejected once
+real usage made the cost concrete: *"i always want the tenant defined and
+cleaning up later is a pain. so if the tenant isn't defined, lead the user
+through defining it then continue."* Cleaning up an `unattributed/` tree
+later is exactly the kind of archaeology decision 8 originally tried to avoid
+turning into — it just moved the guesswork from "which tenant" to "did
+anyone ever go back and fix this," which in practice nobody does.
+
+**Replacement: classify at `dax run` time, refuse to launch until done.**
+Before the container starts, `dax run` walks exactly the same nodes the
+resolution table (decision 7) recognizes as legitimate start points — the
+repo root always, plus (for a multi-tenant project) every immediate child
+under `tenant_subdir` — and interactively prompts for a tenant name wherever
+`.dax-tenant` is missing, offering the known-tenant list plus a "new tenant"
+escape hatch. Anything already declared is left untouched. The container
+does not launch until every node classifies. Implemented as
+`_ensure_tenants_classified()` in `dax.py`, invoked from `cmd_run()` whenever
+`claude_tenant_state` is in the project's `features` list.
+
+`dax tenant classify` re-runs the same walk on demand, but with every node
+re-prompted (including already-declared ones, offered as the current value
+so accepting is one keystroke) — for correcting a mislabeled tenant without
+having to `rm` the `.dax-tenant` file by hand first.
+
+**Deliberately not extended to a directory discovered mid-session.** Docker
+cannot add a bind mount to an already-running container, so a brand-new
+subdirectory that appears after `dax run` has already launched cannot be
+folded into the running container's mounts regardless of how it's
+classified. That case still hard-refuses via the wrapper's existing
+`dax tenant set <subdir> <tenant>` message — no interactive prompting
+in-container, since satisfying the prompt wouldn't actually unblock the
+session anyway. Accepted as small, livable friction: `dax run` again after
+declaring picks it up on the next launch.
+
+**Prior implementation note, retained for history:** the original
+`unattributed` mechanism kept `tenant` and `project` as two separate fields
+(`'unattributed'` and `<reponame>`), not a combined string — a real bug
+(doubled reponame in the composed path) was caught this way during manual
+testing before the mechanism was removed outright. The two-separate-fields
+lesson still applies wherever `tenant`/`project` pairs are built today.
+
+**`dax tenants` enumerability was originally accidental, not designed —
+fixed 2026-07-28.** As first built, `dax tenants` only listed directories
+under `~/.local/state/dax/tenants/` that already existed — which meant only
+tenants that had already had a real `dax run` session, since nothing else
+ever created that path. A tenant declared with `dax tenant set` but never
+launched was invisible. First fix attempt was to have `dax tenant set` also
+`mkdir -p` the state directory at declaration time; reverted almost
+immediately in favor of the real fix — `dax tenants` re-derives the live
+(tenant, project) set directly from `~/.dax.yaml`'s `projects` plus whatever
+`.dax-tenant` files actually say right now (the same inputs `dax run` itself
+uses), rather than reading anything off the state tree for enumeration at
+all. That makes the pre-create workaround redundant — every declared tenant
+shows up immediately regardless of whether anything's ever mounted it — and
+is also more correct: a stale declaration change can never continue to show
+something that no longer resolves that way, which reading the state tree
+would risk.
+
+Output is a table (`TENANT`/`PROJECT`/`SESSION`/`PATH`, fixed-width columns,
+sorted so same-tenant rows are contiguous), including each project's real
+host path — for a single-tenant project that's the repo root; for a
+multi-tenant one it's `repo_root/[tenant_subdir/]<labeled subdir>`. `SESSION`
+is `yes`/`no` based on whether `~/.local/state/dax/tenants/<tenant>/<project>/`
+has a `.claude.json` or `.credentials.json` in it — the two things only a
+real launch ever writes — so declared-but-unused and actually-active tenants
+are distinguishable at a glance. Projects whose registered `dir` doesn't
+exist on the current machine are silently skipped.
 
 ### 9. Declaration: gitignored `.dax-tenant` per subdir
 
@@ -319,14 +516,62 @@ atomic rename on this setup.
    every new project would otherwise open with a round of onboarding and trust
    dialogs, which is the difference between the cutover being unnoticeable and
    being irritating enough to abandon.
-5. Replace the wholesale `~/.claude` mount and the `~/.claude.json` dotfile mount
-   with per-tenant/project trees under `~/.local/state/dax/tenants/`, plus shared
-   mounts for `plugins/`, `skills/`, `commands/`. For a multi-tenant repo, mount
-   only `tenants/*/<project>/` — the repo's own subtree from each tenant the
-   subdir map references, never a whole tenant tree.
-6. Tenant resolution and refusal in the `claude` wrapper; `dax tenant set`;
-   `dax tenants` enumeration.
-7. Credential-span escalation check.
+5. **Wrapper-side tenant resolution** (`claude` wrapper, `dax_creds/tenant.py`,
+   `dax-creds resolve-tenant`). Reordered ahead of the mount replacement below
+   and decoupled from it via a master switch, `DAX_TENANT_STATE`, which
+   `dax run` sets only for projects that have opted into step 6's feature.
+   Unset — every project today — the wrapper's tenant resolution never runs
+   and behavior is unchanged; this is what lets this step land on its own,
+   independently testable, without the mount replacement also being live yet.
+   `dax tenant set`/`dax tenants` are part of step 6, not this step, since
+   they write/enumerate `.dax-tenant` files that only matter once a project
+   has actually opted in.
+6. Replace the wholesale `~/.claude` mount and the `~/.claude.json` dotfile
+   mount with per-tenant/project trees under `~/.local/state/dax/tenants/`,
+   behind the same opt-in feature (`claude_tenant_state`) that sets
+   `DAX_TENANT_STATE`, `DAX_MULTI_TENANT`, and `DAX_PROJECT_NAME` (the last of
+   these is what lets Gate B tell a real project mount apart from `~/.claude`/
+   `~/.augment`/`~/.aws` sitting at the same `$HOME` level — see decision 7).
+   For a multi-tenant repo, mount only `tenants/*/<project>/` — the repo's own
+   subtree from each tenant the subdir map references, never a whole tenant
+   tree. Includes `dax tenant set`/`dax tenants`/`dax tenant classify` (see
+   decision 8).
+
+   **Implemented and unit-tested** (`feature_claude_tenant_state` in `dax.py`,
+   opted into via a project's own `features:` list — see decision 7's
+   "`multi_tenant` is an explicit flag" note — plus `config['multi_tenant']`
+   wired from the project registry in `cmd_run()`). `cmd_run()` also invokes
+   `_ensure_tenants_classified()` whenever `claude_tenant_state` is opted in,
+   refusing to launch until every root/child node resolves — 259 tests pass
+   as of 2026-07-28, covering the resolution table, `dax tenants`,
+   `_ensure_tenants_classified`, `_prompt_tenant`, and `dax tenant classify`.
+
+   **Verified 2026-07-27: Docker auto-creates a missing bind-mount host
+   directory owned by the actual host user, not root.** This mattered because
+   the per-tenant/project host directories under `~/.local/state/dax/tenants/`
+   don't exist until first use, and every manual test up to this point had
+   only exercised a container-local `mkdir -p` (the wrapper's own, run
+   entirely inside the container's filesystem) — never a real host bind-mount
+   of a brand-new nested path. Checked directly:
+   `docker run --rm -v ~/scratch-permission-test:/test alpine sh -c 'id; ls -la /test'`
+   auto-created the host directory; `ls -la ~/scratch-permission-test` on the
+   Mac side (not through a root-run container, which would trivially bypass
+   permission checks either way) showed it owned by the actual host user.
+   Since the container's own user is built with a matching UID (the repo's
+   "host UID matching" build step), this confirms a brand-new tenant/project
+   directory is fully writable by the container the moment Docker creates it —
+   the specific risk carried out of implementation is closed. Still not done:
+   the full end-to-end proof on a real opted-in project (all resolution-table
+   rows, real Claude Code launch through this exact mount path, multi-day
+   rotation soak) that the plan's Verification section calls for.
+7. ~~Credential-span escalation check.~~ **Dropped.** Traced through what
+   decision this would actually drive: it protects against a `dax_creds`
+   credential-delivery misconfiguration (a project's `creds:` list spanning
+   multiple tenants' credentials) that is orthogonal to the Claude-state-bleed
+   problem this feature fixes, and is exactly as possible today as it would be
+   after this feature ships — steps 3-6 fully close the actual bug without it.
+   Revisit later, separately, if it ever actually bites, rather than inventing
+   a tenant-labeling scheme now to guard a hypothetical.
 
 ## Verification log — paused 2026-07-27
 
@@ -426,7 +671,7 @@ Dave!` and is authenticated. For a zero-prompt launch, seed:
 | --- | --- |
 | `hasCompletedOnboarding` | theme picker, then **login prompt**, then browser OAuth |
 | `projects.<cwd>.hasTrustDialogAccepted` | trust dialog; `settings.local.json` permissions silently ignored |
-| `theme` | theme picker on first launch |
+| `theme` | ~~theme picker on first launch~~ — **retested 2026-07-27 against v2.1.220: false.** With only `hasCompletedOnboarding` seeded, `interactive_launch_probe.py --show` reaches `Welcome back Dave!` directly, no theme picker shown. Not seeded; nothing to fix. |
 | `oauthAccount`, `userID` | cosmetic only — banner omits org name; triggers a profile fetch |
 
 `oauthAccount` is **not** required for auth. It is copied host state, so whether
@@ -502,6 +747,69 @@ to produce FAIL without `--seed` and PASS with it.
 days" Known Limits calls for before trusting refresh-token rotation under an
 unmounted `~/.claude`. Leaving `~/.dax.yaml` unrestored (above) keeps extending
 this observation window for as long as steps 3–7 take to build.
+
+### Confirmed 2026-07-28 — steps 3-6 proven on the two real repos this design exists for
+
+`claude_tenant_state` opted in for real, on the actual `fabric` (single-tenant)
+and `discernment` (multi-tenant, `tenant_subdir: processes`) projects — not
+scratch directories. Both directly exercised the exact failure this whole
+design was written to fix (Problem section, above): `discernment` was the
+repo where a session got preloaded with another customer's candidate slate
+and a third party's compensation model.
+
+- **fabric**: declared (`personal`), real launch, real credential flow (found
+  and fixed a genuine, pre-existing `dax creds add`/Keychain-overwrite bug
+  along the way — see `CLAUDE.md` Backlog), history and arrow-up recall work.
+- **discernment**: `hydraulic-controls-it` and at least one other process
+  labeled under `processes/`. Two concurrent `claude` sessions, different
+  tmux windows, same container, different labeled processes — each got its
+  own isolated `CLAUDE_CONFIG_DIR`. Turns run, quit, restarted: history on
+  restart contained only that session's own prior turns, nothing from the
+  other window's tenant. This is the concrete, positive version of the bug
+  this design exists to fix, not just its absence.
+- Root refusal, unmapped-subdir refusal, and the `tenant_subdir` depth
+  accommodation all confirmed against the real repos, not just unit tests,
+  once the image was rebuilt with that code included (an earlier attempt hit
+  stale pre-rebuild behavior — see the `tenant_subdir` note above).
+
+Still outstanding before this can be trusted as the default: the shared
+`plugins`/`skills`/`commands`/`cache` migration (scoped, not yet built — see
+CLAUDE.md In progress), and the multi-day rotation soak, still not clear
+after any of today's testing since nothing here ran long enough to hit a
+rotation.
+
+### Confirmed 2026-07-28 — `unattributed` dropped, root-as-project, interactive classification
+
+Real-world testing above surfaced two further design gaps addressed the same
+day, both now implemented and tested (see decisions 7 and 8, and Sequencing
+step 6):
+
+- **discernment's own top-level tooling needs its own project/tenant.**
+  Working on discernment independent of any one customer process is a real,
+  recurring need, not an edge case — a multi-tenant repo's root now resolves
+  as its own project when declared, in both single- and multi-tenant modes,
+  rather than always refusing.
+- **The `unattributed` fallback is gone entirely**, replaced by interactive
+  classification at `dax run` time (`_ensure_tenants_classified()`), with
+  `dax tenant classify` as an on-demand re-walk. No location remains that
+  silently resolves to a pooled default; every start point either is already
+  declared, gets classified before the container launches, or hard-refuses
+  (only for a subdirectory discovered mid-session, where Docker's inability
+  to add mounts to a running container makes interactive resolution moot
+  anyway).
+
+Also fixed in the same pass, found while re-testing `dax tenants` against a
+multi-tenant repo whose root now resolves as a project: `cmd_tenants`' path
+computation used `tenant_base / project` unconditionally, which produced a
+nonsense doubled path (`discernment/processes/discernment`) for a declared
+root. Now branches on whether `project == reponame`.
+
+259 tests pass (`tests/test_dax_creds_tenant.py`,
+`tests/test_dax_creds_cli.py`, `tests/test_features.py`,
+`tests/test_dax_tenant_cmds.py`, full suite). Not yet re-run against the real
+fabric/discernment containers since this change — that would require an
+image rebuild (`dax_creds` is a frozen, non-editable install) and a fresh
+round of manual verification, not yet done.
 
 ## Deferred
 

--- a/docs/design/VALIDATION.md
+++ b/docs/design/VALIDATION.md
@@ -1,0 +1,387 @@
+# Manual validation run
+
+Steps to prove the substrate wiring works end to end on a real process, before dax automates
+any of it. Run in order. Each step notes what dax will eventually own.
+
+Nothing here has been exercised against real mounts — every test so far used `HOME` overrides
+against sandbox directories, which covers the logic but not grpcfuse behavior on symlinks into
+a mounted state tree. That gap is the reason for this document.
+
+Throughout: `<substrate>` is wherever this repo is mounted, `<process>` is the new process
+directory.
+
+---
+
+## Part 1 — Provision (host / dax)
+
+**1.1** Create an empty host directory for the process. No git, no contents.
+
+**1.2** Define a dax env that mounts:
+
+| Mount | Path in container | Mode |
+|---|---|---|
+| the process directory | `$HOME/<process>` | read-write |
+| this repo | `$HOME/<substrate>` | read-write — the feedback path writes here |
+| the env's state tree | `$HOME/.claude` | read-write — `wire.sh` writes here |
+
+**1.3** Start the container. Do **not** start a Claude session yet.
+
+> *dax owns all of 1.1–1.3. The mount names are dax's to choose; nothing in this repo
+> depends on them.*
+
+**Checkpoint:**
+```sh
+mountpoint -q "$HOME/<substrate>" && echo mounted
+test -w "$HOME/.claude" && echo state tree writable
+```
+Both must print. A read-only state tree fails everything downstream.
+
+---
+
+## Part 2 — Scaffold and wire (in container)
+
+**2.1** Scaffold the process contents. Choose the git answer deliberately — for this run,
+use `--no-git`, since exercising the more constrained path is more informative:
+
+```sh
+$HOME/<substrate>/shared/new-process.sh \
+    --dir "$HOME/<process>" \
+    --title "Validation run" \
+    --type ops \
+    --no-git
+```
+
+Expect four files and `Git: none, by choice.` Confirm `CLAUDE.md` records the decision:
+
+```sh
+grep -A2 '^## Retention' "$HOME/<process>/CLAUDE.md"
+```
+
+**2.2** Confirm the gate has no default — this must fail and create nothing:
+
+```sh
+$HOME/<substrate>/shared/new-process.sh --dir /tmp/gate-test --title X --type ops </dev/null
+test -e /tmp/gate-test && echo "FAIL: directory created" || echo "OK: nothing created"
+```
+
+**2.3** Wire the environment:
+
+```sh
+$HOME/<substrate>/shared/wire.sh
+```
+
+Expect five lines: rules, skills (11), hooks, settings, wired.
+
+**2.4** Run it again. Output must be identical — it runs on every container start.
+
+**2.5** Verify:
+
+```sh
+$HOME/<substrate>/shared/wire.sh --check    # exit 0
+```
+
+> *dax owns invoking 2.1 once and 2.3 on every start, and should gate startup on 2.5.*
+
+---
+
+## Part 3 — Verify the wiring took
+
+**3.1** Links resolve (`-e` is false for a dangling symlink, which is the failure that would
+otherwise be silent):
+
+```sh
+test -e "$HOME/.claude/rules/telos" && echo OK
+ls "$HOME/.claude/rules/telos/"          # the telos files
+readlink "$HOME/.claude/rules/telos"     # points into <substrate>, not a host path
+ls -l "$HOME/.claude/skills/" | head     # 11 symlinks
+```
+
+`readlink` printing a host path rather than a container path means wiring ran in the wrong
+place.
+
+**3.2** The settings fragment exists and `settings.json` was **not** touched:
+
+```sh
+jq '{env, permissions, hooks: (.hooks | keys)}' "$HOME/.claude/substrate-settings.json"
+cat "$HOME/.claude/substrate-root"
+```
+
+`env.SUBSTRATE_ROOT` set, `permissions.additionalDirectories` includes the substrate, three
+hook events present, marker file holds the substrate path.
+
+`~/.claude/settings.json`, `CLAUDE.md`, and `settings.local.json` must be **byte-identical** to
+what dax delivered. `wire.sh` never writes them; if any changed, that's a defect.
+
+**3.3** Start a Claude session with cwd `$HOME/<process>`, with dax delivering the fragment
+(see the contract below).
+
+**3.4** In session, run `/context`. Under **Memory files**, expect every file in `telos/` plus
+the process conventions. If they're absent, nothing else in this part will pass.
+
+Symlinks are displayed by their **resolved target**, not the link name, so the list shows
+`telos/BELIEFS.md` and `shared/PROCESS-CONTEXT.md` — not `~/.claude/rules/telos/BELIEFS.md` or
+`00-substrate.md`. `shared/PROCESS-CONTEXT.md` in the list *is* `00-substrate.md`; its absence
+under that name is correct. Seeing any `~/.claude/rules/...` path would mean something else is
+going on.
+
+Expect roughly 13k tokens of telos plus ~1.7k of conventions.
+
+**3.5** Confirm the hooks are actually registered, which is the same thing as confirming dax
+delivered the settings fragment:
+
+```sh
+tail -3 ~/.claude/discernment-instructions.log
+```
+
+`InstructionsLoaded` fires at session start, so entries timestamped from this session prove
+all three hooks are live. A missing or stale file means the fragment wasn't delivered — and
+therefore that the PreToolUse guard is not running. `/hooks` in-session shows the same thing.
+
+**Do not use a conversational question as the delivery test.** Asking "what substrate are you
+working from?" looks like it probes the SessionStart output, but Claude can answer it by
+running `git` itself, so a correct answer proves nothing. The tell that the hook was *not* the
+source is detail the hook never prints — a full-length SHA, a commit subject, a file-level
+breakdown — or the absence of detail it always prints, like the skill count.
+
+As a secondary check, the hook's exact two lines should appear in context: the mount path with
+a **short** hash, and `N skills linked`.
+
+**3.6** **Content probe — the real test.** File listings only prove files loaded. Ask something
+answerable *only* from telos:
+
+> What does my telos say about on-call work?
+
+A correct answer names on-call as incompatible with the margin goal and structurally
+pre-compressing margin before any incident. A vague or generic answer means telos is present
+as filenames but not as grounding.
+
+**3.7** Skills are discoverable — type `/` and confirm the five type skills and five thinking
+packs appear.
+
+**3.8** Auto-memory is isolated:
+
+```sh
+ls "$HOME/.claude/projects/"
+```
+Should key on the process directory, not on the substrate. Nothing from another process should
+appear.
+
+---
+
+## Part 4 — Verify the failure modes
+
+The whole architecture rests on these failing loudly rather than silently. Test them.
+
+> **Restart a Claude session, not a dax session.** `wire.sh` runs on every container start, so
+> restarting the container repairs whatever you just broke and the test silently passes for the
+> wrong reason. Self-healing is a feature everywhere except in Part 4. Break the wiring, then
+> either stay in the session you're in or exit and re-run `claude` — without letting `wire.sh`
+> run in between.
+
+**4.1 Dangling rules link.**
+
+```sh
+mv "$HOME/.claude/rules/telos" "$HOME/.claude/rules/telos.bak"
+```
+
+The PreToolUse guard stats the filesystem on every tool call, so this should block tool use
+**immediately, in the session already running** — no restart required. Expect every tool call
+refused, with Claude reporting the substrate is missing and stopping rather than working
+around it. Restarting `claude` additionally surfaces the SessionStart warning in context.
+
+Probe with two tools at once, so a single blocked call isn't mistaken for a tool-specific rule:
+
+> Read /etc/hostname and run `echo hi`
+
+Both must be refused. Note that the UI renders **attempted** calls the same way it renders
+completed ones — a line reading `Read 1 file, ran 1 shell command` above a block report means
+both were attempted and both were denied, not that either ran. Judge by whether output came
+back, not by the tool-call line.
+
+Blocking is deliberately blanket rather than scoped to "risky" tools. `Read` on `/etc/hostname`
+and `Read` on counterparty material are the same tool, so any carve-out for diagnostics is a
+carve-out for ungrounded process work — and a partly working session invites continuing rather
+than repairing. Repair happens from a container shell, not from inside the session, so nothing
+needed is lost.
+
+Restore with `wire.sh`.
+
+**4.2 Unresolvable substrate root.** The hooks resolve `$SUBSTRATE_ROOT` first and fall back to
+`~/.claude/substrate-root`, so breaking this needs both gone at once — and the env var is fixed
+in a running session, so deleting only the marker proves nothing there. To test the fallback
+chain live, delete the marker *and* start a fresh `claude` with the fragment's `env` block
+removed.
+
+This one is lower value than it looks: the fail-closed behavior is deterministic and already
+verified outside the container. If short on time, skip it and spend the effort on 4.3.
+
+Restore with `wire.sh`.
+
+**4.3 Substrate unmounted.** The exception to the note above — this one *requires* a dax
+restart, since changing mounts is what's being tested, and `wire.sh` running is part of the
+expected behavior rather than something to avoid.
+
+Stop the container, remove the substrate mount from the env, restart.
+
+**`wire.sh` cannot report this failure — it lives on the mount, so it is gone too.** Invoking
+it fails at the shell with "no such file or directory" (exit 127), not with a message from the
+script. That is a distinct case from a mounted-but-broken substrate, where the script does run
+and refuses with `no telos/ at <path> — not a substrate repo` (exit 1). Both are non-zero, so a
+dax gate on non-zero catches both, but they need different error messages.
+
+If a session starts anyway, the guard must block every tool call: the state-tree symlinks
+survive the unmount as **dangling** links, which still look present in a directory listing
+while resolving to nothing and reporting nothing on their own.
+
+**This is the failure mode the split introduces and the single most important test here** —
+the old single-repo layout could not produce it, because the substrate and the process were
+the same directory.
+
+**4.4 Confirm SessionStart alone is not enough.** With the substrate broken, note that the
+session still *starts* — SessionStart cannot abort. The guard is what makes it inert. If tool
+calls succeed while the substrate is broken, the design has failed.
+
+---
+
+## Part 5 — Feedback path
+
+**5.1** From the process session, edit something in the substrate — add a line to
+`telos/WISDOM.md` or a note to a skill.
+
+**5.2** Commit it *in the substrate repo*, generalized: no proper names, no situational detail.
+
+**5.3** Confirm the process directory is untouched by that commit — separate repos, separate
+histories.
+
+**5.4** Start a new session and confirm `substrate-check.sh` reports the new commit, and
+reports uncommitted changes when the substrate is left dirty.
+
+> *5.1–5.4 must work identically for a `--no-git` process. That's the point: version control
+> in the process directory is independent of write access to the substrate.*
+
+---
+
+## Part 6 — Teardown
+
+Not yet built, and the half that matters most for deletability.
+
+**6.1** Destroy the process directory, the dax env, and the state tree.
+
+**6.2** Confirm the auto-memory pool is gone:
+
+```sh
+ls "$HOME/.claude/projects/"   # from a different env — the process's namespace must be absent
+```
+
+**6.3** Confirm nothing about the process reached the substrate repo:
+
+```sh
+git -C "$HOME/<substrate>" log --all -p | grep -i "<process name or counterparty>"
+```
+No hits. If there are, the write-back rule was not followed and the history is not scrubbable.
+
+> *dax owns `destroy-process`. Auto-memory is the piece most easily left behind: it lives in
+> the state tree, outside git, and accumulates situational detail nobody explicitly wrote.*
+
+---
+
+## The dax contract
+
+Everything dax must do. This is the authoritative list — `README.md` explains *why* each
+piece exists, but implement from here.
+
+### 1. Mounts
+
+| Mount | Container path | Mode | Why |
+|---|---|---|---|
+| process directory | `$HOME/<process>` | rw | the working directory |
+| substrate repo | `$HOME/<substrate>` | rw | read-only breaks the feedback path |
+| env state tree | `$HOME/.claude` | rw | `wire.sh` writes `rules/`, `skills/`, `hooks/` here |
+
+dax chooses all three names. **Nothing in the substrate depends on them** — the scripts
+self-locate via `dirname $0`, so renaming or relocating the substrate is a one-line change
+here and nowhere else.
+
+### 2. `new-process` — once, at creation
+
+```sh
+$HOME/<substrate>/shared/new-process.sh \
+    --dir "$HOME/<process>" --title "..." --type <type> (--git | --no-git)
+```
+
+- Prompt the user for title, type, **and the git decision**.
+- Read valid types from `$HOME/<substrate>/shared/process-types.tsv`. Do not hardcode them —
+  adding a process type must not require a dax release.
+- **The git decision has no default.** Passing neither flag non-interactively is an error, by
+  design: choosing git when you shouldn't have is unfixable, since history can't be
+  selectively scrubbed. Surface it as a real question, not a checkbox with a preselected value.
+- Under `--git` the script inits the repo and makes the first commit. Under `--no-git` it
+  writes files only. **Do not create a repository yourself**, and do not add a remote — a
+  remote reproduces the deletability problem one layer out.
+
+### 3. `wire.sh` — every container start
+
+```sh
+$HOME/<substrate>/shared/wire.sh --quiet
+```
+
+Idempotent, and intended to run on **every** start rather than once at creation, so wiring
+drift self-heals when the substrate changes. Must run **after mounts are up and before the
+session starts.**
+
+### 4. Deliver the settings fragment — **required**
+
+`wire.sh` writes `$HOME/.claude/substrate-settings.json`. It deliberately does **not** write
+`~/.claude/settings.json`, `CLAUDE.md`, or `settings.local.json`, because dax delivers those
+from a synced global file — a write there would be clobbered on the next sync or silently
+detached from what the session reads.
+
+dax must deliver the fragment. Either route works:
+
+```sh
+claude --settings "$HOME/.claude/substrate-settings.json"     # loads additional settings
+```
+or merge the fragment into the settings dax already syncs.
+
+The fragment carries three things: `env.SUBSTRATE_ROOT`, `permissions.additionalDirectories`
+(write access for the feedback path), and the three hooks.
+
+**If delivery is skipped, the session still grounds correctly** — rules and skills are
+directory-based and load with no settings at all. What's lost is the verification layer: no
+substrate report at session start, and **no PreToolUse guard**, which is the thing that makes
+a broken mount fail loudly instead of silently. Treat delivery as mandatory.
+
+### 5. Gate startup
+
+```sh
+$HOME/<substrate>/shared/wire.sh --check      # exit 0 = wired
+```
+
+Refuse to launch on non-zero, and distinguish the two failures — they have different causes and
+different fixes:
+
+| Exit | Meaning | Fix |
+|---|---|---|
+| `127` / command not found | **the substrate isn't mounted** — the script is on the mount, so it's gone with it | repair the mount in the env definition |
+| `1` | substrate mounted but incomplete, wrong, or not wired | run `wire.sh`; if it still fails, the mount points at the wrong repo |
+| `0` | wired | — |
+
+A missing script cannot report its own absence, so dax must treat "command not found" as a
+first-class failure rather than assuming a non-zero exit came from the script.
+
+This verifies the substrate *side* only. Whether dax actually delivered the settings fragment
+can't be checked from inside the substrate — step 3.5 is the end-to-end test for that.
+
+### 6. `destroy-process`
+
+Remove **all three**: the process directory, the env, and the state tree. Auto-memory lives at
+`~/.claude/projects/<repo>/memory/`, outside git, and accumulates situational detail nobody
+explicitly wrote. It is the piece most easily left behind, and leaving it behind means the
+deletion was not real.
+
+### What dax must not do
+
+- Don't hardcode the substrate's name or path — it moves, and the scripts don't care.
+- Don't hardcode the process types — read the TSV.
+- Don't create the process repo or a remote — `new-process.sh` owns that, gated on `--git`.
+- Don't default the git decision.

--- a/docs/testing/2026-07-30-cred-management-test-sequence.md
+++ b/docs/testing/2026-07-30-cred-management-test-sequence.md
@@ -1,0 +1,332 @@
+# Credential Management — Manual Test Sequence
+
+Written 2026-07-30, after the container rebuild that picked up the C2/C3/C4
+credential work (see `docs/design/2026-07-27-tenant-isolation.md` decisions
+C, C2, C3, C4 and G2).
+
+**Why a manual sequence at all.** The automated suite covers resolution,
+naming, listing, and the import guards, but three things it cannot reach are
+exactly where the real bugs were: the macOS **Keychain**, the **Chrome profile**
+a login opens, and whether two credentials are **the same OAuth grant**. The
+2026-07-30 sharing bug (C3) passed every unit test and authenticated perfectly.
+Only step 3 below catches that class of failure.
+
+**Where things run.** `dax` commands that touch credentials are **host**
+(macOS) commands — keyring is unreachable from inside a container, so
+`dax creds list` there always reports `stored: no` / `[!] key on disk`. Env
+commands are host commands too: `~/.dax.yaml` records host paths
+(`/Users/dfarrow/...`), so `dax env show` from inside a container can't match
+cwd to an env.
+
+Run the steps in order. Steps 0–4 are non-destructive; step 5 mints a real
+OAuth grant; step 6 overwrites a stored secret.
+
+---
+
+## 0. Container — did the rebuild take?
+
+Run inside a freshly launched container, from the repo:
+
+```bash
+python3 -m pytest -q
+diff -rq /usr/local/lib/python3.14/dist-packages/dax_creds ./dax_creds \
+    -x __pycache__ -x '*.pyc'
+diff -q /usr/bin/claude ./dax_creds/wrappers/claude
+python3 -c "import ruamel.yaml; print('ok')"
+dax-creds list
+env | grep DAX_CREDS_CLAUDE
+```
+
+| Check | Expected output |
+| --- | --- |
+| pytest | `342 passed` (as of 2026-07-30) |
+| installed `dax_creds` vs repo | exactly `Only in ./dax_creds: wrappers` — **and nothing else.** That one line is expected: wrappers install to `/usr/bin`, not into the package. Any other line means the image is running different code than the repo. |
+| `/usr/bin/claude` vs repo wrapper | **no output** → identical → inject-if-absent shipped |
+| `ruamel.yaml` | `ok` (the `Dockerfile.tmpl` pip line took) |
+| `dax-creds list` | the env's resolved credential names, e.g. `claude-personal-dax  claude` |
+| `DAX_CREDS_CLAUDE` | `claude-<tenant>-<project>`, e.g. `claude-personal-dax` |
+
+Two of the six pass by printing **nothing** — the `diff -q` on the wrapper, and
+`diff -rq` if wrappers ever stop being the only difference. Silence is the pass
+there; count the lines rather than skimming, because a missing check reads
+identically to a passing one. Expect four blocks of output from six commands.
+
+The last two are the end-to-end proof that C2's derived naming survives all the
+way from `~/.dax.yaml` through `dax run` into the container's environment.
+
+**This matters because `dax_creds` in a container is a frozen, non-editable
+install.** Editing the repo changes nothing about what the container actually
+runs until the image is rebuilt; the `diff -rq` above is what tells you the two
+are in step.
+
+Recorded 2026-07-30: all six passed, confirmed twice in separate containers.
+
+## 1. Host — editable install took, and the config round-trip is byte-stable
+
+```bash
+cd ~/fatsec/dax && pip install -e . && python3 -c "import ruamel.yaml; print('ok')"
+cp ~/.dax.yaml /tmp/dax.yaml.bak
+dax env set dax tenant personal        # writes through save_config
+diff /tmp/dax.yaml.bak ~/.dax.yaml     # must be empty
+```
+
+Expect `[dax] tenant: personal -> personal` from the set, and an **empty diff**
+— meaning comments, key order, long unwrapped `dir:` paths, and the
+commented-out `#- claude_tenant_state` toggle all survived a real write.
+
+Setting the field to the value it already holds is a **valid** probe here:
+`run_env_set` calls `save_config(config)` unconditionally, with no equality
+short-circuit (`dax_creds/init.py:649`), so a no-op value still triggers a full
+serialize-and-rewrite. That's the point — it exercises the write path while
+leaving the file's *content* unchanged, so any diff at all is pure round-trip
+damage rather than the edit you asked for. Verified 2026-07-30.
+
+The host is an editable install and the container is not, so this step gates
+everything else on the host side.
+
+## 2. Host — resolution and listing agree with each other
+
+```bash
+dax creds list
+dax env show dax
+dax envs list
+```
+
+- `dax creds list`: one row per derived Claude credential, tagged `(derived)`,
+  `stored: yes`, and a populated "used by" column. On the host this column is
+  meaningful — it's Keychain-backed.
+- `claude-fre` should show as used by **nothing**. That's the credential whose
+  name was typo'd (`claud-fre` in an env's `creds:`) and sat unused for weeks;
+  the resolving "used by" column is what finally makes it read as dead.
+- `dax env show dax`: prints the *resolved* credential name, so the derived
+  convention is visible rather than magic.
+- `dax envs list`: TENANT/STATE/USED columns; `?` marks a state tree with no
+  registry entry, `!` a missing directory, `*` running.
+
+Cross-check against step 0's `dax-creds list`. Host and container disagreeing
+about which credentials exist is itself the bug C4's related fix closed.
+
+## 3. Host — grant independence (**the load-bearing check**)
+
+```bash
+python3 tests/manual/check_claude_grants.py
+```
+
+Expect `PASS — N distinct grant(s) across N credential(s); no sharing.`
+
+Per-env credentials only isolate anything if **each came from its own login**.
+Two entries holding the same refresh token are one grant wearing two names:
+they authenticate fine, nothing looks wrong, and a rotation on either kills
+both. That is precisely what happened on 2026-07-30 (C3). No other check in
+this document, and no test in the suite, detects it.
+
+Also read the final line:
+
+```
+~/.claude/.credentials.json  grant:abc123def456  matches: claude-personal-dax
+```
+
+While `feature_claude` still mounts `~/.claude` wholesale, whichever env wrote
+last owns that file and *every* non-tenant-state container reads it. This line
+tells you which env's grant your sessions are actually running on.
+
+Refresh tokens are never printed — only a 12-char hash, enough to compare.
+Exits non-zero on any sharing, and prints the `dax creds remove` commands to
+clear the duplicates.
+
+**What a PASS does and does not prove.** The refresh token stands in for grant
+identity because the blob carries no grant ID. That catches a copy only while
+both entries still hold the same token: if each side refreshes independently
+afterward, both get new tokens while still descending from one grant, and this
+reports PASS. Read the `refresh expires` column alongside it — dates spread
+across the days the logins actually happened corroborate separate mints; tightly
+clustered dates with differing tokens is the shape a shared-then-rotated grant
+would take. A PASS is strongest immediately after minting, so run this **right
+after** step 5 rather than only weeks later.
+
+Recorded 2026-07-30: PASS, 4 distinct grants across 4 credentials, refresh
+expiries staggered 08-27 / 08-28 / 08-29 / 08-28 — consistent with separate
+mints on separate days. `~/.claude/.credentials.json` matched
+`claude-personal-dax`.
+
+## 4. Host — C3 and C4 in a single launch, non-destructively
+
+```bash
+dax creds login claude-personal-fabric
+```
+
+Observe two things from this one run, then **cancel without completing** —
+close the browser tab, or Ctrl-C:
+
+1. **C4:** it opens **Chrome, Profile 2** — not the default browser. This
+   proves the top-level `credential_defaults: {claude: {browser, chrome_profile}}`
+   block reached the *synthesized* definition. A derived credential has no
+   `credentials:` entry to carry those keys, so before C4 every per-env login
+   opened the wrong browser.
+2. **C3:** on cancel it **refuses to import** and reports that the provider's
+   on-disk token was unchanged. Previously `_post_login_import` ran
+   unconditionally after `subprocess.run()`, read the existing shared token out
+   of `~/.claude/.credentials.json`, and stored it under the new per-env name.
+
+Then re-run step 3 and confirm no new shared grant appeared.
+
+This mints nothing and costs one cancelled browser tab, which makes it the
+cheap regression test for the bug that drove this entire pass. Run it first,
+before step 5 changes any state.
+
+**If you complete the flow instead of cancelling, it is not read-only.**
+`_LOGIN_PROVIDERS['claude']` mounts the host's `~/.claude` (`dax.py:644`), so a
+successful login writes its new credential into the **shared**
+`.credentials.json`. While `feature_claude`'s wholesale mount is still in use,
+that repoints *every* container: inject-if-absent skips a non-empty file, so each
+one then authenticates on whichever env logged in last, regardless of its own
+`DAX_CREDS_CLAUDE`. Re-run step 3 afterward and read the "matches" line to see
+which env owns the shared file now. (This is also why the C3 guard works — the
+flow writes to the same file it snapshots.)
+
+Recorded 2026-07-30: run after the C5 fix. Chrome opened on Profile 2, the
+device-flow `redirect_uri` was rewritten to
+`platform.claude.com/oauth/code/callback`, the flow was **completed** rather than
+cancelled, and the grant hash changed `49a03025bda2` → `56b0ef07fcbe` — direct
+proof of a new grant, since a copy would have carried another credential's hash.
+The
+shared file's owner moved from `claude-personal-dax` to `claude-personal-fabric`.
+
+A second run was then **cancelled** at the paste-code prompt, confirming the C3
+refusal live: the "predates this login" message printed and Keychain was
+untouched (`56b0ef07fcbe` unchanged). Both halves of step 4 are now confirmed
+against real infrastructure. See decision C6 for the residual hole this
+inspection turned up — the guard compares the whole on-disk envelope, so a token
+refresh landing inside the login window can still let an abandoned login import
+another env's grant.
+
+## 5. Host — mint a real per-env grant
+
+```bash
+dax creds remove claude-personal-dax    # derived → clears Keychain only, no config write
+dax creds login claude-personal-dax     # complete it this time
+python3 tests/manual/check_claude_grants.py
+```
+
+Expect a **distinct** grant hash for `claude-personal-dax`, different from every
+other row.
+
+`dax creds remove` on a derived name is exempt from the still-referenced
+refusal: the reference is the naming convention itself, which survives removal
+and simply re-mints on the next run. Before C3's corollary fix, a derived
+credential couldn't be removed at all — it was rejected as unknown, so a bad
+one was unclearable.
+
+**Use `login`, never `add`.** `dax creds add`'s claude path still imports from
+`~/.claude/.credentials.json` with no before/after guard, so minting a derived
+name that way would silently share a grant — the exact C3 failure, through the
+one door that's still open. This is a known gap, not an oversight of this doc.
+
+## 6. Host — a confirmed overwrite actually overwrites (OPTIONAL, low value)
+
+**Downgraded 2026-07-30 after reading the code paths.** All three behaviors are
+already covered by unit tests (`tests/test_dax_creds_init.py:281–320`: replace
+rewrites the secret, replace reports "left in place", no-replace still skips),
+and running it live carries a real hazard, so this is optional rather than part
+of the required pass.
+
+**The hazard: `dax creds add` on an existing credential is lossy.**
+`_define_credential` rebuilds the definition from scratch (`init.py:113`) and
+`_run_creds_add` assigns it wholesale (`init.py:369`), so **any field the prompts
+don't ask for is silently dropped**. Use `dax creds update` for metadata edits.
+Copy the entry out of `~/.dax.yaml` before running this, and retype every field
+exactly.
+
+Target selection matters, and the obvious choice is wrong:
+
+| Target | Rebuild | Reaches the "left in place" message? |
+| --- | --- | --- |
+| `github-dbfarrow` | lossless (`{browser, provider}`) | **no** — with no `client_id` it exits at "skipped — no client_id provided" |
+| `gmail-personal` | lossless only if `client_id`, `client_secret`, `scopes` are retyped exactly | **yes** — goes straight to `_report_no_token` |
+| `claude-fre` | lossless | yes, but **never do this** — claude's replace path calls `import_from_disk`, copying whatever is in the shared `~/.claude/.credentials.json` into this name and manufacturing the shared grant C3 exists to prevent |
+
+So if you run it, run it on `gmail-personal`:
+
+```bash
+dax creds add        # name: gmail-personal, answer yes to "Overwrite it?", provider: gmail
+```
+
+Expect `no token found` plus the two "left in place" lines — where **not**
+overwriting is the correct outcome, since Google's setup has nothing to import.
+The pass condition is that the early-exit was bypassed at all: without
+`replace=`, this prints `refresh token already in Keychain` and stops.
+
+The old `if provider.check(...): return` early-exit made that confirmation a
+lie — YAML metadata was rewritten while the Keychain secret went untouched, so
+a rotated credential couldn't be re-imported without `dax creds remove` first.
+Every `_setup_*_credential` now takes `replace=`, set only on a confirmed
+overwrite.
+
+If nothing new is found to store, it must say **explicitly that the old secret
+survived** and how to clear it — not print the ordinary "no token found" and
+leave you believing the store was emptied.
+
+## 7. Container — end-to-end, per-env credential in use
+
+```bash
+dax run dax
+# inside the container:
+env | grep DAX_CREDS_CLAUDE                    # claude-personal-dax
+stat -c %y ~/.claude/.credentials.json
+claude                                          # authenticates
+```
+
+Then test both halves of inject-if-absent:
+
+- Exit `claude`, relaunch it, `stat` again → **mtime unchanged.** The wrapper
+  did not clobber a live token with the Keychain snapshot.
+- `rm ~/.claude/.credentials.json`, relaunch → recreated from Keychain. The
+  wrapper's test is `-s`, not `-e`, so a zero-byte file left by an interrupted
+  write also counts as absent.
+
+Keychain is a **bootstrap**; Claude Code owns rotation from first launch onward.
+
+## 8. Multi-day soak — the residual unknown
+
+Two things only time reveals:
+
+- **Cross-grant independence.** Use env A's Claude session, then launch env B's,
+  then return to A. All must keep working. It's unknown whether Anthropic caps
+  concurrent grants per account or invalidates older grants for the same
+  `client_id`.
+- **Refresh-token rotation.** Re-run step 3 after several days. No env's
+  credential should have died. Because teardown write-back to Keychain is
+  **not built** (deferred by choice — decision C), the Keychain snapshots go
+  stale by design. Inject-if-absent is what makes that survivable: a stale
+  snapshot is never forced over the tree's working token.
+
+---
+
+## What this sequence cannot yet reach
+
+`feature_claude_tenant_state` is still in its **pre-redesign shape**. It mounts
+trees at `~/.local/state/dax/tenants/<tenant>/<project>` and still emits
+`DAX_MULTI_TENANT`/`DAX_TENANT_SUBDIR`, and the `claude` wrapper still carries
+Gate B calling `dax-creds resolve-tenant`. **Decision B — state tree mounted at
+`~/.claude` with `CLAUDE_CONFIG_DIR` as a constant — is not built.**
+
+So step 7 exercises inject-if-absent under the **shared** `~/.claude` mount,
+where the divergence it exists to prevent cannot actually arise: there's one
+tree, and Claude Code refreshes it in place. The failure mode the logic guards
+against — a session refreshing into its own persistent per-project tree, and
+the next launch overwriting it with the stale Keychain snapshot — stays
+unit-tested only until decision B lands.
+
+**Do not enable `claude_tenant_state` to test this.** You would be exercising
+the abandoned multi-tenant design, whose code is slated for deletion (decision
+E), not extension.
+
+## Known-open items, so a failure here isn't misread as a regression
+
+- `dax creds add`'s claude path has no `_disk_token_for` guard (step 5).
+- Teardown write-back to Keychain is deferred (step 8).
+- A credential named literally `claude` would collide with the bare token in an
+  env's `creds:` list. Not blocked in `dax creds add`.
+- Debug scaffolding still present: `~/.dax-debug/open-url.log` in the
+  `dax-creds-open-url` wrapper, and the `~/.dax-debug` mount in
+  `_LOGIN_PROVIDERS`.

--- a/docs/testing/2026-07-31-migrate-env-to-state-tree.md
+++ b/docs/testing/2026-07-31-migrate-env-to-state-tree.md
@@ -9,6 +9,20 @@ choice.
 Every step runs on the **host**. The destination tree is not mounted into any
 container except the one that owns it, so a container cannot migrate itself.
 
+**Steps 1-5 are scripted** — `tools/migrate_env_state.py <env>` does the
+preconditions, the transcript copy, the history filter, and the credential and
+`.claude.json` checks, dry-run by default:
+
+```bash
+python3 tools/migrate_env_state.py dax            # shows the plan
+python3 tools/migrate_env_state.py dax --apply
+```
+
+It deliberately does **not** touch `~/.dax.yaml` (step 6 stays a manual
+`dax env set`) and does not handle `.claude.json` (step 4), which has to be copied
+out of the running container before shutdown. The prose below is the reference for
+what it does and why, and for the steps it leaves to you.
+
 ---
 
 ## What is actually per-env, and how it separates

--- a/docs/testing/2026-07-31-migrate-env-to-state-tree.md
+++ b/docs/testing/2026-07-31-migrate-env-to-state-tree.md
@@ -25,6 +25,54 @@ what it does and why, and for the steps it leaves to you.
 
 ---
 
+## When the env predates its container: `--legacy-cwd`
+
+Everything above assumes the env has always run inside a dax container, so it
+has exactly one `projects/` key — the flat one `workdir_name` produces. That
+assumption breaks for a directory being migrated *out of* a larger host tree it
+used to be a plain subdirectory of (discernment's per-process repo split is the
+case that surfaced this, 2026-08-01, once the real host `~/.claude/projects/`
+was visible from inside a container via `mounts: ['~/.claude:host-claude']`).
+
+Checked against real data for the `self-employment-setup` process, which used to
+live at `~/work/processes/self-employment-setup`:
+
+| key | what it is | migrate? |
+| --- | --- | --- |
+| `-home-dfarrow-work-processes-self-employment-setup` | this process's own nested-path key — 1 session, 30MB, 21 `history.jsonl` lines | yes, via `--legacy-cwd` |
+| `-home-dfarrow-work-processes` | sessions recorded with cwd at the parent, before/without `cd`-ing into the process dir — 155 `history.jsonl` lines, shared across every process ever nested there | **no** — no reliable way to attribute one line to one process without reading it |
+| `-home-dfarrow-work` | same problem one level further up — 1858 `history.jsonl` lines | **no** |
+
+Pass every historical cwd explicitly — the tool cannot infer them, since a
+rename or restructure is exactly what makes the old path differ from the new
+one:
+
+```bash
+python3 tools/migrate_env_state.py self-employment-setup \
+  --legacy-cwd /home/dfarrow/work/processes/self-employment-setup
+```
+
+`--legacy-cwd` is repeatable, for a process that moved more than once. Each
+legacy cwd's `projects/<key>/` copies into the tree as **its own directory**,
+not merged into the canonical key's — Claude Code's `/resume` is scoped to the
+container's current cwd, so merging wouldn't make old sessions resumable
+anyway, while keeping them separate keeps provenance honest. Its
+`history.jsonl` lines are filtered in by exact match on the literal legacy path
+alongside the canonical one.
+
+Every run — with or without `--legacy-cwd` — prints a **discovery report**
+first: any other `projects/` key ending in this env's name that wasn't passed
+(a legacy cwd you forgot), and any ancestor key of one being migrated (a real
+`projects/` directory that is itself a dash-prefix of a migrated key, i.e. the
+commingled-parent case above), each with its real path and `history.jsonl` line
+count pulled from actual recorded data — never a guess, since the dash-mangled
+key can't be reversed reliably on its own. Ancestor lines are reported, never
+copied. Read them before deciding whether anything in there is worth hand-
+copying; the tool won't do it for you because it can't tell whose session was
+whose.
+
+---
+
 ## What is actually per-env, and how it separates
 
 Checked against the real shared directory rather than assumed. The good news is

--- a/docs/testing/2026-07-31-migrate-env-to-state-tree.md
+++ b/docs/testing/2026-07-31-migrate-env-to-state-tree.md
@@ -1,0 +1,177 @@
+# Migrating an Env's Claude State Into Its Own Tree
+
+Runbook for moving one env off `feature_claude`'s shared `~/.claude` mount and onto
+`claude_tenant_state` (decision B) **without losing its accumulated session
+state**. Written 2026-07-31 while migrating `dax`; `fabric` was switched over
+without a migration and started from an empty tree, which is the other valid
+choice.
+
+Every step runs on the **host**. The destination tree is not mounted into any
+container except the one that owns it, so a container cannot migrate itself.
+
+---
+
+## What is actually per-env, and how it separates
+
+Checked against the real shared directory rather than assumed. The good news is
+that the two big items carry their own scoping key:
+
+| Item | Size | Per-env? | How |
+| --- | --- | --- | --- |
+| `projects/<mangled-cwd>/` | 6.3M for dax | **yes** | Directory name *is* the container cwd (`/home/dfarrow/dax` → `-home-dfarrow-dax`). Holds the session transcripts and the auto-memory dir. |
+| `history.jsonl` | 756K total, 92 of 2185 lines were dax | **yes, filterable** | Every line carries a `project` field holding the container cwd. |
+| `~/.claude.json` | 35K | **already** | Its `projects{}` block had exactly one key, `/home/dfarrow/dax`. Copy wholesale. |
+| `file-history/` | 9.6M, 27 dirs | mappable | Keyed by session UUID, and the env's UUIDs are the `.jsonl` filenames in its `projects/` dir. Low value (edit-undo history) — skip unless you want it. |
+| `paste-cache/`, `shell-snapshots/`, `backups/`, `cache/`, `sessions/`, `tasks/` | small | no | Regenerable or not worth mapping. |
+| `CLAUDE.md`, `settings.json`, `settings.local.json` | 2K | **no — user-level** | Mounted read-only into every tree by the feature. Do not copy. |
+
+The mangled name is stable across the migration: `workdir_name` doesn't change, so
+the container cwd stays `/home/dfarrow/<env>` and Claude Code keeps using the same
+`projects/` key.
+
+## 0. Prerequisite
+
+The env must already have a `tenant`, and the feature must mount the user-level
+files. Confirm both:
+
+```bash
+dax env show <env> | grep -E 'tenant|state'
+grep -n "_CLAUDE_HOST_SHARED_FILES" ~/fatsec/dax/dax.py
+```
+
+Without the second, the tree mount hides your global `CLAUDE.md` and settings —
+silently. `fabric` ran a full day that way before it was noticed.
+
+## 1. Stop the env's container
+
+The transcript is being appended to while a session is live, so a copy taken
+mid-session is torn.
+
+```bash
+docker ps --filter name=<container> --format '{{.Names}}'   # expect nothing
+```
+
+## 2. Copy the transcripts and memory
+
+```bash
+ENV=dax
+KEY=-home-dfarrow-$ENV
+TREE=~/.local/state/dax/tenants/personal/$ENV
+
+mkdir -p "$TREE/projects"
+cp -a ~/.claude/projects/$KEY "$TREE/projects/"
+du -sh "$TREE/projects/$KEY"        # expect to match the source
+```
+
+`cp -a`, not `mv`: the original stays until the migrated env has run cleanly. It
+costs disk and nothing else, and it is the only rollback.
+
+## 3. Filter this env's shell history into the tree
+
+```bash
+python3 - <<PY
+import json, pathlib
+env_cwd = '/home/dfarrow/$ENV'
+src = pathlib.Path.home() / '.claude' / 'history.jsonl'
+dst = pathlib.Path("$TREE") / 'history.jsonl'
+kept = [l for l in src.read_text().splitlines()
+        if l.strip() and json.loads(l).get('project') == env_cwd]
+dst.write_text('\n'.join(kept) + '\n')
+print(f'{len(kept)} lines -> {dst}')
+PY
+```
+
+Filtered rather than copied: the shared file holds every env's prompts, and moving
+it wholesale would pool other envs' history into this tree — the exact thing the
+isolation is for. Arrow-up history then contains only this env's prompts, which is
+decision 11's stated intent.
+
+## 4. Seed `.claude.json` from the live container copy
+
+This is the file that would otherwise cost you the trust dialog, `allowedTools`,
+and replayed tips (see the design doc's "Accepted costs" table). Take it from the
+env's most recent container if you still have it — its `projects{}` block is
+already scoped to that one env:
+
+```bash
+# from inside the env's container, before shutting it down:
+cp ~/.claude.json /tmp/claude-json-$ENV
+# then on the host:
+docker cp <container>:/tmp/claude-json-$ENV "$TREE/.claude.json"
+```
+
+If the container is already gone, skip this — the wrapper seeds
+`{"hasCompletedOnboarding": true}` on first launch, which is enough to reach a
+normal prompt. You lose only re-consent and tips.
+
+**Check before copying** that `projects{}` holds only this env's path:
+
+```bash
+python3 -c "
+import json; d=json.load(open('$TREE/.claude.json'))
+print(list((d.get('projects') or {}).keys()))"
+```
+
+More than one key means it came from a shared-mount host rather than a container,
+and copying it would carry other projects' state in.
+
+## 5. Confirm no stale credential
+
+```bash
+ls -la "$TREE/.credentials.json" 2>/dev/null && echo "DELETE THIS" || echo ok
+```
+
+A credentials file in the tree **blocks** the Keychain bootstrap: the wrapper
+injects only when the file is absent or empty (`-s`), never when it is merely
+invalid or stale. Delete it and let the env bootstrap from its own Keychain entry.
+
+## 6. Switch the env over
+
+```bash
+dax env set $ENV features claude_tenant_state
+dax env show $ENV                       # features: claude_tenant_state
+cd ~/fatsec/$ENV && dax -t run          # inspect before launching
+```
+
+The dry run must show `adding claude_tenant_state` (not `adding claude`), plus:
+
+```
+-e CLAUDE_CONFIG_DIR=/home/dfarrow/.claude
+--volume=…/state/dax/tenants/personal/<env>:/home/dfarrow/.claude
+--volume=/Users/dfarrow/.claude/commands:/home/dfarrow/.claude/commands
+--volume=/Users/dfarrow/.claude/plugins:/home/dfarrow/.claude/plugins
+--volume=/Users/dfarrow/.claude/CLAUDE.md:/home/dfarrow/.claude/CLAUDE.md:ro
+--volume=/Users/dfarrow/.claude/settings.json:/home/dfarrow/.claude/settings.json:ro
+--volume=/Users/dfarrow/.claude/settings.local.json:…:ro
+```
+
+Because per-env features are additive only, `claude` must not be in the global
+`features:` list — otherwise both target `~/.claude` and `dax run` refuses. Push
+`claude` down onto the envs still using the shared mount.
+
+## 7. Verify inside
+
+```bash
+echo $CLAUDE_CONFIG_DIR            # /home/dfarrow/.claude
+ls ~/.claude.json                  # must NOT exist — it belongs inside the tree
+ls ~/.claude/.claude.json          # here instead
+ls ~/.claude/projects/             # only this env's key
+wc -l ~/.claude/history.jsonl      # only this env's lines
+head -3 ~/.claude/CLAUDE.md        # your global instructions, via the ro mount
+claude                             # then /resume — the migrated sessions
+```
+
+`/resume` listing the migrated sessions is the real proof: transcripts, memory,
+and history all landed where Claude Code looks for them.
+
+## 8. Then, and only then, clean up the source
+
+After a successful session **and** a container restart that shows the state
+persisting:
+
+```bash
+rm -rf ~/.claude/projects/$KEY
+```
+
+Leave the shared `history.jsonl` alone — the other envs still on the shared mount
+are using it.

--- a/docs/testing/2026-07-31-shared-files-sync-test.md
+++ b/docs/testing/2026-07-31-shared-files-sync-test.md
@@ -1,0 +1,100 @@
+# Manual test: shared-files sync (`sync_claude_shared_files`)
+
+Verifies the copy-with-drift-detection mechanism that replaced the abandoned
+read-only file mount (see `CLAUDE.md`'s "Built, same day" note under decision
+B2). All host commands — the sync runs while `dax run` assembles the docker
+command, before any container exists, so no image rebuild is needed.
+
+## 0. Check where fabric's tree currently stands
+
+```
+diff ~/.claude/CLAUDE.md ~/.local/state/dax/tenants/personal/fabric/CLAUDE.md
+diff ~/.claude/settings.json ~/.local/state/dax/tenants/personal/fabric/settings.json
+```
+
+fabric's tree already holds a hand-copied `CLAUDE.md` from before this was
+built (see CLAUDE.md's item 2). If these differ, the first run below should
+warn rather than silently overwrite — that's expected, not a bug.
+
+## 1. First run under the new code
+
+```
+dax run fabric
+```
+
+- No warning + `diff` in step 0 showed no difference: confirm the tree still
+  matches host — nothing should have changed.
+- No warning + step 0 showed a difference: unexpected — the manifest has no
+  prior record, so a differing tree should have been treated as drift, not
+  silently overwritten. Worth investigating before trusting the mechanism.
+- Warning (`[!] fabric: CLAUDE.md in state tree differs from both host and
+  last-synced copy...`): expected if step 0 showed a difference. Confirm the
+  tree file is untouched, then:
+
+  ```
+  dax env accept-shared-files fabric
+  dax run fabric   # should be silent now
+  ```
+
+## 2. Host moves on — should sync silently
+
+```
+echo '<!-- sync test -->' >> ~/.claude/CLAUDE.md
+dax run fabric
+cat ~/.local/state/dax/tenants/personal/fabric/CLAUDE.md   # should show the new line
+```
+
+No warning expected — the tree's copy was untouched since the last sync, so
+this is the "host moved forward" case. Revert the host edit afterward:
+
+```
+sed -i '' '/<!-- sync test -->/d' ~/.claude/CLAUDE.md   # macOS sed
+```
+
+## 3. Tree edited independently — should warn, not clobber
+
+This is the actual risk the manifest exists to catch: a container can now
+write `~/.claude/CLAUDE.md` directly (a plain file, not a mount).
+
+```
+# inside the fabric container
+echo 'edited from inside the container' >> ~/.claude/CLAUDE.md
+exit
+```
+
+```
+# on the host
+echo '<!-- host moved on too -->' >> ~/.claude/CLAUDE.md
+dax run fabric
+```
+
+Expect the `[!]` warning, and the tree's file to still hold the in-container
+edit — not the host's. Then:
+
+```
+dax env accept-shared-files fabric
+cat ~/.local/state/dax/tenants/personal/fabric/CLAUDE.md   # now matches host
+```
+
+## 4. Confirm Claude Code actually sees it
+
+The original bug (2026-07-31) was silent loss — a wholesale tree mount simply
+made the global `CLAUDE.md` disappear, no error. Worth confirming once for
+real rather than trusting the file copy alone:
+
+```
+# inside the fabric container
+cat ~/.claude/CLAUDE.md   # should be the real global content
+claude                    # should behave per your global instructions
+```
+
+## 5. Manifest hygiene
+
+```
+cat ~/.local/state/dax/tenants/personal/fabric.shared-files.json
+ls ~/.local/state/dax/tenants/personal/fabric/   # manifest must NOT appear here
+```
+
+Sibling of the tree, three sha256 hashes, valid JSON — and absent from the
+tree itself, since anything inside it is what the container sees at
+`~/.claude`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "dax"
 dynamic = ["version"]
 requires-python = ">=3.7"
-dependencies = ["pyyaml", "questionary"]
+dependencies = ["pyyaml", "ruamel.yaml", "questionary"]
 
 [project.optional-dependencies]
 container = ["mcp", "python-docx", "lxml"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Test-wide guards.
+
+`HOME` is redirected for every test, because a dax container bind-mounts the real
+`~/.dax.yaml` **rw** — so a test that writes it does not corrupt a copy, it
+corrupts the developer's actual configuration on the host, including credential
+`client_id`/`client_secret` values that exist nowhere else.
+
+That happened on 2026-07-31: four tests called `run_env_set` with a synthetic
+config dict and no `HOME` isolation. `run_env_set` calls `save_config`
+unconditionally, so the suite overwrote the real config with fixture data
+(`dir: /repos/fabric`, `features: [anything]`), destroying four env definitions
+and eight credentials. Recovery depended on a backup that happened to exist.
+
+Redirecting by default rather than asking each test to remember is the fix: a
+test that genuinely wants a populated home writes one under the redirected path,
+which is what the existing per-module `home` fixtures already do (their own
+`monkeypatch.setenv` simply wins over this one).
+"""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path_factory, monkeypatch):
+    home = tmp_path_factory.mktemp('home')
+    monkeypatch.setenv('HOME', str(home))
+    return home

--- a/tests/manual/check_claude_grants.py
+++ b/tests/manual/check_claude_grants.py
@@ -65,10 +65,17 @@ def envelope(blob):
 
 
 def grant_id(oauth):
-    """Short hash of the refresh token — the grant's identity, not its value."""
+    """Short hash of the refresh token — the grant's identity, not its value.
+
+    **None** when there is no refresh token, deliberately rather than a sentinel
+    string. A sentinel compares equal to itself, so grouping by it reported every
+    credential that had *no* grant as all sharing *one* grant — three state trees
+    with junk files were flagged as an isolation failure on 2026-07-31. Absence of
+    an identity is not an identity; callers must exclude None from comparisons.
+    """
     token = oauth.get('refreshToken') or ''
     if not token:
-        return 'NO-REFRESH-TOKEN'
+        return None
     return hashlib.sha256(token.encode()).hexdigest()[:12]
 
 
@@ -151,16 +158,37 @@ def report_state_trees(keychain_grants):
     print(f'{"-" * 34}  {"-" * 14}  {"-" * 15}  {"-" * 20}')
 
     by_grant = {}
+    unusable = []
     for tree, blob in trees:
         oauth = envelope(blob)
         if oauth is None:
-            print(f'{tree:34}  (not a Claude envelope)')
+            print(f'{tree:34}  {"-":14}  {"-":15}  not a Claude envelope')
+            unusable.append(tree)
             continue
         gid = grant_id(oauth)
+        if gid is None:
+            # Excluded from the sharing comparison on purpose: no refresh token
+            # means no grant to share, and treating that as a value made three
+            # junk files look like an isolation failure.
+            print(f'{tree:34}  {"-":14}  {"-":15}  no refresh token')
+            unusable.append(tree)
+            continue
         by_grant.setdefault(gid, []).append(tree)
         match = name_for_grant.get(gid, 'nothing — see note below')
         print(f'{tree:34}  {gid:14}  '
               f'{when(oauth.get("refreshTokenExpiresAt")):15}  {match}')
+
+    if unusable:
+        print(f'\n  {len(unusable)} tree(s) hold a credentials file with no usable '
+              f'refresh token:')
+        for tree in unusable:
+            print(f'    {tree}')
+        print('  This blocks the Keychain bootstrap rather than being merely stale:')
+        print('  the wrapper injects only when the file is absent or empty (`-s`), not')
+        print('  when it is invalid — so the env starts unauthenticated and re-runs')
+        print('  onboarding. Delete the file and it will bootstrap on next launch:')
+        for tree in unusable:
+            print(f'    rm ~/.local/state/dax/tenants/{tree}/.credentials.json')
 
     if any(g not in name_for_grant for g in by_grant):
         print('\n  Note: a tree grant matching nothing in Keychain is expected, not')
@@ -199,6 +227,10 @@ def main():
             print(f'{name:34}  {names[name]:16}  (not a Claude envelope)')
             continue
         gid = grant_id(oauth)
+        if gid is None:
+            # Not grouped: see grant_id's docstring on why absence is not a value.
+            print(f'{name:34}  {names[name]:16}  (no refresh token — not refreshable)')
+            continue
         grants.setdefault(gid, []).append(name)
         print(f'{name:34}  {names[name]:16}  {gid:14}  '
               f'{when(oauth.get("refreshTokenExpiresAt")):15}  '

--- a/tests/manual/check_claude_grants.py
+++ b/tests/manual/check_claude_grants.py
@@ -102,6 +102,74 @@ def claude_credential_names(config):
     return names
 
 
+def state_tree_credentials():
+    """[(tenant/project, blob)] for every credential sitting in a state tree.
+
+    Under decision B each env's tree mounts at ~/.claude, so this is where the
+    *working* credential lives — Keychain only ever holds the bootstrap copy. An
+    audit that reads Keychain alone is therefore looking in the wrong place.
+    """
+    root = Path.home() / '.local' / 'state' / 'dax' / 'tenants'
+    found = []
+    if not root.is_dir():
+        return found
+    for path in sorted(root.glob('*/*/.credentials.json')):
+        try:
+            found.append((f'{path.parent.parent.name}/{path.parent.name}',
+                          path.read_text()))
+        except OSError:
+            continue
+    return found
+
+
+def report_state_trees(keychain_grants):
+    """Print each tree's grant. Returns {grant: [tree, ...]}.
+
+    Two findings here are unambiguous and worth acting on:
+
+      * the same grant in two trees — two envs sharing one refresh-token chain,
+        which is the isolation failure this whole design exists to prevent;
+      * a credential in a tree for an env that no longer exists, which is dead
+        weight holding a live grant.
+
+    A tree grant that matches *no* Keychain entry is **not** conclusive, and the
+    report says so rather than crying orphan. A refresh may rotate the refresh
+    token, and the grant id is a hash of that token, so a tree's id legitimately
+    drifts from its Keychain snapshot while still descending from the same grant.
+    Keychain is not updated on refresh — teardown write-back is deliberately not
+    built (decision C) — so drift is the expected steady state, not a red flag.
+    """
+    trees = state_tree_credentials()
+    print()
+    if not trees:
+        print('state trees: no credentials on disk '
+              '(~/.local/state/dax/tenants/*/*/.credentials.json)')
+        return {}
+
+    name_for_grant = {g: ', '.join(n) for g, n in keychain_grants.items()}
+    print(f'{"state tree":34}  {"grant":14}  {"refresh expires":15}  matches Keychain')
+    print(f'{"-" * 34}  {"-" * 14}  {"-" * 15}  {"-" * 20}')
+
+    by_grant = {}
+    for tree, blob in trees:
+        oauth = envelope(blob)
+        if oauth is None:
+            print(f'{tree:34}  (not a Claude envelope)')
+            continue
+        gid = grant_id(oauth)
+        by_grant.setdefault(gid, []).append(tree)
+        match = name_for_grant.get(gid, 'nothing — see note below')
+        print(f'{tree:34}  {gid:14}  '
+              f'{when(oauth.get("refreshTokenExpiresAt")):15}  {match}')
+
+    if any(g not in name_for_grant for g in by_grant):
+        print('\n  Note: a tree grant matching nothing in Keychain is expected, not')
+        print('  necessarily an orphan — a refresh rotates the refresh token this id')
+        print('  hashes, and Keychain is never updated on refresh. It *is* worth a look')
+        print('  when the tree belongs to an env you no longer have.')
+    return by_grant
+
+
 def main():
     config_path = Path.home() / '.dax.yaml'
     if not config_path.exists():
@@ -154,8 +222,22 @@ def main():
     else:
         print('~/.claude/.credentials.json  absent')
 
+    tree_grants = report_state_trees(grants)
+
     shared_grants = {g: n for g, n in grants.items() if len(n) > 1}
+    shared_trees = {g: t for g, t in tree_grants.items() if len(t) > 1}
     print()
+    if shared_trees:
+        print('FAIL — these state trees hold the same grant, so two envs are not '
+              'isolated:')
+        for gid, trees in shared_trees.items():
+            print(f'  grant:{gid}  {", ".join(trees)}')
+        print('\nDelete the credential from all but one and let each re-bootstrap:')
+        for trees in shared_trees.values():
+            for tree in trees:
+                print(f'  rm ~/.local/state/dax/tenants/{tree}/.credentials.json')
+        return 1
+
     if shared_grants:
         print('FAIL — these credentials are the same grant under different names:')
         for gid, sharers in shared_grants.items():

--- a/tests/manual/check_claude_grants.py
+++ b/tests/manual/check_claude_grants.py
@@ -18,6 +18,13 @@ passed every check except this one.
 Refresh tokens are never printed — only a short hash, enough to compare.
 Exits non-zero if any grant is shared.
 
+Since 2026-07-30 (decision C6) dax also enforces this at the moment of storing:
+`dax creds login` and `dax creds add` both refuse to store a Claude token whose
+grant already sits under another name. This script is therefore no longer the
+only detector — but it is still the only way to audit sharing that *already*
+exists, and the only check that runs where the Keychain does (the in-container
+check is inert, having no Keychain to compare against).
+
 LIMIT, and it bounds what a PASS is worth: the refresh token is a proxy for
 grant identity, not the identity itself — the blob carries no grant ID. A copy
 is caught only while both entries still hold the *same* token. If each side then

--- a/tests/manual/check_claude_grants.py
+++ b/tests/manual/check_claude_grants.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Check that each env's Claude credential is an independent OAuth grant.
+
+Run on the **host** (macOS), where the Keychain lives:
+
+    python3 tests/manual/check_claude_grants.py
+
+Per-env credentials only isolate anything if each one came from its own login.
+Two entries holding the *same* refresh token are one grant wearing two names:
+they authenticate fine, so nothing looks wrong, but a rotation on either kills
+both — and that is precisely the failure the per-env naming exists to prevent.
+
+It has happened for real (2026-07-30): a login abandoned at the browser step
+still ran the post-login import, which read the credential already sitting in
+~/.claude/.credentials.json and stored it under the new per-env name. The result
+passed every check except this one.
+
+Refresh tokens are never printed — only a short hash, enough to compare.
+Exits non-zero if any grant is shared.
+
+LIMIT, and it bounds what a PASS is worth: the refresh token is a proxy for
+grant identity, not the identity itself — the blob carries no grant ID. A copy
+is caught only while both entries still hold the *same* token. If each side then
+refreshes independently, each gets a new refresh token while still descending
+from one OAuth grant, and this check reports PASS. (Whether Anthropic rotates
+refresh tokens on use, and whether it invalidates the old one, is unverified —
+see the design doc's "Open gap: Claude refresh-token rotation".)
+
+So a PASS is strong evidence right after minting and weaker the longer the
+credentials have been in use. The `refresh expires` column is the corroborating
+signal: distinct dates spread across the days the logins actually happened
+support genuinely separate mints, whereas dates that cluster tightly while
+tokens differ is the shape rotation-from-a-shared-grant would produce.
+"""
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+KEYCHAIN_SERVICE = 'dax-creds'
+
+
+def keychain_secret(name):
+    result = subprocess.run(
+        ['security', 'find-generic-password', '-s', KEYCHAIN_SERVICE, '-a', name, '-w'],
+        capture_output=True, text=True)
+    return None if result.returncode else result.stdout.strip()
+
+
+def envelope(blob):
+    try:
+        oauth = json.loads(blob)['claudeAiOauth']
+    except (TypeError, ValueError, KeyError):
+        return None
+    return oauth if isinstance(oauth, dict) else None
+
+
+def grant_id(oauth):
+    """Short hash of the refresh token — the grant's identity, not its value."""
+    token = oauth.get('refreshToken') or ''
+    if not token:
+        return 'NO-REFRESH-TOKEN'
+    return hashlib.sha256(token.encode()).hexdigest()[:12]
+
+
+def when(ms):
+    if not ms:
+        return '?'
+    try:
+        return datetime.fromtimestamp(ms / 1000, timezone.utc).strftime('%Y-%m-%d')
+    except (TypeError, ValueError, OSError):
+        return '?'
+
+
+def claude_credential_names(config):
+    """Every Claude credential name: registered ones, plus those derived from
+    an env's bare `claude` token. Mirrors dax_creds.config's resolution, but
+    standalone so this script runs without importing dax."""
+    names = {}
+    for name, cred in (config.get('credentials') or {}).items():
+        if cred.get('provider') == 'claude':
+            names[name] = '(registered)'
+
+    for env_name, project in (config.get('projects') or {}).items():
+        tenant = project.get('tenant')
+        for entry in project.get('creds') or []:
+            if entry != 'claude':
+                continue
+            if not tenant:
+                print(f'  ! env {env_name!r} wants a claude credential but has no tenant')
+                continue
+            names[f'claude-{tenant}-{env_name}'] = env_name
+    return names
+
+
+def main():
+    config_path = Path.home() / '.dax.yaml'
+    if not config_path.exists():
+        sys.exit(f'no {config_path}')
+
+    try:
+        import yaml
+    except ImportError:
+        sys.exit('pyyaml required: pip install pyyaml')
+    config = yaml.safe_load(config_path.read_text()) or {}
+
+    names = claude_credential_names(config)
+    if not names:
+        sys.exit('no Claude credentials found in ~/.dax.yaml')
+
+    print(f'\n{"credential":34}  {"used by":16}  {"grant":14}  {"refresh expires":15}  access')
+    print(f'{"-" * 34}  {"-" * 16}  {"-" * 14}  {"-" * 15}  {"-" * 10}')
+
+    grants = {}
+    for name in sorted(names):
+        blob = keychain_secret(name)
+        if blob is None:
+            print(f'{name:34}  {names[name]:16}  (not in Keychain)')
+            continue
+        oauth = envelope(blob)
+        if oauth is None:
+            print(f'{name:34}  {names[name]:16}  (not a Claude envelope)')
+            continue
+        gid = grant_id(oauth)
+        grants.setdefault(gid, []).append(name)
+        print(f'{name:34}  {names[name]:16}  {gid:14}  '
+              f'{when(oauth.get("refreshTokenExpiresAt")):15}  '
+              f'{when(oauth.get("expiresAt"))}')
+
+    # The shared ~/.claude/.credentials.json, while feature `claude` still
+    # mounts it into every container. Whichever env wrote last owns it, and
+    # every container reads it — so a match here tells you which env's grant
+    # any non-tenant-state session is actually running on.
+    shared = Path.home() / '.claude' / '.credentials.json'
+    print()
+    if shared.exists():
+        oauth = envelope(shared.read_text())
+        if oauth:
+            gid = grant_id(oauth)
+            owners = grants.get(gid, [])
+            owner = ', '.join(owners) if owners else 'no credential above'
+            print(f'~/.claude/.credentials.json  grant:{gid}  matches: {owner}')
+        else:
+            print('~/.claude/.credentials.json  present but not a Claude envelope')
+    else:
+        print('~/.claude/.credentials.json  absent')
+
+    shared_grants = {g: n for g, n in grants.items() if len(n) > 1}
+    print()
+    if shared_grants:
+        print('FAIL — these credentials are the same grant under different names:')
+        for gid, sharers in shared_grants.items():
+            print(f'  grant:{gid}  {", ".join(sharers)}')
+        print('\nEach needs its own `dax creds login`. Clear the duplicates first:')
+        for sharers in shared_grants.values():
+            for name in sharers[1:]:
+                print(f'  dax creds remove {name}')
+        return 1
+
+    print(f'PASS — {len(grants)} distinct grant(s) across {sum(len(v) for v in grants.values())} '
+          f'credential(s); no sharing.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -24,3 +24,13 @@ def test_render_dockerfile_contains_key_tools():
     assert 'nmap' in content
     assert 'tmux' in content
     assert 'claude' in content.lower() or 'claude-code' in content
+
+
+def test_render_dockerfile_activates_the_generated_locale():
+    """locale-gen only builds en_US.UTF-8's data; found 2026-07-31 that nothing
+    ever selected it, so every shell defaulted to POSIX/C and `less` flagged a
+    plain-text CLAUDE.md (ordinary em-dashes) as binary."""
+    content = render_dockerfile('testuser', '/bin/zsh', 'testpass')
+    assert 'locale-gen' in content
+    assert 'ENV LANG=en_US.UTF-8' in content
+    assert 'ENV LC_ALL=en_US.UTF-8' in content

--- a/tests/test_cmd_run_project_resolution.py
+++ b/tests/test_cmd_run_project_resolution.py
@@ -1,0 +1,101 @@
+"""Gate 0: cmd_run's project-resolution step, ahead of Gate A/B tenant
+
+Covers dax.py's `find_project_by_dir` -> `find_enclosing_project` fallback:
+`dax run` invoked from *inside* an already-registered project (rather than
+from its root) must refuse with a clear message, not silently auto-register
+the subdirectory as a brand-new, unrelated project via `run_init`. That
+auto-register path previously mounted only the subdirectory, silently
+dropping repo-root content (`.git`, `.claude/skills/`, etc.) with no error.
+"""
+import argparse
+import yaml
+import pytest
+
+from dax import cmd_run
+
+
+def _write_yaml(path, data):
+    with open(path, 'w') as f:
+        yaml.dump(data, f)
+
+
+def _args():
+    return argparse.Namespace(features=None, ports=None, test_only=True)
+
+
+def test_cmd_run_refuses_when_invoked_from_inside_registered_multi_tenant_project(
+        tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    repo = home / 'discernment'
+    subdir = repo / 'processes' / 'ysecurity-onboard'
+    subdir.mkdir(parents=True)
+    (subdir / '.dax-tenant').write_text('personal')
+
+    _write_yaml(home / '.dax.yaml', {
+        'image': 'test/dax:latest',
+        'features': [],
+        'projects': {
+            'discernment': {
+                'dir': str(repo),
+                'multi_tenant': True,
+                'tenant_subdir': 'processes',
+                'creds': [],
+            },
+        },
+    })
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(subdir)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_run(_args())
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert str(subdir) in out
+    assert "registered project 'discernment'" in out
+    assert str(repo) in out
+    assert 'dax run' in out
+
+
+def test_cmd_run_still_auto_registers_a_genuinely_new_project(tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    other_repo = home / 'other-project'
+    other_repo.mkdir()
+    new_repo = home / 'brand-new-project'
+    new_repo.mkdir()
+
+    _write_yaml(home / '.dax.yaml', {
+        'image': 'test/dax:latest',
+        'features': [],
+        'projects': {
+            'other-project': {'dir': str(other_repo), 'creds': []},
+        },
+    })
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(new_repo)
+
+    def fake_run_init(dax_config, cwd):
+        dax_config.setdefault('projects', {})['brand-new-project'] = {
+            'dir': str(cwd), 'creds': [],
+        }
+        _write_yaml(home / '.dax.yaml', dax_config)
+        return dax_config
+
+    monkeypatch.setattr('dax_creds.init.run_init', fake_run_init)
+
+    # cmd_run proceeds past project resolution into real docker/daemon
+    # machinery next, which this test has no interest in exercising - a
+    # missing `docker` binary (or any other failure past this point) is fine;
+    # only that it did NOT take the refusal branch matters here.
+    try:
+        cmd_run(_args())
+    except SystemExit as e:
+        assert e.code != 1
+    except Exception:
+        pass
+
+    out = capsys.readouterr().out
+    assert 'project not registered' in out
+    assert 'registered project' not in out

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,6 @@ def test_load_config_reads_home_defaults(tmp_path, monkeypatch):
     defaults = {
         'image': 'test/dax:latest',
         'features': ['workdir'],
-        'workdir': {'container': '/home/test/work'},
     }
     _write_yaml(home / '.dax.yaml', defaults)
     monkeypatch.setenv('HOME', str(home))
@@ -41,7 +40,6 @@ def test_load_config_merges_local_config(tmp_path, monkeypatch):
     defaults = {
         'image': 'test/dax:latest',
         'features': ['workdir'],
-        'workdir': {'container': '/home/test/work'},
     }
     local = {
         'features': ['aws'],
@@ -71,6 +69,40 @@ def test_load_config_sets_envname(tmp_path, monkeypatch):
     config = load_config()
 
     assert config['envname'] == 'foo-bar'
+
+
+def test_load_config_sets_workdir_name(tmp_path, monkeypatch):
+    home = tmp_path / 'home'
+    home.mkdir()
+    workdir = tmp_path / 'home' / 'foo' / 'bar'
+    workdir.mkdir(parents=True)
+
+    _write_yaml(home / '.dax.yaml', {'image': 'x', 'features': []})
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(workdir)
+
+    config = load_config()
+
+    # envname is the full path relative to $HOME (used for --name); workdir_name
+    # is just the final component (used for the mount destination) — they
+    # diverge whenever cwd is more than one level deep.
+    assert config['envname'] == 'foo-bar'
+    assert config['workdir_name'] == 'bar'
+
+
+def test_load_config_workdir_name_handles_dotted_and_spaced_dirs(tmp_path, monkeypatch):
+    home = tmp_path / 'home'
+    home.mkdir()
+    workdir = tmp_path / 'home' / 'my.project (copy)'
+    workdir.mkdir(parents=True)
+
+    _write_yaml(home / '.dax.yaml', {'image': 'x', 'features': []})
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(workdir)
+
+    config = load_config()
+
+    assert config['workdir_name'] == 'my.project (copy)'
 
 
 def test_load_config_exits_if_outside_home(tmp_path, monkeypatch):

--- a/tests/test_dax_claude_grant_collision.py
+++ b/tests/test_dax_claude_grant_collision.py
@@ -1,0 +1,225 @@
+"""One OAuth grant must never end up stored under two credential names.
+
+Per-env Claude credentials only isolate anything because each is its own grant:
+independent grants have independent refresh-token chains, so a rotation in one
+project cannot invalidate another's. Two names backed by one grant authenticate
+perfectly and look correct — until a rotation kills both at once.
+
+Decision C3 guarded the login path by comparing the provider's on-disk token
+before and after the flow, which answers "did the file change" rather than "did
+the grant change". Two holes remained, both closed here (decision C6):
+
+  * a Claude Code token refresh landing inside the login window changes the
+    file, so an abandoned login looks successful and imports another env's grant;
+  * `dax creds add`'s claude path never had the before/after guard at all.
+"""
+import json
+
+import pytest
+
+import dax_creds.providers.claude as claude_provider_module
+from dax import _post_login_import
+from dax_creds.config import credential_names_for_provider
+from dax_creds.init import _setup_claude_credential
+from dax_creds.providers.claude import (
+    ClaudeProvider, grant_collision_message, grant_id,
+)
+
+
+class FakeKeyring:
+    def __init__(self, stored=None):
+        self.stored = dict(stored or {})
+
+    def get_password(self, service, name):
+        return self.stored.get((service, name))
+
+    def set_password(self, service, name, value):
+        self.stored[(service, name)] = value
+
+
+def envelope(refresh, access='sk-ant-oat01-x'):
+    return json.dumps({'claudeAiOauth': {'accessToken': access,
+                                         'refreshToken': refresh}})
+
+
+CONFIG = {
+    'credentials': {'github-dbfarrow': {'provider': 'github'}},
+    'projects': {
+        'dax': {'tenant': 'personal', 'creds': ['claude']},
+        'fabric': {'tenant': 'personal', 'creds': ['claude']},
+    },
+}
+
+
+def write_disk_token(home, blob):
+    claude_dir = home / '.claude'
+    claude_dir.mkdir(exist_ok=True)
+    (claude_dir / '.credentials.json').write_text(blob)
+
+
+# --- grant identity ---------------------------------------------------------
+
+def test_grant_id_is_stable_and_ignores_the_access_token():
+    """Access tokens rotate constantly; the grant is the refresh-token chain."""
+    a = envelope('sk-ant-ort01-same', access='first')
+    b = envelope('sk-ant-ort01-same', access='second-refreshed')
+
+    assert grant_id(a) == grant_id(b)
+
+
+def test_grant_id_differs_between_grants():
+    assert grant_id(envelope('one')) != grant_id(envelope('two'))
+
+
+def test_grant_id_never_returns_the_secret():
+    assert 'sk-ant-ort01-secret' not in grant_id(envelope('sk-ant-ort01-secret'))
+
+
+@pytest.mark.parametrize('value', [
+    None, '', 'not json', '{}', '{"claudeAiOauth": {}}',
+    '{"claudeAiOauth": {"accessToken": "bare-access-token-only"}}',
+])
+def test_grant_id_is_none_for_anything_without_a_refresh_token(value):
+    assert grant_id(value) is None
+
+
+# --- collision detection ----------------------------------------------------
+
+def test_collision_detected_across_names():
+    kr = FakeKeyring({('dax-creds', 'claude-personal-dax'): envelope('shared')})
+    provider = ClaudeProvider(keyring=kr)
+
+    clash = provider.grant_collision(
+        'claude-personal-fabric', envelope('shared'),
+        {'claude-personal-dax', 'claude-personal-fabric'})
+
+    assert clash == 'claude-personal-dax'
+
+
+def test_no_collision_between_independent_grants():
+    kr = FakeKeyring({('dax-creds', 'claude-personal-dax'): envelope('grant-a')})
+    provider = ClaudeProvider(keyring=kr)
+
+    clash = provider.grant_collision(
+        'claude-personal-fabric', envelope('grant-b'),
+        {'claude-personal-dax', 'claude-personal-fabric'})
+
+    assert clash is None
+
+
+def test_a_credentials_own_grant_is_not_a_collision():
+    """Re-importing a name's own token is a no-op, not sharing — and refusing it
+    would block re-importing after a `dax creds remove`."""
+    kr = FakeKeyring({('dax-creds', 'claude-personal-dax'): envelope('mine')})
+    provider = ClaudeProvider(keyring=kr)
+
+    clash = provider.grant_collision('claude-personal-dax', envelope('mine'),
+                                     {'claude-personal-dax'})
+
+    assert clash is None
+
+
+def test_collision_check_is_inert_without_a_keychain():
+    """In a container there is no Keychain to compare against. Nothing to check
+    is not the same as a collision, so the import must not be blocked."""
+    provider = ClaudeProvider(keyring=None)
+
+    assert provider.grant_collision('claude-personal-dax', envelope('x'),
+                                    {'claude-personal-fabric'}) is None
+
+
+def test_credential_names_for_provider_includes_derived_names():
+    """The colliding name is usually derived, so enumerating only the registry
+    would make the check pass by seeing nothing."""
+    names = credential_names_for_provider(CONFIG, 'claude')
+
+    assert names == {'claude-personal-dax', 'claude-personal-fabric'}
+    assert 'github-dbfarrow' not in names
+
+
+# --- login path (decision C3's residual hole) -------------------------------
+
+def test_login_refuses_a_grant_already_stored_under_another_name(
+        tmp_path, monkeypatch, capsys):
+    """The C6 scenario: `before != after`, so C3's file comparison is satisfied,
+    but the token on disk is still another env's grant — as happens when Claude
+    Code refreshes it during the login window."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    write_disk_token(tmp_path, envelope('dax-grant', access='refreshed'))
+    kr = FakeKeyring({('dax-creds', 'claude-personal-dax'): envelope('dax-grant')})
+    monkeypatch.setattr(claude_provider_module, '_keyring', kr)
+
+    _post_login_import('claude-personal-fabric', {'provider': 'claude'}, CONFIG,
+                       'claude', before=envelope('dax-grant', access='stale'))
+
+    assert ('dax-creds', 'claude-personal-fabric') not in kr.stored
+    out = capsys.readouterr().out
+    assert "same OAuth grant as 'claude-personal-dax'" in out
+    assert 'dax creds login claude-personal-fabric' in out
+
+
+def test_login_stores_an_independent_grant(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    write_disk_token(tmp_path, envelope('fresh-fabric-grant'))
+    kr = FakeKeyring({('dax-creds', 'claude-personal-dax'): envelope('dax-grant')})
+    monkeypatch.setattr(claude_provider_module, '_keyring', kr)
+
+    _post_login_import('claude-personal-fabric', {'provider': 'claude'}, CONFIG,
+                       'claude', before=envelope('dax-grant'))
+
+    stored = kr.stored[('dax-creds', 'claude-personal-fabric')]
+    assert grant_id(stored) == grant_id(envelope('fresh-fabric-grant'))
+
+
+# --- add path (never had a guard at all) ------------------------------------
+
+def test_add_refuses_to_copy_another_envs_grant(tmp_path, monkeypatch, capsys):
+    """`dax creds add`'s claude path imports straight from
+    ~/.claude/.credentials.json, which under a shared mount is whichever env
+    logged in last. This was the one remaining door to a shared grant."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    write_disk_token(tmp_path, envelope('dax-grant'))
+    kr = FakeKeyring({('dax-creds', 'claude-personal-dax'): envelope('dax-grant')})
+    monkeypatch.setattr(claude_provider_module, '_keyring', kr)
+
+    _setup_claude_credential('claude-personal-fabric', {'provider': 'claude'},
+                             config=CONFIG)
+
+    assert ('dax-creds', 'claude-personal-fabric') not in kr.stored
+    assert "same OAuth grant as 'claude-personal-dax'" in capsys.readouterr().out
+
+
+def test_add_still_imports_an_unshared_grant(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    write_disk_token(tmp_path, envelope('fabric-only-grant'))
+    kr = FakeKeyring({('dax-creds', 'claude-personal-dax'): envelope('dax-grant')})
+    monkeypatch.setattr(claude_provider_module, '_keyring', kr)
+
+    _setup_claude_credential('claude-personal-fabric', {'provider': 'claude'},
+                             config=CONFIG)
+
+    assert ('dax-creds', 'claude-personal-fabric') in kr.stored
+
+
+def test_add_without_config_skips_the_check_rather_than_crashing(
+        tmp_path, monkeypatch):
+    """`config` is optional so callers that have none still work — `dax init`'s
+    path passes it, but the signature must not become load-bearing."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    write_disk_token(tmp_path, envelope('some-grant'))
+    kr = FakeKeyring()
+    monkeypatch.setattr(claude_provider_module, '_keyring', kr)
+
+    _setup_claude_credential('claude-work', {'provider': 'claude'})
+
+    assert ('dax-creds', 'claude-work') in kr.stored
+
+
+# --- message ----------------------------------------------------------------
+
+def test_both_paths_share_one_explanation():
+    lines = grant_collision_message('claude-personal-fabric', 'claude-personal-dax')
+
+    assert "'claude-personal-dax'" in lines[0]
+    assert 'rotation' in ' '.join(lines)
+    assert 'dax creds login claude-personal-fabric' in ' '.join(lines)

--- a/tests/test_dax_claude_mount_exclusivity.py
+++ b/tests/test_dax_claude_mount_exclusivity.py
@@ -1,0 +1,137 @@
+"""`claude` and `claude_tenant_state` both mount ~/.claude, so `dax run` refuses.
+
+Decision B makes the state tree the *replacement* for `feature_claude`'s wholesale
+mount, not an addition to it. Left to Docker the collision is still caught — it
+rejects a duplicate mount point — but the message names neither feature, and
+`claude` is normally inherited from the global `features:` list rather than written
+on the env, so "remove one of them" is not obvious advice.
+"""
+import argparse
+
+import pytest
+import yaml
+
+from dax import cmd_run
+
+
+def _args():
+    return argparse.Namespace(features=None, ports=None, test_only=True)
+
+
+def _setup(tmp_path, monkeypatch, features, project_extra=None):
+    home = tmp_path / 'home'
+    home.mkdir(exist_ok=True)
+    repo = home / 'fabric'
+    repo.mkdir(exist_ok=True)
+
+    project = {'dir': str(repo), 'tenant': 'personal', 'creds': []}
+    project.update(project_extra or {})
+
+    with open(home / '.dax.yaml', 'w') as f:
+        yaml.dump({'image': 'test/dax:latest', 'features': features,
+                   'claudedir': {'mount': '~/.claude'},
+                   'projects': {'fabric': project}}, f)
+
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(repo)
+    return home, repo
+
+
+def test_both_features_together_is_refused(tmp_path, monkeypatch, capsys):
+    _setup(tmp_path, monkeypatch, ['claude', 'claude_tenant_state'])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cmd_run(_args())
+
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert 'both mount ~/.claude' in out
+    # The advice has to mention where `claude` actually comes from, or the user
+    # looks at the env entry, finds nothing, and is stuck.
+    assert 'global features list' in out
+
+
+def test_the_tenant_state_tree_alone_is_fine(tmp_path, monkeypatch, capsys):
+    _setup(tmp_path, monkeypatch, ['claude_tenant_state'])
+
+    cmd_run(_args())
+
+    out = capsys.readouterr().out
+    assert 'both mount' not in out
+
+
+def test_the_shared_mount_alone_is_still_fine(tmp_path, monkeypatch, capsys):
+    """Every env works this way today; opting in is per env and reversible."""
+    _setup(tmp_path, monkeypatch, ['claude'])
+
+    cmd_run(_args())
+
+    assert 'both mount' not in capsys.readouterr().out
+
+
+def test_a_command_line_feature_can_collide_too(tmp_path, monkeypatch, capsys):
+    """`-f claude_tenant_state` on an env that inherits `claude` globally is the
+    most likely way to hit this, so the check must run after argv is merged."""
+    _setup(tmp_path, monkeypatch, ['claude'])
+    args = _args()
+    args.features = 'claude_tenant_state'
+
+    with pytest.raises(SystemExit):
+        cmd_run(args)
+
+    assert 'both mount ~/.claude' in capsys.readouterr().out
+
+
+# --- per-env feature opt-in -------------------------------------------------
+#
+# This was never wired up: features came only from the global `features:` list, a
+# `.dax.yaml` in cwd, and `-f`. An env's own `features:` list — which the design
+# doc, CLAUDE.md, and the feature's docstring all name as the way to switch
+# claude_tenant_state on for one project — was read by nothing, so opting in per
+# env was impossible.
+
+def test_an_envs_own_features_list_is_honoured(tmp_path, monkeypatch, capsys):
+    _setup(tmp_path, monkeypatch, [],
+           project_extra={'features': ['claude_tenant_state']})
+
+    cmd_run(_args())
+
+    assert 'adding claude_tenant_state' in capsys.readouterr().out
+
+
+def test_opting_in_per_env_collides_with_a_globally_inherited_claude(
+        tmp_path, monkeypatch, capsys):
+    """The realistic collision, and the reason the check has to run after the
+    per-env merge rather than on the global list alone."""
+    _setup(tmp_path, monkeypatch, ['claude'],
+           project_extra={'features': ['claude_tenant_state']})
+
+    with pytest.raises(SystemExit):
+        cmd_run(_args())
+
+    assert 'both mount ~/.claude' in capsys.readouterr().out
+
+
+def test_a_feature_already_global_is_not_added_twice(tmp_path, monkeypatch, capsys):
+    """A duplicate would emit the same mount twice and Docker would reject it."""
+    _setup(tmp_path, monkeypatch, ['claude_tenant_state'],
+           project_extra={'features': ['claude_tenant_state']})
+
+    cmd_run(_args())
+
+    out = capsys.readouterr().out
+    assert out.count('adding claude_tenant_state') == 1
+
+
+def test_an_env_without_a_tenant_is_refused_before_launch(tmp_path, monkeypatch, capsys):
+    """The refusal moved here from the container-side wrapper: with Gate B gone
+    there is nothing left to resolve at launch, so this is the only place it can
+    be caught — and catching it before the container starts is better anyway."""
+    _setup(tmp_path, monkeypatch, ['claude_tenant_state'],
+           project_extra={'tenant': None})
+
+    with pytest.raises(SystemExit) as excinfo:
+        cmd_run(_args())
+
+    assert excinfo.value.code != 0
+    assert 'dax env set fabric tenant' in capsys.readouterr().out

--- a/tests/test_dax_claude_tenant_state_mount.py
+++ b/tests/test_dax_claude_tenant_state_mount.py
@@ -13,7 +13,10 @@ import os
 import pytest
 
 import dax as dax_module
-from dax import _CLAUDE_HOST_SHARED_DIRS, feature_claude_tenant_state
+from dax import (
+    _CLAUDE_HOST_SHARED_DIRS, _CLAUDE_HOST_SHARED_FILES,
+    feature_claude_tenant_state,
+)
 
 
 @pytest.fixture
@@ -157,3 +160,54 @@ def test_a_different_tenant_changes_the_path(config):
 
     assert '/tenants/personal/' in a
     assert '/tenants/acme/' in b
+
+
+# --- user-level files the tree mount would otherwise hide -------------------
+#
+# Found 2026-07-31, after `fabric` had run for a day without them: a tree mount
+# replaces ~/.claude wholesale, so the global CLAUDE.md and settings.json simply
+# vanished. Silently — no error, just absent instructions.
+
+def test_global_claude_md_and_settings_are_mounted(config, tmp_path):
+    for f in _CLAUDE_HOST_SHARED_FILES:
+        (tmp_path / '.claude').mkdir(exist_ok=True)
+        (tmp_path / '.claude' / f).write_text('x')
+
+    vols = volumes(feature_claude_tenant_state(config))
+
+    assert f'{tmp_path}/.claude/CLAUDE.md:/home/dfarrow/.claude/CLAUDE.md:ro' in vols
+    assert f'{tmp_path}/.claude/settings.json:/home/dfarrow/.claude/settings.json:ro' in vols
+
+
+def test_those_files_are_read_only(config, tmp_path):
+    """A writable single-file bind mount is where write-temp-plus-rename breaks on
+    grpcfuse: the rename replaces the mount with a regular file and the write stops
+    reaching the host silently. Read-only fails loudly instead."""
+    (tmp_path / '.claude').mkdir()
+    (tmp_path / '.claude' / 'settings.json').write_text('{}')
+
+    vols = volumes(feature_claude_tenant_state(config))
+
+    settings = [v for v in vols if v.endswith('/settings.json:ro')]
+    assert settings, vols
+
+
+def test_absent_user_files_are_skipped(config, tmp_path):
+    (tmp_path / '.claude').mkdir()
+    (tmp_path / '.claude' / 'CLAUDE.md').write_text('x')
+
+    vols = volumes(feature_claude_tenant_state(config))
+
+    assert not any('settings.json' in v for v in vols)
+    assert any('CLAUDE.md' in v for v in vols)
+
+
+def test_directories_stay_writable(config, tmp_path):
+    """commands/ is mounted rw on purpose — authoring a command inside a container
+    and having it persist is worth more than insulating the host directory."""
+    (tmp_path / '.claude' / 'commands').mkdir(parents=True)
+
+    vols = volumes(feature_claude_tenant_state(config))
+
+    commands = next(v for v in vols if v.endswith('/commands'))
+    assert not commands.endswith(':ro')

--- a/tests/test_dax_claude_tenant_state_mount.py
+++ b/tests/test_dax_claude_tenant_state_mount.py
@@ -167,39 +167,81 @@ def test_a_different_tenant_changes_the_path(config):
 # Found 2026-07-31, after `fabric` had run for a day without them: a tree mount
 # replaces ~/.claude wholesale, so the global CLAUDE.md and settings.json simply
 # vanished. Silently — no error, just absent instructions.
+#
+# First fix attempt was a nested read-only *file* bind mount, abandoned within
+# hours: unlike a nested directory mount, it never delivered the host's content
+# at all — the container saw an empty file. These files are now copied into the
+# tree at `dax run` time instead (`dax_creds.config.sync_claude_shared_files`).
 
-def test_global_claude_md_and_settings_are_mounted(config, tmp_path):
+def _tree_dir(tmp_path):
+    return tmp_path / '.local' / 'state' / 'dax' / 'tenants' / 'personal' / 'fabric'
+
+
+def test_global_claude_md_and_settings_are_copied_into_the_tree(config, tmp_path):
     for f in _CLAUDE_HOST_SHARED_FILES:
         (tmp_path / '.claude').mkdir(exist_ok=True)
-        (tmp_path / '.claude' / f).write_text('x')
+        (tmp_path / '.claude' / f).write_text(f'host {f}')
 
-    vols = volumes(feature_claude_tenant_state(config))
+    feature_claude_tenant_state(config)
 
-    assert f'{tmp_path}/.claude/CLAUDE.md:/home/dfarrow/.claude/CLAUDE.md:ro' in vols
-    assert f'{tmp_path}/.claude/settings.json:/home/dfarrow/.claude/settings.json:ro' in vols
+    tree = _tree_dir(tmp_path)
+    for f in _CLAUDE_HOST_SHARED_FILES:
+        assert (tree / f).read_text() == f'host {f}'
 
 
-def test_those_files_are_read_only(config, tmp_path):
-    """A writable single-file bind mount is where write-temp-plus-rename breaks on
-    grpcfuse: the rename replaces the mount with a regular file and the write stops
-    reaching the host silently. Read-only fails loudly instead."""
+def test_copied_files_are_not_mounted(config, tmp_path):
+    """These are plain writes into the tree, picked up by the tree's own volume
+    mount — not a separate bind mount, and definitely not a read-only one (the
+    first fix attempt, which never worked)."""
     (tmp_path / '.claude').mkdir()
     (tmp_path / '.claude' / 'settings.json').write_text('{}')
 
     vols = volumes(feature_claude_tenant_state(config))
 
-    settings = [v for v in vols if v.endswith('/settings.json:ro')]
-    assert settings, vols
+    assert not any('settings.json' in v for v in vols)
+    assert len(vols) == 1
 
 
 def test_absent_user_files_are_skipped(config, tmp_path):
     (tmp_path / '.claude').mkdir()
     (tmp_path / '.claude' / 'CLAUDE.md').write_text('x')
 
-    vols = volumes(feature_claude_tenant_state(config))
+    feature_claude_tenant_state(config)
 
-    assert not any('settings.json' in v for v in vols)
-    assert any('CLAUDE.md' in v for v in vols)
+    tree = _tree_dir(tmp_path)
+    assert (tree / 'CLAUDE.md').read_text() == 'x'
+    assert not (tree / 'settings.json').exists()
+
+
+def test_a_host_update_is_picked_up_on_the_next_run(config, tmp_path):
+    """The common case: host content moves on, and the tree — untouched since
+    dax last synced it — should just follow along."""
+    (tmp_path / '.claude').mkdir()
+    (tmp_path / '.claude' / 'CLAUDE.md').write_text('v1')
+    feature_claude_tenant_state(config)
+
+    (tmp_path / '.claude' / 'CLAUDE.md').write_text('v2')
+    feature_claude_tenant_state(config)
+
+    assert (_tree_dir(tmp_path) / 'CLAUDE.md').read_text() == 'v2'
+
+
+def test_a_tree_copy_touched_independently_of_dax_is_left_alone(config, tmp_path, capsys):
+    """A container can edit this file directly now that it's a plain copy, not a
+    mount. That's exactly the drift a blind overwrite would destroy, so dax must
+    not clobber it — even though the host has since moved on too."""
+    (tmp_path / '.claude').mkdir()
+    (tmp_path / '.claude' / 'CLAUDE.md').write_text('v1')
+    feature_claude_tenant_state(config)
+
+    (_tree_dir(tmp_path) / 'CLAUDE.md').write_text('edited independently in a container')
+    (tmp_path / '.claude' / 'CLAUDE.md').write_text('v2')
+    feature_claude_tenant_state(config)
+
+    assert (_tree_dir(tmp_path) / 'CLAUDE.md').read_text() == 'edited independently in a container'
+    out = capsys.readouterr().out
+    assert 'CLAUDE.md' in out
+    assert 'dax env accept-shared-files fabric' in out
 
 
 def test_directories_stay_writable(config, tmp_path):

--- a/tests/test_dax_claude_tenant_state_mount.py
+++ b/tests/test_dax_claude_tenant_state_mount.py
@@ -1,0 +1,159 @@
+"""`feature_claude_tenant_state` mounts this env's state tree at `~/.claude`.
+
+Decision B. The feature previously mounted trees at
+`~/.local/state/dax/tenants/<t>/<p>` and left the container-side `claude` wrapper
+to compute `CLAUDE_CONFIG_DIR` from cwd — the multi-tenant shape, where one repo
+could hold several tenants. Each env is single-tenant now, so the path is knowable
+before launch.
+
+It had no tests at all, which is part of why the shape drifted from the design.
+"""
+import os
+
+import pytest
+
+import dax as dax_module
+from dax import _CLAUDE_HOST_SHARED_DIRS, feature_claude_tenant_state
+
+
+@pytest.fixture
+def config(tmp_path, monkeypatch):
+    """A dax run config, with HOME redirected so host paths are inspectable."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    return {'workdir_name': 'fabric', 'tenant': 'personal',
+            'cwd': '/repos/fabric', 'user': 'dfarrow'}
+
+
+def volumes(opts):
+    return [o[len('--volume='):] for o in opts if o.startswith('--volume=')]
+
+
+def env_vars(opts):
+    out = {}
+    for flag, value in zip(opts, opts[1:]):
+        if flag == '-e' and '=' in value:
+            key, val = value.split('=', 1)
+            out[key] = val
+    return out
+
+
+def test_the_tree_mounts_at_the_config_dir_itself(config):
+    """Not at a `~/.local/state/dax/...` path inside the container: Claude Code
+    scans `~/.claude`, and the whole point is that it finds this env's tree there."""
+    vols = volumes(feature_claude_tenant_state(config))
+
+    assert vols[0].endswith(':/home/dfarrow/.claude')
+    assert vols[0].startswith(os.path.expanduser(
+        '~/.local/state/dax/tenants/personal/fabric'))
+
+
+def test_config_dir_is_a_constant_pointing_at_the_mount(config):
+    """Kept only because it relocates .claude.json *into* the tree — unset, that
+    file lands at ~/.claude.json, outside the mount, and is lost on teardown."""
+    assert env_vars(feature_claude_tenant_state(config))['CLAUDE_CONFIG_DIR'] == \
+        '/home/dfarrow/.claude'
+
+
+def test_no_tenant_state_switch_is_exported(config):
+    """`dax run` must not set DAX_TENANT_STATE any more: a wrapper from an image
+    built before decision B still contains Gate B and would resolve its own path,
+    overriding the mount. Not setting it is what makes this work unrebuilt."""
+    exported = env_vars(feature_claude_tenant_state(config))
+
+    assert 'DAX_TENANT_STATE' not in exported
+    assert 'DAX_PROJECT_NAME' not in exported
+    assert 'DAX_MULTI_TENANT' not in exported
+    assert 'DAX_TENANT_SUBDIR' not in exported
+
+
+def test_the_tenant_comes_from_the_registry_not_the_filesystem(config, tmp_path):
+    """Decision A: a declared label on the env's ~/.dax.yaml entry. A stray
+    .dax-tenant file in the repo must have no say."""
+    (tmp_path / '.dax-tenant').write_text('some-other-tenant\n')
+    config['cwd'] = str(tmp_path)
+
+    assert 'tenants/personal/fabric' in volumes(feature_claude_tenant_state(config))[0]
+
+
+def test_a_missing_tenant_refuses_rather_than_pooling(config, capsys):
+    """Falling back to a default would pool two envs' state, which is the exact
+    failure this design exists to prevent (decision C2's rule, applied to state)."""
+    config['tenant'] = None
+
+    with pytest.raises(SystemExit) as excinfo:
+        feature_claude_tenant_state(config)
+
+    assert excinfo.value.code != 0
+    out = capsys.readouterr().out
+    assert 'dax env set fabric tenant' in out
+
+
+# --- the two host directories (decision B2) ---------------------------------
+
+def test_host_commands_and_plugins_nest_inside_the_tree(config, tmp_path):
+    for d in _CLAUDE_HOST_SHARED_DIRS:
+        (tmp_path / '.claude' / d).mkdir(parents=True)
+
+    vols = volumes(feature_claude_tenant_state(config))
+
+    assert f'{tmp_path}/.claude/commands:/home/dfarrow/.claude/commands' in vols
+    assert f'{tmp_path}/.claude/plugins:/home/dfarrow/.claude/plugins' in vols
+
+
+def test_they_are_mounted_from_the_host_claude_dir_not_a_shared_tree(config, tmp_path):
+    """Decision B2: no `shared/` copy, so there is one source of truth and no
+    seeding step that can silently leave a project with empty directories."""
+    (tmp_path / '.claude' / 'commands').mkdir(parents=True)
+
+    vols = volumes(feature_claude_tenant_state(config))
+
+    assert not any('/state/dax/shared/' in v for v in vols)
+
+
+def test_the_tree_mount_comes_first(config, tmp_path):
+    """Docker orders by destination depth, but emitting the parent first keeps the
+    intent legible in `docker run` output and in any future ordering change."""
+    (tmp_path / '.claude' / 'commands').mkdir(parents=True)
+
+    vols = volumes(feature_claude_tenant_state(config))
+
+    assert vols[0].endswith(':/home/dfarrow/.claude')
+
+
+def test_absent_host_directories_are_skipped(config):
+    """A host with no commands of its own should not acquire an empty
+    ~/.claude/commands as a side effect of running a container."""
+    vols = volumes(feature_claude_tenant_state(config))
+
+    assert len(vols) == 1
+
+
+def test_skills_and_cache_are_not_shared(config, tmp_path):
+    """Skills arrive from the discernment sidecar (decision D), so a copy here
+    goes stale. Cache is derived and the only one where fetched content can turn
+    account-specific."""
+    for d in ('skills', 'cache', 'commands'):
+        (tmp_path / '.claude' / d).mkdir(parents=True)
+
+    vols = volumes(feature_claude_tenant_state(config))
+
+    assert not any(v.endswith('/skills') or v.endswith('/cache') for v in vols)
+    assert 'skills' not in _CLAUDE_HOST_SHARED_DIRS
+    assert 'cache' not in _CLAUDE_HOST_SHARED_DIRS
+
+
+def test_each_env_gets_its_own_tree(config, monkeypatch):
+    """The property the whole design is for: two envs must not share a path."""
+    fabric = volumes(feature_claude_tenant_state(config))[0]
+
+    other = dict(config, workdir_name='dax')
+    assert volumes(feature_claude_tenant_state(other))[0] != fabric
+
+
+def test_a_different_tenant_changes_the_path(config):
+    """`tenant` is the outer key, so ending an engagement is one rm -rf."""
+    a = volumes(feature_claude_tenant_state(config))[0]
+    b = volumes(feature_claude_tenant_state(dict(config, tenant='acme')))[0]
+
+    assert '/tenants/personal/' in a
+    assert '/tenants/acme/' in b

--- a/tests/test_dax_cmd_creds_login.py
+++ b/tests/test_dax_cmd_creds_login.py
@@ -1,0 +1,70 @@
+"""Tests for dax.py's _post_login_import, the step that runs right after a
+`dax creds login` browser auth flow completes.
+
+Covers the claude branch specifically, since it was just brought in line
+with the existing github/auggie behavior (read the token the auth flow just
+wrote to disk, store it in Keychain) rather than only printing a manual
+`dax creds add` hint.
+"""
+import json
+
+import dax_creds.providers.claude as claude_provider_module
+from dax import _post_login_import
+
+
+class FakeKeyring:
+    def __init__(self):
+        self.stored = {}
+
+    def get_password(self, service, name):
+        return self.stored.get((service, name))
+
+    def set_password(self, service, name, value):
+        self.stored[(service, name)] = value
+
+
+ENVELOPE = {'claudeAiOauth': {'accessToken': 'sk-ant-oat01-abc',
+                              'refreshToken': 'sk-ant-ort01-xyz'}}
+
+
+def test_post_login_import_claude_stores_token_from_disk(tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    (home / '.claude').mkdir(parents=True)
+    (home / '.claude' / '.credentials.json').write_text(json.dumps(ENVELOPE))
+    monkeypatch.setenv('HOME', str(home))
+    fake_keyring = FakeKeyring()
+    monkeypatch.setattr(claude_provider_module, '_keyring', fake_keyring)
+
+    _post_login_import('claude-personal-fabric', {'provider': 'claude'}, {}, 'claude')
+
+    stored = fake_keyring.stored[('dax-creds', 'claude-personal-fabric')]
+    assert json.loads(stored) == ENVELOPE
+    assert 'imported to Keychain' in capsys.readouterr().out
+
+
+def test_post_login_import_claude_reports_when_nothing_on_disk(tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    monkeypatch.setenv('HOME', str(home))
+    fake_keyring = FakeKeyring()
+    monkeypatch.setattr(claude_provider_module, '_keyring', fake_keyring)
+
+    _post_login_import('claude-personal-fabric', {'provider': 'claude'}, {}, 'claude')
+
+    assert fake_keyring.stored == {}
+    assert 'no token found' in capsys.readouterr().out
+
+
+def test_post_login_import_claude_overwrites_existing_keychain_entry(tmp_path, monkeypatch):
+    home = tmp_path / 'home'
+    (home / '.claude').mkdir(parents=True)
+    (home / '.claude' / '.credentials.json').write_text(json.dumps(ENVELOPE))
+    monkeypatch.setenv('HOME', str(home))
+    fake_keyring = FakeKeyring()
+    fake_keyring.set_password('dax-creds', 'claude-personal-fabric', 'stale-old-value')
+    monkeypatch.setattr(claude_provider_module, '_keyring', fake_keyring)
+
+    _post_login_import('claude-personal-fabric', {'provider': 'claude'}, {}, 'claude')
+
+    stored = fake_keyring.stored[('dax-creds', 'claude-personal-fabric')]
+    assert json.loads(stored) == ENVELOPE

--- a/tests/test_dax_cmd_creds_login.py
+++ b/tests/test_dax_cmd_creds_login.py
@@ -1,5 +1,6 @@
-"""Tests for dax.py's _post_login_import, the step that runs right after a
-`dax creds login` browser auth flow completes.
+"""Tests for dax.py's `dax creds login` support: which credential definition the
+command resolves, and `_post_login_import`, the step that runs right after the
+browser auth flow completes.
 
 Covers the claude branch specifically, since it was just brought in line
 with the existing github/auggie behavior (read the token the auth flow just
@@ -8,8 +9,10 @@ wrote to disk, store it in Keychain) rather than only printing a manual
 """
 import json
 
+import pytest
+
 import dax_creds.providers.claude as claude_provider_module
-from dax import _post_login_import
+from dax import _login_credential_def, _post_login_import
 
 
 class FakeKeyring:
@@ -25,6 +28,63 @@ class FakeKeyring:
 
 ENVELOPE = {'claudeAiOauth': {'accessToken': 'sk-ant-oat01-abc',
                               'refreshToken': 'sk-ant-ort01-xyz'}}
+
+
+DERIVED_CONFIG = {
+    'credential_defaults': {'claude': {'browser': 'chrome',
+                                       'chrome_profile': 'Profile 2'}},
+    'credentials': {'github-dbfarrow': {'provider': 'github'}},
+    'projects': {'fabric': {'tenant': 'personal',
+                            'creds': ['claude', 'github-dbfarrow']}},
+}
+
+
+def test_login_resolves_a_derived_credential_name():
+    """`dax creds login claude-personal-fabric` refused a name `dax creds list`
+    displayed, because only the registry was consulted. With `add`'s claude path
+    being the unguarded copy-from-disk route, that left no way to mint a per-env
+    credential at all. Found by manual step 4 on 2026-07-30 (decision C5)."""
+    cred_def = _login_credential_def(DERIVED_CONFIG, 'claude-personal-fabric')
+
+    assert cred_def['provider'] == 'claude'
+
+
+def test_login_derived_credential_carries_credential_defaults():
+    """Without this the per-env login opens the default browser instead of the
+    Chrome profile the account lives in — decision C4."""
+    cred_def = _login_credential_def(DERIVED_CONFIG, 'claude-personal-fabric')
+
+    assert cred_def['browser'] == 'chrome'
+    assert cred_def['chrome_profile'] == 'Profile 2'
+
+
+def test_login_prefers_an_explicit_registration_over_the_derived_name():
+    """An explicit entry wins everywhere else resolution happens; login matches.
+    It is also the escape hatch for deliberately sharing one credential."""
+    config = dict(DERIVED_CONFIG,
+                  credentials=dict(DERIVED_CONFIG['credentials'],
+                                   **{'claude-personal-fabric': {
+                                       'provider': 'claude',
+                                       'chrome_profile': 'Profile 9'}}))
+
+    cred_def = _login_credential_def(config, 'claude-personal-fabric')
+
+    assert cred_def['chrome_profile'] == 'Profile 9'
+
+
+def test_login_still_rejects_a_name_that_is_neither_registered_nor_derived():
+    with pytest.raises(KeyError):
+        _login_credential_def(DERIVED_CONFIG, 'claude-personal-typo')
+
+
+def test_login_rejects_a_derived_name_whose_env_has_no_tenant():
+    """A bare `claude` with no tenant is unresolvable, so no name is derived from
+    it — the refusal must stay a refusal rather than crashing out of login."""
+    config = dict(DERIVED_CONFIG,
+                  projects={'fabric': {'creds': ['claude']}})
+
+    with pytest.raises(KeyError):
+        _login_credential_def(config, 'claude-personal-fabric')
 
 
 def test_post_login_import_claude_stores_token_from_disk(tmp_path, monkeypatch, capsys):
@@ -53,6 +113,59 @@ def test_post_login_import_claude_reports_when_nothing_on_disk(tmp_path, monkeyp
 
     assert fake_keyring.stored == {}
     assert 'no token found' in capsys.readouterr().out
+
+
+def test_post_login_import_refuses_a_token_the_flow_did_not_write(tmp_path, monkeypatch, capsys):
+    """An abandoned login leaves the pre-existing credential on disk. Importing
+    it would store an existing grant under a new name — two Keychain entries,
+    one grant, no isolation — and it presents as success. Observed 2026-07-30
+    when a login was cancelled at the wrong browser."""
+    home = tmp_path / 'home'
+    (home / '.claude').mkdir(parents=True)
+    (home / '.claude' / '.credentials.json').write_text(json.dumps(ENVELOPE))
+    monkeypatch.setenv('HOME', str(home))
+    fake_keyring = FakeKeyring()
+    monkeypatch.setattr(claude_provider_module, '_keyring', fake_keyring)
+
+    # `before` is what the same file already held — unchanged by the flow.
+    _post_login_import('claude-personal-discernment', {'provider': 'claude'}, {},
+                       'claude', before=json.dumps(ENVELOPE))
+
+    assert fake_keyring.stored == {}
+    out = capsys.readouterr().out
+    assert 'did not write a new credential' in out
+    assert 'share an existing grant' in out
+
+
+def test_post_login_import_accepts_a_token_the_flow_did_write(tmp_path, monkeypatch):
+    """A real login replaces the file, so before != after and the import runs."""
+    home = tmp_path / 'home'
+    (home / '.claude').mkdir(parents=True)
+    (home / '.claude' / '.credentials.json').write_text(json.dumps(ENVELOPE))
+    monkeypatch.setenv('HOME', str(home))
+    fake_keyring = FakeKeyring()
+    monkeypatch.setattr(claude_provider_module, '_keyring', fake_keyring)
+
+    stale = json.dumps({'claudeAiOauth': {'accessToken': 'old', 'refreshToken': 'old'}})
+    _post_login_import('claude-personal-discernment', {'provider': 'claude'}, {},
+                       'claude', before=stale)
+
+    stored = fake_keyring.stored[('dax-creds', 'claude-personal-discernment')]
+    assert json.loads(stored) == ENVELOPE
+
+
+def test_post_login_import_first_ever_login_has_nothing_before(tmp_path, monkeypatch):
+    """No credential on disk beforehand — `before` is None, import proceeds."""
+    home = tmp_path / 'home'
+    (home / '.claude').mkdir(parents=True)
+    (home / '.claude' / '.credentials.json').write_text(json.dumps(ENVELOPE))
+    monkeypatch.setenv('HOME', str(home))
+    fake_keyring = FakeKeyring()
+    monkeypatch.setattr(claude_provider_module, '_keyring', fake_keyring)
+
+    _post_login_import('claude-new', {'provider': 'claude'}, {}, 'claude', before=None)
+
+    assert ('dax-creds', 'claude-new') in fake_keyring.stored
 
 
 def test_post_login_import_claude_overwrites_existing_keychain_entry(tmp_path, monkeypatch):

--- a/tests/test_dax_cmd_run_creds_daemon.py
+++ b/tests/test_dax_cmd_run_creds_daemon.py
@@ -1,0 +1,110 @@
+"""`dax run`'s per-project credential daemon must use TCP, not a bind-mounted
+Unix socket.
+
+Found 2026-08: with two or more projects' containers running concurrently,
+only the most-recently-started one's `dax-creds list` could reach its daemon;
+every earlier one got ECONNREFUSED despite its daemon process being alive.
+Docker Desktop's Mac-VM file sharing does not reliably forward a live
+macOS-native Unix socket's connect/accept semantics into a container — the
+same class of problem `_start_login_daemon` already solved for `dax creds
+login` by switching to `tcp:host.docker.internal:<port>` (see its own comment,
+"avoids Docker Desktop Unix socket permission issues"). `cmd_run`'s daemon
+never got the same fix.
+
+The real daemon subprocess needs `keyring` importable just to construct
+`KeyringTokenStore()` at startup, before it ever serves a request — not
+installed in this sandbox, so `_start_creds_daemon`/`_wait_for_tcp` are faked
+here rather than actually spawned. That's fine: the bug and the fix are both
+entirely about which transport `cmd_run` tells the container to use, i.e. the
+assembled `docker run` command — not the daemon's own request handling, which
+`test_dax_creds_daemon.py` already covers directly.
+"""
+import argparse
+
+import yaml
+
+import dax
+from dax import _start_creds_daemon, cmd_run
+
+
+def _args():
+    return argparse.Namespace(features=None, ports=None, test_only=True)
+
+
+def _setup(tmp_path, monkeypatch):
+    home = tmp_path / 'home'
+    home.mkdir(exist_ok=True)
+    repo = home / 'myenv'
+    repo.mkdir(exist_ok=True)
+
+    project = {'dir': str(repo), 'tenant': 'personal', 'creds': ['test-github']}
+    with open(home / '.dax.yaml', 'w') as f:
+        yaml.dump({
+            'image': 'test/dax:latest', 'features': [],
+            'credentials': {'test-github': {'provider': 'github'}},
+            'projects': {'myenv': project},
+        }, f)
+
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(repo)
+    # Sidesteps the real Keychain (unreachable in this sandbox anyway) so
+    # `cmd_run` doesn't hit the interactive "run dax creds login now? [Y/n]"
+    # prompt, which would hang the test waiting on stdin.
+    monkeypatch.setattr('dax_creds.init.ensure_project_credentials', lambda *a, **k: [])
+    # Fakes daemon startup/liveness — see module docstring for why the real
+    # subprocess can't run here — while still recording exactly what
+    # cmd_run asked for, and its own terminate()/wait() for the finally block.
+    monkeypatch.setattr(dax, '_find_free_port', lambda: 54321)
+
+    class _FakeDaemon:
+        def terminate(self):
+            pass
+
+        def wait(self):
+            pass
+
+    started = {}
+
+    def _fake_start(credentials, port):
+        started['credentials'] = credentials
+        started['port'] = port
+        return _FakeDaemon()
+
+    monkeypatch.setattr(dax, '_start_creds_daemon', _fake_start)
+    monkeypatch.setattr(dax, '_wait_for_tcp', lambda host, port, timeout=5.0: True)
+    return home, repo, started
+
+
+def test_creds_daemon_uses_tcp_not_a_bind_mounted_socket(tmp_path, monkeypatch, capsys):
+    home, repo, started = _setup(tmp_path, monkeypatch)
+
+    cmd_run(_args())
+
+    out = capsys.readouterr().out
+    assert started['port'] == 54321
+    assert 'DAX_CREDS_SOCK=tcp:host.docker.internal:54321' in out
+    assert '--add-host=host.docker.internal:host-gateway' in out
+    assert 'DAX_CREDS_GITHUB=test-github' in out
+    assert 'dax-creds.sock' not in out
+    assert 'dax-state' not in out
+
+
+def test_start_creds_daemon_passes_tcp_port_not_a_socket_path(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    captured = {}
+
+    class _FakeProc:
+        pass
+
+    def _fake_popen(cmd, **kwargs):
+        captured['cmd'] = cmd
+        return _FakeProc()
+
+    monkeypatch.setattr('dax.subprocess.Popen', _fake_popen)
+
+    _start_creds_daemon({'test-github': {'provider': 'github'}}, 54321)
+
+    cmd = captured['cmd']
+    assert '--tcp-port' in cmd
+    assert cmd[cmd.index('--tcp-port') + 1] == '54321'
+    assert '--socket' not in cmd

--- a/tests/test_dax_cmd_run_mounts.py
+++ b/tests/test_dax_cmd_run_mounts.py
@@ -1,0 +1,66 @@
+"""cmd_run must promote an env's `mounts:` list into the flat config
+feature_mounts reads — the same promotion `tenant` and `features` already get.
+
+Found 2026-07-31: `dax env show` displayed a configured `mounts` entry
+correctly (it reads straight from the project dict), but `dax run` printed
+"no mounts defined for this env" and built no --volume for it. feature_mounts
+itself was fine in isolation (see test_features.py) — cmd_run just never
+copied project['mounts'] into config['mounts'] the way it does for
+project['tenant'], so the field was invisible at launch despite `env show`
+and `env set` both working. Only an integration test through cmd_run itself,
+not a unit test of feature_mounts alone, catches this class of bug.
+"""
+import argparse
+
+import pytest
+import yaml
+
+from dax import cmd_run
+
+
+def _args():
+    return argparse.Namespace(features=None, ports=None, test_only=True)
+
+
+def _setup(tmp_path, monkeypatch, project_extra=None):
+    home = tmp_path / 'home'
+    home.mkdir(exist_ok=True)
+    repo = home / 'a-priest-and-an-imam'
+    repo.mkdir(exist_ok=True)
+    (home / 'discernment').mkdir(exist_ok=True)
+
+    project = {'dir': str(repo), 'tenant': 'personal', 'creds': []}
+    project.update(project_extra or {})
+
+    with open(home / '.dax.yaml', 'w') as f:
+        yaml.dump({'image': 'test/dax:latest', 'features': [],
+                   'projects': {'a-priest-and-an-imam': project}}, f)
+
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(repo)
+    return home, repo
+
+
+def test_an_envs_mounts_list_reaches_feature_mounts(tmp_path, monkeypatch, capsys):
+    home, _ = _setup(tmp_path, monkeypatch, project_extra={
+        'mounts': ['~/discernment'],
+        'features': ['mounts'],
+    })
+
+    cmd_run(_args())
+
+    out = capsys.readouterr().out
+    assert 'no mounts defined' not in out
+    assert f'--volume={home}/discernment:/home/' in out
+
+
+def test_mounts_without_the_feature_is_silently_inactive(tmp_path, monkeypatch, capsys):
+    """Data present but the opt-in feature missing must not mount anything —
+    matches feature_ports' existing shape, not a regression."""
+    _setup(tmp_path, monkeypatch, project_extra={'mounts': ['~/discernment']})
+
+    cmd_run(_args())
+
+    out = capsys.readouterr().out
+    assert 'adding mounts' not in out
+    assert 'discernment' not in out

--- a/tests/test_dax_cmd_run_substrate.py
+++ b/tests/test_dax_cmd_run_substrate.py
@@ -1,0 +1,63 @@
+"""cmd_run must promote an env's `substrate` field into the flat config
+feature_substrate reads — the same promotion `tenant` and `mounts` already get.
+
+Same bug class as tests/test_dax_cmd_run_mounts.py caught for `mounts`: a
+unit test of feature_substrate alone (see test_features.py) cannot catch a
+wiring gap between the project registry and cmd_run's flat config, since it
+never exercises cmd_run's own promotion step.
+"""
+import argparse
+
+import pytest
+import yaml
+
+from dax import cmd_run
+
+
+def _args():
+    return argparse.Namespace(features=None, ports=None, test_only=True)
+
+
+def _setup(tmp_path, monkeypatch, project_extra=None):
+    home = tmp_path / 'home'
+    home.mkdir(exist_ok=True)
+    repo = home / 'a-priest-and-an-imam'
+    repo.mkdir(exist_ok=True)
+    (home / 'virgil').mkdir(exist_ok=True)
+
+    project = {'dir': str(repo), 'tenant': 'personal', 'creds': []}
+    project.update(project_extra or {})
+
+    with open(home / '.dax.yaml', 'w') as f:
+        yaml.dump({'image': 'test/dax:latest', 'features': [],
+                   'projects': {'a-priest-and-an-imam': project}}, f)
+
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(repo)
+    return home, repo
+
+
+def test_an_envs_substrate_reaches_feature_substrate(tmp_path, monkeypatch, capsys):
+    home, _ = _setup(tmp_path, monkeypatch, project_extra={
+        'substrate': '~/virgil',
+        'features': ['substrate'],
+    })
+
+    cmd_run(_args())
+
+    out = capsys.readouterr().out
+    assert 'no substrate configured' not in out
+    assert f'--volume={home}/virgil:/home/' in out
+    assert 'SUBSTRATE_ROOT=' in out
+
+
+def test_substrate_without_the_feature_is_silently_inactive(tmp_path, monkeypatch, capsys):
+    """Data present but the opt-in feature missing must not mount anything —
+    matches feature_mounts'/feature_ports' existing shape, not a regression."""
+    _setup(tmp_path, monkeypatch, project_extra={'substrate': '~/virgil'})
+
+    cmd_run(_args())
+
+    out = capsys.readouterr().out
+    assert 'adding substrate' not in out
+    assert 'SUBSTRATE_ROOT' not in out

--- a/tests/test_dax_config_round_trip.py
+++ b/tests/test_dax_config_round_trip.py
@@ -1,0 +1,151 @@
+"""Tests for ~/.dax.yaml round-trip preservation.
+
+`dax creds add`, `dax creds update`, and `dax init` all rewrite the whole
+config file. Under pyyaml that deleted every comment and alphabetised every
+key, because `safe_load` never sees comments and `dump` defaults to
+`sort_keys=True`. The commented-out feature line `#- claude_tenant_state` is
+the case that made this urgent: it is a toggle, not decoration, and losing it
+silently changes which features a project opts into.
+"""
+import sys
+
+import pytest
+
+from dax_creds.config import load_dax_config
+from dax_creds.init import save_config
+
+
+CONFIG_WITH_COMMENTS = """\
+# dax configuration — hand-maintained, order matters for readability
+defaults:
+  image: dax-base
+
+# Credentials are delivered by the daemon, never mounted.
+credentials:
+  claude-personal-fabric:
+    provider: claude
+  github-dfarrow:
+    provider: github
+
+features:
+- claude
+# Opt-in per project; left off until the shared plugin migration lands.
+#- claude_tenant_state
+- ssh
+
+projects:
+  fabric:
+    dir: /Users/dfarrow/src/fabric
+    tenant: personal
+    creds:
+    - claude-personal-fabric
+"""
+
+
+def _write(tmp_path, text):
+    (tmp_path / '.dax.yaml').write_text(text)
+
+
+def _read(tmp_path):
+    return (tmp_path / '.dax.yaml').read_text()
+
+
+def test_comments_survive_a_load_save_cycle(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write(tmp_path, CONFIG_WITH_COMMENTS)
+
+    save_config(load_dax_config())
+
+    written = _read(tmp_path)
+    assert '# dax configuration — hand-maintained' in written
+    assert '# Credentials are delivered by the daemon, never mounted.' in written
+
+
+def test_commented_out_feature_line_survives(tmp_path, monkeypatch):
+    """The toggle that motivated this fix. Losing it silently opts a project in."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write(tmp_path, CONFIG_WITH_COMMENTS)
+
+    save_config(load_dax_config())
+
+    written = _read(tmp_path)
+    assert '#- claude_tenant_state' in written
+    assert '# Opt-in per project' in written
+
+
+def test_key_order_is_not_alphabetised(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write(tmp_path, CONFIG_WITH_COMMENTS)
+
+    save_config(load_dax_config())
+
+    written = _read(tmp_path)
+    order = [written.index(k) for k in ('defaults:', 'credentials:', 'features:', 'projects:')]
+    assert order == sorted(order), 'top-level keys were reordered'
+    # pyyaml's sort_keys=True would have put credentials before defaults.
+    assert written.index('credentials:') > written.index('defaults:')
+
+
+def test_edits_are_applied_while_comments_are_kept(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write(tmp_path, CONFIG_WITH_COMMENTS)
+
+    config = load_dax_config()
+    config['projects']['fabric']['tenant'] = 'ysecurity'
+    config['credentials']['claude-ysecurity-fabric'] = {'provider': 'claude'}
+    save_config(config)
+
+    reloaded = load_dax_config()
+    assert reloaded['projects']['fabric']['tenant'] == 'ysecurity'
+    assert reloaded['credentials']['claude-ysecurity-fabric']['provider'] == 'claude'
+    assert '#- claude_tenant_state' in _read(tmp_path)
+
+
+def test_long_paths_are_not_line_wrapped(tmp_path, monkeypatch):
+    """ruamel wraps at 80 columns by default; `dir:` values routinely exceed it."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    long_dir = '/Users/dfarrow/src/' + ('a' * 100)
+    _write(tmp_path, 'projects:\n  p:\n    dir: {}\n'.format(long_dir))
+
+    save_config(load_dax_config())
+
+    assert long_dir in _read(tmp_path)
+    assert load_dax_config()['projects']['p']['dir'] == long_dir
+
+
+def test_saving_is_idempotent_after_the_first_write(tmp_path, monkeypatch):
+    """ruamel normalises some scalars once (e.g. `True` -> `true`); it must not
+    keep churning the file on every subsequent save."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write(tmp_path, CONFIG_WITH_COMMENTS + 'multi_tenant: True\n')
+
+    save_config(load_dax_config())
+    first = _read(tmp_path)
+    save_config(load_dax_config())
+
+    assert _read(tmp_path) == first
+
+
+def test_save_config_refuses_when_ruamel_is_missing(tmp_path, monkeypatch):
+    """Refusing beats falling back: a pyyaml rewrite destroys the file."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write(tmp_path, CONFIG_WITH_COMMENTS)
+    config = load_dax_config()
+    monkeypatch.setitem(sys.modules, 'ruamel.yaml', None)
+
+    with pytest.raises(ImportError, match='ruamel.yaml'):
+        save_config(config)
+
+    assert _read(tmp_path) == CONFIG_WITH_COMMENTS, 'config was modified despite the refusal'
+
+
+def test_load_dax_config_falls_back_to_pyyaml_when_ruamel_is_missing(tmp_path, monkeypatch):
+    """Reads must keep working — `dax run` calls this and only ever reads."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write(tmp_path, CONFIG_WITH_COMMENTS)
+    monkeypatch.setitem(sys.modules, 'ruamel.yaml', None)
+
+    config = load_dax_config()
+
+    assert config['projects']['fabric']['tenant'] == 'personal'
+    assert config['features'] == ['claude', 'ssh']

--- a/tests/test_dax_cred_resolution.py
+++ b/tests/test_dax_cred_resolution.py
@@ -1,0 +1,164 @@
+"""Tests for per-env Claude credential naming.
+
+Listing a bare `claude` in an env's `creds:` asks dax to derive
+`claude-<tenant>-<project>` rather than the user hand-maintaining the
+convention. That matters because a hand-maintained convention is one users
+typo — a real `claud-fre` entry sat unused in ~/.dax.yaml for weeks — and
+because per-env credentials are what make rotation in one project unable to
+poison another (redesign decision C).
+"""
+import pytest
+
+from dax_creds.config import (
+    credential_users, derived_credential_name, derived_credentials,
+    find_named_project_by_dir, get_project_credentials, resolve_credential_names,
+    synthesized_credential,
+)
+
+
+FABRIC = {'dir': '/src/fabric', 'tenant': 'personal',
+          'creds': ['claude', 'github-dfarrow']}
+REGISTRY = {'credentials': {'github-dfarrow': {'provider': 'github'}}}
+
+
+def test_bare_token_resolves_to_the_convention():
+    """The second element is the provider when dax derived the name, None when
+    the user named it — that is what tells the caller to synthesize."""
+    resolved = resolve_credential_names(FABRIC, 'fabric')
+
+    assert resolved == [('claude-personal-fabric', 'claude'), ('github-dfarrow', None)]
+
+
+def test_derived_name_shape():
+    assert derived_credential_name('claude', 'ysecurity', 'onboard') == 'claude-ysecurity-onboard'
+
+
+def test_explicit_name_wins_over_the_convention():
+    """Backward compatibility, and a deliberate escape hatch for sharing one
+    credential across two envs."""
+    project = dict(FABRIC, creds=['claude-fre'])
+
+    assert resolve_credential_names(project, 'fabric') == [('claude-fre', None)]
+
+
+def test_bare_token_without_a_tenant_is_refused():
+    project = {'dir': '/src/fabric', 'creds': ['claude']}
+
+    with pytest.raises(ValueError) as excinfo:
+        resolve_credential_names(project, 'fabric')
+
+    message = excinfo.value.args[0]
+    assert 'no tenant' in message
+    assert 'dax env set fabric tenant' in message
+
+
+def test_unregistered_derived_credential_is_synthesized():
+    """First run for a new env: the name resolves before anything registers it,
+    so the caller can report it missing from Keychain and offer a login."""
+    creds = get_project_credentials(REGISTRY, FABRIC, 'fabric')
+
+    assert creds['claude-personal-fabric'] == {'provider': 'claude'}
+    assert creds['github-dfarrow']['provider'] == 'github'
+
+
+def test_registered_derived_credential_uses_its_real_definition():
+    config = {'credentials': dict(
+        REGISTRY['credentials'],
+        **{'claude-personal-fabric': {'provider': 'claude', 'browser': 'chrome'}})}
+
+    creds = get_project_credentials(config, FABRIC, 'fabric')
+
+    assert creds['claude-personal-fabric']['browser'] == 'chrome'
+
+
+def test_unknown_explicit_credential_still_raises():
+    project = dict(FABRIC, creds=['nope'])
+
+    with pytest.raises(KeyError):
+        get_project_credentials(REGISTRY, project, 'fabric')
+
+
+def test_without_a_project_name_the_list_is_taken_literally():
+    """The older call signature, kept so existing callers don't change meaning."""
+    project = dict(FABRIC, creds=['github-dfarrow'])
+
+    assert list(get_project_credentials(REGISTRY, project)) == ['github-dfarrow']
+
+
+# --- per-provider defaults -------------------------------------------------
+
+DEFAULTS = {'credential_defaults': {'claude': {'browser': 'chrome',
+                                               'chrome_profile': 'Profile 2'}}}
+
+
+def test_derived_credential_inherits_browser_defaults():
+    """A derived credential has no entry to hold browser/chrome_profile, so
+    without defaults every per-env login opens the wrong browser."""
+    config = dict(REGISTRY, **DEFAULTS)
+
+    creds = get_project_credentials(config, FABRIC, 'fabric')
+
+    assert creds['claude-personal-fabric'] == {
+        'provider': 'claude', 'browser': 'chrome', 'chrome_profile': 'Profile 2'}
+
+
+def test_synthesized_credential_without_defaults_is_bare():
+    assert synthesized_credential({}, 'claude') == {'provider': 'claude'}
+
+
+def test_defaults_never_override_the_provider():
+    config = {'credential_defaults': {'claude': {'provider': 'nonsense'}}}
+
+    assert synthesized_credential(config, 'claude')['provider'] == 'claude'
+
+
+def test_a_registered_credential_ignores_the_defaults():
+    """An explicit entry owns its own settings."""
+    config = dict(DEFAULTS, credentials=dict(
+        REGISTRY['credentials'],
+        **{'claude-personal-fabric': {'provider': 'claude', 'browser': 'firefox'}}))
+
+    creds = get_project_credentials(config, FABRIC, 'fabric')
+
+    assert creds['claude-personal-fabric']['browser'] == 'firefox'
+
+
+# --- enumeration -----------------------------------------------------------
+
+def test_derived_credentials_are_enumerable():
+    """`dax creds list` on the host must not disagree with `dax-creds list`
+    inside the container about which credentials exist."""
+    config = dict(REGISTRY, projects={'fabric': FABRIC}, **DEFAULTS)
+
+    derived = derived_credentials(config)
+
+    assert list(derived) == ['claude-personal-fabric']
+    assert derived['claude-personal-fabric']['chrome_profile'] == 'Profile 2'
+
+
+def test_enumeration_skips_envs_that_cannot_resolve():
+    config = {'credentials': {}, 'projects': {'broken': {'creds': ['claude']}}}
+
+    assert derived_credentials(config) == {}
+
+
+def test_credential_users_resolves_bare_tokens():
+    config = {'projects': {'fabric': FABRIC}}
+
+    assert credential_users(config, 'claude-personal-fabric') == ['fabric']
+    assert credential_users(config, 'github-dfarrow') == ['fabric']
+    assert credential_users(config, 'claude') == []
+
+
+def test_find_named_project_by_dir_returns_the_name(tmp_path):
+    config = {'projects': {'fabric': {'dir': str(tmp_path)}}}
+
+    name, project = find_named_project_by_dir(config, tmp_path)
+
+    assert name == 'fabric'
+    assert project['dir'] == str(tmp_path)
+
+
+def test_find_named_project_by_dir_raises_when_absent(tmp_path):
+    with pytest.raises(KeyError):
+        find_named_project_by_dir({'projects': {}}, tmp_path)

--- a/tests/test_dax_creds_add_flow.py
+++ b/tests/test_dax_creds_add_flow.py
@@ -1,0 +1,262 @@
+"""`dax creds add` asks the provider first, and never asks for a per-env name.
+
+Naming is dax's job (decision C2): a hand-typed name is where `claud-fre` came
+from — a misspelling that sat unused in ~/.dax.yaml for weeks, silently, because
+a credential name nothing resolves to is simply never matched. Asking the
+provider first is what makes skipping the name prompt possible.
+
+The claude path also never imports a token from disk. That copy is what puts two
+names on one OAuth grant, so `add` sets up the definition and hands off to the
+login that mints an independent grant.
+"""
+import pytest
+
+import dax_creds.init as init_module
+from dax_creds.init import _add_per_env_credential, _env_choices, _run_creds_add
+
+
+@pytest.fixture
+def config():
+    return {
+        'credential_defaults': {'claude': {'browser': 'chrome',
+                                           'chrome_profile': 'Profile 2'}},
+        'credentials': {'github-dbfarrow': {'provider': 'github'}},
+        'projects': {
+            'dax': {'tenant': 'personal', 'dir': '/repos/dax',
+                    'creds': ['claude', 'github-dbfarrow']},
+            'fabric': {'tenant': 'personal', 'dir': '/repos/fabric',
+                       'creds': ['github-dbfarrow']},
+            'untenanted': {'dir': '/repos/untenanted', 'creds': []},
+        },
+    }
+
+
+class Answers:
+    """Scripted replies, so a prompt the flow should not reach raises."""
+
+    def __init__(self, selects=(), texts=(), confirms=()):
+        self.selects = list(selects)
+        self.texts = list(texts)
+        self.confirms = list(confirms)
+        self.prompts_seen = []
+
+    def select(self, prompt, choices):
+        self.prompts_seen.append(prompt)
+        assert self.selects, f'unexpected select: {prompt}'
+        return self.selects.pop(0)
+
+    def text(self, prompt, default=None):
+        self.prompts_seen.append(prompt)
+        assert self.texts, f'unexpected text prompt: {prompt}'
+        return self.texts.pop(0)
+
+    def confirm(self, prompt, default=False):
+        self.prompts_seen.append(prompt)
+        assert self.confirms, f'unexpected confirm: {prompt}'
+        return self.confirms.pop(0)
+
+
+@pytest.fixture
+def answers(monkeypatch):
+    a = Answers()
+    monkeypatch.setattr(init_module, '_q_select', a.select)
+    monkeypatch.setattr(init_module, '_prompt', a.text)
+    monkeypatch.setattr(init_module, '_q_confirm', a.confirm)
+    monkeypatch.setattr(init_module, 'save_config', lambda cfg: None)
+    monkeypatch.setattr(init_module, '_keyring_module', None)
+    return a
+
+
+# --- the claude path: no name prompt ----------------------------------------
+
+def test_claude_never_asks_for_a_credential_name(config, answers):
+    answers.selects = ['claude', 'dax']
+    answers.confirms = [True]          # run the login now?
+
+    _, pending = _run_creds_add(config, cwd='/repos/dax')
+
+    assert pending == 'claude-personal-dax'
+    assert not any('name' in p.lower() for p in answers.prompts_seen), \
+        answers.prompts_seen
+
+
+def test_claude_offers_the_login_that_mints_the_grant(config, answers):
+    answers.selects = ['claude', 'fabric']
+    answers.confirms = [True, True]    # add to creds list, then run login
+
+    _, pending = _run_creds_add(config, cwd='/repos/fabric')
+
+    assert pending == 'claude-personal-fabric'
+
+
+def test_declining_the_login_still_saves_and_says_how(config, answers, capsys):
+    answers.selects = ['claude', 'dax']
+    answers.confirms = [False]
+
+    _, pending = _run_creds_add(config, cwd='/repos/dax')
+
+    assert pending is None
+    assert 'dax creds login claude-personal-dax' in capsys.readouterr().out
+
+
+def test_claude_adds_the_bare_token_to_an_env_that_lacks_it(config, answers):
+    answers.selects = ['claude', 'fabric']
+    answers.confirms = [True, False]
+
+    _run_creds_add(config, cwd='/repos/fabric')
+
+    assert config['projects']['fabric']['creds'] == ['github-dbfarrow', 'claude']
+
+
+def test_declining_that_leaves_the_creds_list_alone(config, answers, capsys):
+    answers.selects = ['claude', 'fabric']
+    answers.confirms = [False, False]
+
+    _run_creds_add(config, cwd='/repos/fabric')
+
+    assert config['projects']['fabric']['creds'] == ['github-dbfarrow']
+    assert 'go unused' in capsys.readouterr().out
+
+
+def test_an_env_that_already_uses_it_is_not_asked_again(config, answers):
+    """`dax` already lists a bare `claude`, so only the login confirm is due."""
+    answers.selects = ['claude', 'dax']
+    answers.confirms = [True]
+
+    _run_creds_add(config, cwd='/repos/dax')
+
+    assert config['projects']['dax']['creds'].count('claude') == 1
+
+
+# --- tenant, asked only where it is genuinely unknown ------------------------
+
+def test_tenant_is_not_asked_when_the_env_already_has_one(config, answers):
+    answers.selects = ['claude', 'dax']
+    answers.confirms = [True]
+
+    _run_creds_add(config, cwd='/repos/dax')
+
+    assert not any('tenant' in p.lower() for p in answers.prompts_seen), \
+        answers.prompts_seen
+
+
+def test_tenant_is_asked_when_the_env_has_none(config, answers):
+    """The derived name cannot be built without it, and C2 refuses rather than
+    falling back to a shared credential."""
+    answers.selects = ['claude', 'untenanted']
+    answers.texts = ['acme']
+    answers.confirms = [True, True]
+
+    _, pending = _run_creds_add(config, cwd='/repos/untenanted')
+
+    assert config['projects']['untenanted']['tenant'] == 'acme'
+    assert pending == 'claude-acme-untenanted'
+
+
+def test_no_tenant_given_saves_nothing(config, answers, capsys):
+    answers.selects = ['claude', 'untenanted']
+    answers.texts = ['']
+
+    _, pending = _run_creds_add(config, cwd='/repos/untenanted')
+
+    assert pending is None
+    assert 'tenant' not in config['projects']['untenanted']
+    assert 'Nothing saved' in capsys.readouterr().out
+
+
+# --- credential_defaults ----------------------------------------------------
+
+def test_browser_is_not_asked_when_defaults_exist(config, answers):
+    """Browser belongs to the human authenticating, so one defaults block covers
+    every derived credential (C4) instead of being re-answered per env."""
+    answers.selects = ['claude', 'dax']
+    answers.confirms = [True]
+
+    _run_creds_add(config, cwd='/repos/dax')
+
+    assert not any('rowser' in p for p in answers.prompts_seen), answers.prompts_seen
+
+
+def test_browser_is_asked_once_and_written_to_defaults(config, answers, monkeypatch):
+    del config['credential_defaults']
+    monkeypatch.setattr(init_module, '_pick_browser',
+                        lambda *a, **k: {'browser': 'chrome',
+                                         'chrome_profile': 'Profile 7'})
+    answers.selects = ['claude', 'dax']
+    answers.confirms = [True]
+
+    _run_creds_add(config, cwd='/repos/dax')
+
+    assert config['credential_defaults']['claude'] == {'browser': 'chrome',
+                                                       'chrome_profile': 'Profile 7'}
+
+
+# --- env selection ----------------------------------------------------------
+
+def test_the_env_containing_cwd_is_offered_first(config):
+    assert _env_choices(config, cwd='/repos/fabric')[0] == 'fabric'
+
+
+def test_a_subdirectory_still_resolves_to_its_env(config):
+    """`find_enclosing_project`'s case: cwd nested inside a registered env."""
+    assert _env_choices(config, cwd='/repos/dax/dax_creds')[0] == 'dax'
+
+
+def test_an_unrelated_cwd_just_leaves_the_order_alone(config):
+    assert set(_env_choices(config, cwd='/tmp/elsewhere')) == set(config['projects'])
+
+
+def test_no_envs_registered_is_refused_with_a_pointer(answers, capsys):
+    _, pending = _add_per_env_credential({'projects': {}}, 'claude', cwd='/tmp')
+
+    assert pending is None
+    assert 'dax init' in capsys.readouterr().out
+
+
+# --- the honest report on the non-per-env path -------------------------------
+
+def test_a_credential_with_no_secret_does_not_claim_to_be_saved(
+        config, answers, monkeypatch, capsys):
+    """"saved" is true of the YAML write but answers the wrong question — the
+    user is asking whether the credential works now."""
+    monkeypatch.setattr(init_module, '_define_credential',
+                        lambda *a, **k: {'provider': 'gmail'})
+    monkeypatch.setattr(init_module, '_setup_google_credential',
+                        lambda *a, **k: False)
+    answers.selects = ['gmail']
+    answers.texts = ['gmail-new']
+
+    _run_creds_add(config, cwd='/repos/dax')
+
+    out = capsys.readouterr().out
+    assert 'no secret is stored for it yet' in out
+    assert 'dax creds login gmail-new' in out
+
+
+def test_a_credential_that_did_store_reports_plainly(
+        config, answers, monkeypatch, capsys):
+    monkeypatch.setattr(init_module, '_define_credential',
+                        lambda *a, **k: {'provider': 'ssh', 'key': '~/.ssh/id_rsa'})
+    monkeypatch.setattr(init_module, '_setup_ssh_credential', lambda *a, **k: True)
+    answers.selects = ['ssh']
+    answers.texts = ['ssh-new']
+
+    _run_creds_add(config, cwd='/repos/dax')
+
+    out = capsys.readouterr().out
+    assert 'saved' in out
+    assert 'no secret' not in out
+
+
+def test_provider_is_asked_before_the_name(config, answers, monkeypatch):
+    """Reversed from the original flow, and it is what lets the claude path skip
+    the name prompt entirely."""
+    monkeypatch.setattr(init_module, '_define_credential',
+                        lambda *a, **k: {'provider': 'ssh'})
+    monkeypatch.setattr(init_module, '_setup_ssh_credential', lambda *a, **k: True)
+    answers.selects = ['ssh']
+    answers.texts = ['ssh-new']
+
+    _run_creds_add(config, cwd='/repos/dax')
+
+    assert answers.prompts_seen[0] == 'Provider:'

--- a/tests/test_dax_creds_claude_wrapper.py
+++ b/tests/test_dax_creds_claude_wrapper.py
@@ -108,6 +108,56 @@ def test_no_fetch_attempted_without_credential_name(tmp_path):
     assert proc.stderr == ''
 
 
+# --- inject-if-absent ------------------------------------------------------
+#
+# The Keychain copy is a bootstrap, not the running source of truth. Claude Code
+# refreshes the credential into its own state tree and nothing propagates back,
+# so re-writing the daemon snapshot on every launch would clobber a refreshed
+# token with a stale one — and if refresh tokens rotate on use, that stale token
+# is already dead. See decision C of docs/design/2026-07-27-tenant-isolation.md.
+
+REFRESHED = {'claudeAiOauth': {'accessToken': 'sk-ant-oat01-rotated',
+                               'refreshToken': 'sk-ant-ort01-rotated'}}
+
+
+def _seed_credential(tmp_path, content):
+    creds = tmp_path / 'home' / '.claude' / '.credentials.json'
+    creds.parent.mkdir(parents=True, exist_ok=True)
+    creds.write_text(content)
+    return creds
+
+
+def test_existing_credential_is_not_overwritten(tmp_path):
+    """A token Claude Code refreshed in-tree must survive the next launch."""
+    _seed_credential(tmp_path, json.dumps(REFRESHED))
+
+    proc, creds = _run(tmp_path, ENVELOPE_JSON)
+
+    assert proc.returncode == 0
+    assert json.loads(creds.read_text()) == REFRESHED
+
+
+def test_existing_credential_skips_the_daemon_fetch(tmp_path):
+    """Nothing is fetched when the tree already has a credential — so a daemon
+    that is down or holding a dead snapshot cannot break an existing session."""
+    _seed_credential(tmp_path, json.dumps(REFRESHED))
+
+    proc, creds = _run(tmp_path, '', dax_creds_exit=1)
+
+    assert proc.returncode == 0
+    assert 'could not fetch' not in proc.stderr
+    assert json.loads(creds.read_text()) == REFRESHED
+
+
+def test_empty_credential_file_is_treated_as_absent(tmp_path):
+    """An interrupted write leaves a zero-byte file; that must not wedge auth."""
+    _seed_credential(tmp_path, '')
+
+    proc, creds = _run(tmp_path, ENVELOPE_JSON)
+
+    assert json.loads(creds.read_text()) == ENVELOPE
+
+
 # --- onboarding seed -------------------------------------------------------
 #
 # Claude Code's first-run wizard is gated on .claude.json and runs *ahead of*

--- a/tests/test_dax_creds_claude_wrapper.py
+++ b/tests/test_dax_creds_claude_wrapper.py
@@ -166,6 +166,16 @@ def test_seed_does_not_set_folder_trust(tmp_path):
     assert 'projects' not in seeded
 
 
+def test_seed_does_not_set_oauth_account(tmp_path):
+    # oauthAccount/userID need real account data (email, org, account UUID);
+    # nothing plumbs that from the daemon/host into the wrapper today, so
+    # seeding a fabricated value would be worse than seeding nothing.
+    _run(tmp_path, ENVELOPE_JSON)
+    seeded = json.loads((tmp_path / 'home' / '.claude.json').read_text())
+    assert 'oauthAccount' not in seeded
+    assert 'userID' not in seeded
+
+
 def test_seed_is_owner_only(tmp_path):
     _run(tmp_path, ENVELOPE_JSON)
     state = tmp_path / 'home' / '.claude.json'
@@ -199,4 +209,126 @@ def test_config_dir_created_when_missing(tmp_path):
     proc, _ = _run(tmp_path, ENVELOPE_JSON, env={'CLAUDE_CONFIG_DIR': str(cfg)})
     assert proc.returncode == 0
     assert (cfg / '.credentials.json').exists()
+    assert (cfg / '.claude.json').exists()
+
+
+# --- DAX_TENANT_STATE: Gate B tenant resolution -----------------------------
+#
+# DAX_TENANT_STATE is the master switch, set by `dax run` only for projects
+# that have opted into the (not yet built) claude_tenant_state feature. Unset
+# - every project today - none of this runs; the tests above already prove
+# that (none of them set it). These tests cover the opted-in path, stubbing
+# `dax-creds resolve-tenant` rather than exercising the real tenant-resolution
+# module - that module has its own full unit coverage in
+# tests/test_dax_creds_tenant.py.
+
+def _run_tenant_state(tmp_path, resolve_stdout, resolve_exit=0,
+                       dax_creds_stdout=ENVELOPE_JSON, dax_creds_exit=0, env=None):
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir(exist_ok=True)
+
+    wrapper = bin_dir / 'claude'
+    wrapper.write_text(WRAPPER.read_text())
+    wrapper.chmod(0o755)
+
+    call_log = tmp_path / 'dax-creds-calls.log'
+    stub = bin_dir / 'dax-creds'
+    stub.write_text(
+        '#!/bin/bash\n'
+        'echo "$@" >> {log!r}\n'
+        'if [ "$1" = "resolve-tenant" ]; then\n'
+        '    printf %b {resolve_stdout!r} >&1\n'
+        '    printf %b {resolve_stderr!r} >&2\n'
+        '    exit {resolve_exit}\n'
+        'else\n'
+        '    printf %s {get_stdout!r}\n'
+        '    exit {get_exit}\n'
+        'fi\n'.format(
+            log=str(call_log), resolve_stdout=resolve_stdout,
+            resolve_stderr='' if resolve_exit == 0 else 'dax-creds: refused\n',
+            resolve_exit=resolve_exit, get_stdout=dax_creds_stdout, get_exit=dax_creds_exit))
+    stub.chmod(0o755)
+
+    real = bin_dir / 'claude-real'
+    real.write_text('#!/bin/bash\necho ran-claude-real > {}\nexit 0\n'.format(
+        tmp_path / 'claude-real-ran'))
+    real.chmod(0o755)
+
+    home = tmp_path / 'home'
+    home.mkdir(exist_ok=True)
+
+    full_env = {
+        'PATH': f'{bin_dir}:/usr/bin:/bin',
+        'HOME': str(home),
+        'DAX_CREDS_SOCK': 'tcp:127.0.0.1:9999',
+        'DAX_CREDS_CLAUDE': 'claude-fre',
+        'DAX_CLAUDE_REAL': str(real),
+        'DAX_TENANT_STATE': '1',
+    }
+    if env:
+        full_env.update(env)
+
+    proc = subprocess.run([str(wrapper)], env=full_env, capture_output=True,
+                          text=True, timeout=30)
+    return proc, home, call_log
+
+
+def test_tenant_state_unset_never_invokes_resolve_tenant(tmp_path):
+    # Belt-and-suspenders on top of every test above not setting
+    # DAX_TENANT_STATE: confirm dax-creds is never even called with
+    # resolve-tenant when the switch is off.
+    proc, creds = _run(tmp_path, ENVELOPE_JSON)
+    assert proc.returncode == 0
+    assert json.loads(creds.read_text()) == ENVELOPE
+
+
+def test_tenant_state_sets_claude_config_dir_from_resolution(tmp_path):
+    proc, home, _ = _run_tenant_state(
+        tmp_path, resolve_stdout='TENANT=personal\nPROJECT=fabric\n')
+
+    assert proc.returncode == 0
+    cfg = home / '.local' / 'state' / 'dax' / 'tenants' / 'personal' / 'fabric'
+    assert json.loads((cfg / '.credentials.json').read_text()) == ENVELOPE
+    assert json.loads((cfg / '.claude.json').read_text()) == {
+        'hasCompletedOnboarding': True}
+
+
+def test_tenant_state_refusal_exits_nonzero_without_running_claude(tmp_path):
+    # Unlike a bad credential (which still execs claude, degraded), a
+    # resolution refusal must not start claude at all.
+    proc, home, _ = _run_tenant_state(tmp_path, resolve_stdout='', resolve_exit=1)
+
+    assert proc.returncode != 0
+    assert not (tmp_path / 'claude-real-ran').exists()
+    assert 'refused' in proc.stderr
+
+
+def test_tenant_state_refusal_does_not_fetch_credential(tmp_path):
+    # Refusing must happen before any credential work, not just before exec.
+    proc, home, call_log = _run_tenant_state(tmp_path, resolve_stdout='', resolve_exit=1)
+
+    calls = call_log.read_text().splitlines()
+    assert calls == ['resolve-tenant']
+
+
+def test_tenant_state_success_still_execs_claude(tmp_path):
+    proc, home, _ = _run_tenant_state(
+        tmp_path, resolve_stdout='TENANT=personal\nPROJECT=fabric\n')
+
+    assert proc.returncode == 0
+    assert (tmp_path / 'claude-real-ran').exists()
+
+
+def test_tenant_state_warn_reaches_stderr(tmp_path):
+    # dax-creds itself prints the warn/refuse detail (see cli.py); the
+    # wrapper does not need its own duplicate messaging for this path.
+    # tenant='unattributed' (not a combined 'unattributed/fabric' string) is
+    # what avoids the wrapper's tenants/$_tenant/$_project template stuttering
+    # into .../unattributed/fabric/fabric.
+    proc, home, _ = _run_tenant_state(
+        tmp_path, resolve_stdout='TENANT=unattributed\nPROJECT=fabric\n',
+        resolve_exit=0)
+
+    assert proc.returncode == 0
+    cfg = home / '.local' / 'state' / 'dax' / 'tenants' / 'unattributed' / 'fabric'
     assert (cfg / '.claude.json').exists()

--- a/tests/test_dax_creds_claude_wrapper.py
+++ b/tests/test_dax_creds_claude_wrapper.py
@@ -261,19 +261,17 @@ def test_config_dir_created_when_missing(tmp_path):
     assert (cfg / '.credentials.json').exists()
     assert (cfg / '.claude.json').exists()
 
-
-# --- DAX_TENANT_STATE: Gate B tenant resolution -----------------------------
+# --- CLAUDE_CONFIG_DIR is handed down, never computed ------------------------
 #
-# DAX_TENANT_STATE is the master switch, set by `dax run` only for projects
-# that have opted into the (not yet built) claude_tenant_state feature. Unset
-# - every project today - none of this runs; the tests above already prove
-# that (none of them set it). These tests cover the opted-in path, stubbing
-# `dax-creds resolve-tenant` rather than exercising the real tenant-resolution
-# module - that module has its own full unit coverage in
-# tests/test_dax_creds_tenant.py.
+# Gate B used to live here: DAX_TENANT_STATE switched on a `dax-creds
+# resolve-tenant` call that derived the path from cwd. That belonged to the
+# multi-tenant model, where one repo could hold several tenants and the answer
+# depended on where the user was standing. Each env is single-tenant now, so
+# `dax run` knows the path before launch and sets it (decision B).
 
-def _run_tenant_state(tmp_path, resolve_stdout, resolve_exit=0,
-                       dax_creds_stdout=ENVELOPE_JSON, dax_creds_exit=0, env=None):
+
+def _run_logging_calls(tmp_path, env=None):
+    """Like `_run`, but records every dax-creds invocation."""
     bin_dir = tmp_path / 'bin'
     bin_dir.mkdir(exist_ok=True)
 
@@ -286,21 +284,11 @@ def _run_tenant_state(tmp_path, resolve_stdout, resolve_exit=0,
     stub.write_text(
         '#!/bin/bash\n'
         'echo "$@" >> {log!r}\n'
-        'if [ "$1" = "resolve-tenant" ]; then\n'
-        '    printf %b {resolve_stdout!r} >&1\n'
-        '    printf %b {resolve_stderr!r} >&2\n'
-        '    exit {resolve_exit}\n'
-        'else\n'
-        '    printf %s {get_stdout!r}\n'
-        '    exit {get_exit}\n'
-        'fi\n'.format(
-            log=str(call_log), resolve_stdout=resolve_stdout,
-            resolve_stderr='' if resolve_exit == 0 else 'dax-creds: refused\n',
-            resolve_exit=resolve_exit, get_stdout=dax_creds_stdout, get_exit=dax_creds_exit))
+        'printf %s {out!r}\n'.format(log=str(call_log), out=ENVELOPE_JSON))
     stub.chmod(0o755)
 
     real = bin_dir / 'claude-real'
-    real.write_text('#!/bin/bash\necho ran-claude-real > {}\nexit 0\n'.format(
+    real.write_text('#!/bin/bash\necho ran > {}\nexit 0\n'.format(
         tmp_path / 'claude-real-ran'))
     real.chmod(0o755)
 
@@ -311,9 +299,8 @@ def _run_tenant_state(tmp_path, resolve_stdout, resolve_exit=0,
         'PATH': f'{bin_dir}:/usr/bin:/bin',
         'HOME': str(home),
         'DAX_CREDS_SOCK': 'tcp:127.0.0.1:9999',
-        'DAX_CREDS_CLAUDE': 'claude-fre',
+        'DAX_CREDS_CLAUDE': 'claude-personal-fabric',
         'DAX_CLAUDE_REAL': str(real),
-        'DAX_TENANT_STATE': '1',
     }
     if env:
         full_env.update(env)
@@ -323,62 +310,42 @@ def _run_tenant_state(tmp_path, resolve_stdout, resolve_exit=0,
     return proc, home, call_log
 
 
-def test_tenant_state_unset_never_invokes_resolve_tenant(tmp_path):
-    # Belt-and-suspenders on top of every test above not setting
-    # DAX_TENANT_STATE: confirm dax-creds is never even called with
-    # resolve-tenant when the switch is off.
-    proc, creds = _run(tmp_path, ENVELOPE_JSON)
-    assert proc.returncode == 0
-    assert json.loads(creds.read_text()) == ENVELOPE
-
-
-def test_tenant_state_sets_claude_config_dir_from_resolution(tmp_path):
-    proc, home, _ = _run_tenant_state(
-        tmp_path, resolve_stdout='TENANT=personal\nPROJECT=fabric\n')
+def test_resolve_tenant_is_never_invoked(tmp_path):
+    """The wrapper must not consult tenant resolution at all any more."""
+    proc, _, call_log = _run_logging_calls(tmp_path)
 
     assert proc.returncode == 0
-    cfg = home / '.local' / 'state' / 'dax' / 'tenants' / 'personal' / 'fabric'
+    assert call_log.read_text().splitlines() == ['get claude-personal-fabric']
+
+
+def test_dax_tenant_state_no_longer_changes_anything(tmp_path):
+    """An image built before decision B carries a wrapper that still contains
+    Gate B, so `dax run` deliberately stopped setting this variable. Setting it
+    here proves the new wrapper ignores it rather than resolving a path."""
+    cfg = tmp_path / 'home' / '.claude'
+    proc, home, call_log = _run_logging_calls(
+        tmp_path, env={'DAX_TENANT_STATE': '1',
+                       'CLAUDE_CONFIG_DIR': str(cfg)})
+
+    assert proc.returncode == 0
+    assert call_log.read_text().splitlines() == ['get claude-personal-fabric']
     assert json.loads((cfg / '.credentials.json').read_text()) == ENVELOPE
+
+
+def test_a_handed_down_config_dir_is_used_verbatim(tmp_path):
+    """`dax run` mounts the state tree at exactly this path, so the wrapper
+    writing anywhere else would silently miss the mount."""
+    cfg = tmp_path / 'home' / '.claude'
+    proc, home, _ = _run_logging_calls(tmp_path, env={'CLAUDE_CONFIG_DIR': str(cfg)})
+
+    assert proc.returncode == 0
     assert json.loads((cfg / '.claude.json').read_text()) == {
         'hasCompletedOnboarding': True}
+    assert not (home / '.claude.json').exists()
 
 
-def test_tenant_state_refusal_exits_nonzero_without_running_claude(tmp_path):
-    # Unlike a bad credential (which still execs claude, degraded), a
-    # resolution refusal must not start claude at all.
-    proc, home, _ = _run_tenant_state(tmp_path, resolve_stdout='', resolve_exit=1)
-
-    assert proc.returncode != 0
-    assert not (tmp_path / 'claude-real-ran').exists()
-    assert 'refused' in proc.stderr
-
-
-def test_tenant_state_refusal_does_not_fetch_credential(tmp_path):
-    # Refusing must happen before any credential work, not just before exec.
-    proc, home, call_log = _run_tenant_state(tmp_path, resolve_stdout='', resolve_exit=1)
-
-    calls = call_log.read_text().splitlines()
-    assert calls == ['resolve-tenant']
-
-
-def test_tenant_state_success_still_execs_claude(tmp_path):
-    proc, home, _ = _run_tenant_state(
-        tmp_path, resolve_stdout='TENANT=personal\nPROJECT=fabric\n')
+def test_claude_still_runs(tmp_path):
+    proc, _, _ = _run_logging_calls(tmp_path)
 
     assert proc.returncode == 0
     assert (tmp_path / 'claude-real-ran').exists()
-
-
-def test_tenant_state_warn_reaches_stderr(tmp_path):
-    # dax-creds itself prints the warn/refuse detail (see cli.py); the
-    # wrapper does not need its own duplicate messaging for this path.
-    # tenant='unattributed' (not a combined 'unattributed/fabric' string) is
-    # what avoids the wrapper's tenants/$_tenant/$_project template stuttering
-    # into .../unattributed/fabric/fabric.
-    proc, home, _ = _run_tenant_state(
-        tmp_path, resolve_stdout='TENANT=unattributed\nPROJECT=fabric\n',
-        resolve_exit=0)
-
-    assert proc.returncode == 0
-    cfg = home / '.local' / 'state' / 'dax' / 'tenants' / 'unattributed' / 'fabric'
-    assert (cfg / '.claude.json').exists()

--- a/tests/test_dax_creds_claude_wrapper.py
+++ b/tests/test_dax_creds_claude_wrapper.py
@@ -349,3 +349,147 @@ def test_claude_still_runs(tmp_path):
 
     assert proc.returncode == 0
     assert (tmp_path / 'claude-real-ran').exists()
+
+
+# --- substrate gate + settings delivery (docs/design/VALIDATION.md) ---------
+#
+# `--check` only, never a bare `wire.sh` — the self-heal already ran once at
+# container boot (dax_creds/wrappers/entrypoint.sh). These tests fake
+# `shared/wire.sh` directly rather than the real virgil script, since only
+# its documented `--check` exit-code contract (0 / 1 / the shell's own 127
+# when it's missing) is part of dax's side of the contract.
+
+def _run_with_substrate(tmp_path, substrate_root=None, wire_check_rc=0,
+                        wire_missing=False, extra_argv=None, env=None,
+                        settings_content=None):
+    """Like `_run`, but wires up $SUBSTRATE_ROOT and records claude-real's argv."""
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir(exist_ok=True)
+
+    wrapper = bin_dir / 'claude'
+    wrapper.write_text(WRAPPER.read_text())
+    wrapper.chmod(0o755)
+
+    real = bin_dir / 'claude-real'
+    argv_log = tmp_path / 'claude-real-argv.txt'
+    # Not a bare `printf '%s\n' "$@" > log`: with zero args that still prints
+    # one blank line (the format string runs once regardless), so an empty
+    # argv would misleadingly read back as [''] instead of [].
+    real.write_text(
+        '#!/bin/bash\n: > {log!r}\nfor a in "$@"; do printf \'%s\\n\' "$a" >> {log!r}; done\n'
+        'exit 0\n'.format(log=str(argv_log)))
+    real.chmod(0o755)
+
+    home = tmp_path / 'home'
+    home.mkdir(exist_ok=True)
+
+    if settings_content is not None:
+        settings = home / '.claude' / 'substrate-settings.json'
+        settings.parent.mkdir(parents=True, exist_ok=True)
+        settings.write_text(settings_content)
+
+    full_env = {
+        'PATH': f'{bin_dir}:/usr/bin:/bin',
+        'HOME': str(home),
+        'DAX_CLAUDE_REAL': str(real),
+    }
+
+    if substrate_root is None:
+        substrate_root = tmp_path / 'virgil'
+    if not wire_missing:
+        shared = substrate_root / 'shared'
+        shared.mkdir(parents=True, exist_ok=True)
+        wire = shared / 'wire.sh'
+        wire.write_text('#!/bin/sh\nexit {}\n'.format(wire_check_rc))
+        wire.chmod(0o755)
+    full_env['SUBSTRATE_ROOT'] = str(substrate_root)
+
+    if env:
+        full_env.update(env)
+
+    argv = [str(wrapper)] + (extra_argv or [])
+    proc = subprocess.run(argv, env=full_env, capture_output=True, text=True, timeout=30)
+    recorded = argv_log.read_text().splitlines() if argv_log.exists() else None
+    return proc, recorded
+
+
+def test_no_substrate_root_skips_the_gate_entirely(tmp_path):
+    """Identical behavior to before this gate existed."""
+    proc, recorded = _run_with_substrate(tmp_path, wire_missing=True,
+                                         env={'SUBSTRATE_ROOT': ''})
+    assert proc.returncode == 0
+    assert recorded == []
+
+
+def test_wired_correctly_proceeds_and_delivers_settings(tmp_path):
+    home = tmp_path / 'home'
+    settings = home / '.claude' / 'substrate-settings.json'
+    proc, recorded = _run_with_substrate(tmp_path, wire_check_rc=0, settings_content='{}')
+
+    assert proc.returncode == 0
+    assert recorded == ['--settings', str(settings)]
+
+
+def test_wired_correctly_without_a_settings_fragment_still_proceeds(tmp_path):
+    proc, recorded = _run_with_substrate(tmp_path, wire_check_rc=0)
+    assert proc.returncode == 0
+    assert recorded == []
+
+
+def test_does_not_clobber_a_caller_supplied_settings_flag(tmp_path):
+    proc, recorded = _run_with_substrate(
+        tmp_path, wire_check_rc=0, settings_content='{}',
+        extra_argv=['--settings', '/some/other/file.json'])
+
+    assert proc.returncode == 0
+    assert recorded == ['--settings', '/some/other/file.json']
+
+
+def test_wired_wrong_refuses_and_never_execs_claude(tmp_path):
+    proc, recorded = _run_with_substrate(tmp_path, wire_check_rc=1)
+
+    assert proc.returncode == 1
+    assert recorded is None
+    assert 'not correctly wired' in proc.stderr
+    assert 'wire.sh' in proc.stderr
+
+
+def test_substrate_not_mounted_refuses_with_a_distinct_message(tmp_path):
+    proc, recorded = _run_with_substrate(tmp_path, wire_missing=True)
+
+    assert proc.returncode == 127
+    assert recorded is None
+    assert 'not mounted' in proc.stderr
+
+
+def test_never_runs_a_bare_wire_sh(tmp_path):
+    """Only --check — a bare `wire.sh` here would let a `claude` restart
+    silently repair wiring broken mid-session, defeating VALIDATION.md's
+    Part 4 failure-mode tests."""
+    substrate_root = tmp_path / 'virgil'
+    shared = substrate_root / 'shared'
+    shared.mkdir(parents=True)
+    call_log = substrate_root / 'wire-calls.txt'
+    wire = shared / 'wire.sh'
+    wire.write_text(
+        '#!/bin/sh\necho "$@" >> {!r}\n[ "$1" = "--check" ] && exit 0 || exit 1\n'.format(
+            str(call_log)))
+    wire.chmod(0o755)
+
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    wrapper = bin_dir / 'claude'
+    wrapper.write_text(WRAPPER.read_text())
+    wrapper.chmod(0o755)
+    real = bin_dir / 'claude-real'
+    real.write_text('#!/bin/bash\nexit 0\n')
+    real.chmod(0o755)
+    home = tmp_path / 'home'
+    home.mkdir()
+
+    subprocess.run([str(wrapper)], env={
+        'PATH': f'{bin_dir}:/usr/bin:/bin', 'HOME': str(home),
+        'DAX_CLAUDE_REAL': str(real), 'SUBSTRATE_ROOT': str(substrate_root),
+    }, capture_output=True, text=True, timeout=30)
+
+    assert call_log.read_text().splitlines() == ['--check']

--- a/tests/test_dax_creds_cli.py
+++ b/tests/test_dax_creds_cli.py
@@ -1,0 +1,171 @@
+"""Tests for the `dax-creds resolve-tenant` subcommand.
+
+Exercises the real dax_creds.tenant module through cli.py's dispatch - the
+module itself has full unit coverage in tests/test_dax_creds_tenant.py; this
+file is about the CLI plumbing around it (argv/env handling, stdout/stderr
+contract, exit codes) that tests/test_dax_creds_claude_wrapper.py stubs out
+rather than exercises.
+"""
+import pytest
+
+from dax_creds.cli import main
+
+
+def _declare(path, tenant):
+    path.mkdir(parents=True, exist_ok=True)
+    (path / '.dax-tenant').write_text(tenant)
+
+
+def test_resolve_tenant_prints_tenant_and_project_on_success(
+        tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    repo = home / 'fabric'
+    _declare(repo, 'personal')
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.setenv('DAX_PROJECT_NAME', 'fabric')
+    monkeypatch.delenv('DAX_MULTI_TENANT', raising=False)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr('sys.argv', ['dax-creds', 'resolve-tenant'])
+
+    main()
+
+    out = capsys.readouterr()
+    assert out.out == 'TENANT=personal\nPROJECT=fabric\n'
+    assert out.err == ''
+
+
+def test_resolve_tenant_exits_nonzero_and_prints_detail_on_refuse(
+        tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    repo = home / 'fabric'
+    _declare(repo, 'personal')
+    subdir = repo / 'src'
+    subdir.mkdir(parents=True)
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.setenv('DAX_PROJECT_NAME', 'fabric')
+    monkeypatch.delenv('DAX_MULTI_TENANT', raising=False)
+    monkeypatch.chdir(subdir)
+    monkeypatch.setattr('sys.argv', ['dax-creds', 'resolve-tenant'])
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code != 0
+    out = capsys.readouterr()
+    assert out.out == ''
+    assert 'project root' in out.err
+
+
+def test_resolve_tenant_undeclared_root_refuses(tmp_path, monkeypatch, capsys):
+    # No automatic unattributed/<reponame> fallback (dropped 2026-07-28) -
+    # dax run's classification step should always resolve this before a
+    # container ever launches; a wrapper invocation reaching an undeclared
+    # root refuses instead of silently pooling into a default tenant.
+    home = tmp_path / 'home'
+    repo = home / 'iandidit'
+    repo.mkdir(parents=True)  # no .dax-tenant at all -> undeclared
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.setenv('DAX_PROJECT_NAME', 'iandidit')
+    monkeypatch.delenv('DAX_MULTI_TENANT', raising=False)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr('sys.argv', ['dax-creds', 'resolve-tenant'])
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code != 0
+    out = capsys.readouterr()
+    assert out.out == ''
+    assert 'dax tenant set' in out.err
+
+
+def test_resolve_tenant_respects_dax_multi_tenant_env_var(
+        tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    repo = home / 'discernment'
+    sub_a = repo / 'project_ysecurity_comp_model'
+    _declare(sub_a, 'ysecurity')
+    _declare(repo / 'project_augment', 'augment')
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.setenv('DAX_PROJECT_NAME', 'discernment')
+    monkeypatch.setenv('DAX_MULTI_TENANT', '1')
+    monkeypatch.chdir(sub_a)
+    monkeypatch.setattr('sys.argv', ['dax-creds', 'resolve-tenant'])
+
+    main()
+
+    out = capsys.readouterr()
+    assert out.out == 'TENANT=ysecurity\nPROJECT=project_ysecurity_comp_model\n'
+
+
+def test_resolve_tenant_respects_dax_tenant_subdir_env_var(
+        tmp_path, monkeypatch, capsys):
+    # discernment's actual tenant subdirectories sit under processes/, not
+    # directly under the repo root - DAX_TENANT_SUBDIR is how that reaches
+    # the wrapper/CLI without generalizing the resolution table itself.
+    home = tmp_path / 'home'
+    repo = home / 'discernment'
+    sub_a = repo / 'processes' / 'project_ysecurity_comp_model'
+    _declare(sub_a, 'ysecurity')
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.setenv('DAX_PROJECT_NAME', 'discernment')
+    monkeypatch.setenv('DAX_MULTI_TENANT', '1')
+    monkeypatch.setenv('DAX_TENANT_SUBDIR', 'processes')
+    monkeypatch.chdir(sub_a)
+    monkeypatch.setattr('sys.argv', ['dax-creds', 'resolve-tenant'])
+
+    main()
+
+    out = capsys.readouterr()
+    assert out.out == 'TENANT=ysecurity\nPROJECT=project_ysecurity_comp_model\n'
+
+
+def test_resolve_tenant_refuses_in_an_unrelated_home_level_mount(
+        tmp_path, monkeypatch, capsys):
+    # ~/.claude, ~/.augment, ~/.aws etc. sit at the same level as a project's
+    # own mount. DAX_PROJECT_NAME is what tells resolve-tenant "fabric" is the
+    # real project here, not whatever directory the user happened to cd into.
+    home = tmp_path / 'home'
+    _declare(home / 'fabric', 'personal')
+    other_mount = home / '.claude'
+    other_mount.mkdir(parents=True)
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.setenv('DAX_PROJECT_NAME', 'fabric')
+    monkeypatch.delenv('DAX_MULTI_TENANT', raising=False)
+    monkeypatch.chdir(other_mount)
+    monkeypatch.setattr('sys.argv', ['dax-creds', 'resolve-tenant'])
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code != 0
+    out = capsys.readouterr()
+    assert 'unattributed' not in out.out
+
+
+def test_resolve_tenant_fails_clearly_when_project_name_env_var_missing(
+        tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    repo = home / 'fabric'
+    _declare(repo, 'personal')
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.delenv('DAX_PROJECT_NAME', raising=False)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr('sys.argv', ['dax-creds', 'resolve-tenant'])
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code != 0
+    out = capsys.readouterr()
+    assert 'DAX_PROJECT_NAME' in out.err
+
+
+def test_resolve_tenant_rejects_extra_arguments(monkeypatch, capsys):
+    monkeypatch.setattr('sys.argv', ['dax-creds', 'resolve-tenant', 'extra'])
+
+    with pytest.raises(SystemExit):
+        main()
+
+    out = capsys.readouterr()
+    assert 'Usage: dax-creds resolve-tenant' in out.err

--- a/tests/test_dax_creds_config.py
+++ b/tests/test_dax_creds_config.py
@@ -1,6 +1,9 @@
 import pytest
 import yaml
-from dax_creds.config import load_dax_config, find_project_by_dir, get_project_credentials
+from dax_creds.config import (
+    load_dax_config, find_project_by_dir, find_enclosing_project,
+    get_project_credentials, dir_basename,
+)
 
 
 def _write_yaml(path, data):
@@ -45,6 +48,38 @@ def test_find_project_by_dir_raises_when_no_match(tmp_path):
         find_project_by_dir(config, tmp_path / 'other-dir')
 
 
+def test_find_enclosing_project_finds_ancestor_for_a_nested_subdir(tmp_path):
+    root = tmp_path / 'discernment'
+    subdir = root / 'processes' / 'ysecurity-onboard'
+    config = {'projects': {'discernment': {'dir': str(root), 'multi_tenant': True}}}
+
+    result = find_enclosing_project(config, subdir)
+
+    assert result is not None
+    name, project = result
+    assert name == 'discernment'
+    assert project['dir'] == str(root)
+
+
+def test_find_enclosing_project_returns_none_for_the_root_itself(tmp_path):
+    root = tmp_path / 'discernment'
+    config = {'projects': {'discernment': {'dir': str(root)}}}
+
+    assert find_enclosing_project(config, root) is None
+
+
+def test_find_enclosing_project_returns_none_when_unrelated(tmp_path):
+    root = tmp_path / 'discernment'
+    unrelated = tmp_path / 'some-other-dir'
+    config = {'projects': {'discernment': {'dir': str(root)}}}
+
+    assert find_enclosing_project(config, unrelated) is None
+
+
+def test_find_enclosing_project_returns_none_when_no_projects_registered(tmp_path):
+    assert find_enclosing_project({}, tmp_path / 'anything') is None
+
+
 def test_load_dax_config_raises_when_file_missing(tmp_path, monkeypatch):
     monkeypatch.setenv('HOME', str(tmp_path))
 
@@ -70,3 +105,26 @@ def test_get_project_credentials_resolves_named_refs(tmp_path):
     creds = get_project_credentials(config, project)
 
     assert creds == {'github-dfarrow': {'provider': 'github'}}
+
+
+@pytest.mark.parametrize('path, expected', [
+    ('/Users/dave/my-project', 'my-project'),
+    ('/Users/dave/my-project/', 'my-project'),
+    ('/Users/dave/my-project//', 'my-project'),
+    ('/Users/dave/my.project', 'my.project'),
+    ('/Users/dave/my project', 'my project'),
+    ('/Users/dave/.hidden-project', '.hidden-project'),
+])
+def test_dir_basename(path, expected):
+    assert dir_basename(path) == expected
+
+
+def test_dir_basename_accepts_path_object(tmp_path):
+    assert dir_basename(tmp_path / 'my-project') == 'my-project'
+
+
+def test_dir_basename_not_fooled_by_trailing_slash_unlike_os_path_basename():
+    import os
+    # The bug class this helper exists to avoid.
+    assert os.path.basename('/Users/dave/my-project/') == ''
+    assert dir_basename('/Users/dave/my-project/') == 'my-project'

--- a/tests/test_dax_creds_daemon.py
+++ b/tests/test_dax_creds_daemon.py
@@ -1,6 +1,33 @@
+import asyncio
 import json
 import pytest
-from dax_creds.daemon import handle_request, handle_open_url, handle_list, FileTokenStore, KeyringTokenStore
+from dax_creds.daemon import handle_request, handle_open_url, handle_list, FileTokenStore, KeyringTokenStore, _make_handle
+
+
+class FakeReader:
+    def __init__(self, data):
+        self._data = data
+
+    async def read(self, n):
+        return self._data
+
+
+class FakeWriter:
+    def __init__(self):
+        self.written = b''
+        self.closed = False
+
+    def write(self, data):
+        self.written += data
+
+    async def drain(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+    async def wait_closed(self):
+        pass
 
 
 class FakeKeyring:
@@ -191,6 +218,97 @@ def test_handle_open_url_returns_error_when_url_missing():
         lambda url, browser, profile: None,
     )
     assert response['error'] == 'missing_url'
+
+
+def test_handle_open_url_rewrites_claude_localhost_redirect_to_device_flow():
+    credentials = {'claude-fre': {'provider': 'claude', 'browser': 'chrome', 'chrome_profile': 'Profile 2'}}
+    opened = []
+    localhost_url = (
+        'https://claude.com/cai/oauth/authorize?code=true&client_id=abc'
+        '&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A43775%2Fcallback'
+        '&scope=user%3Aprofile&code_challenge=xyz&code_challenge_method=S256&state=stateval'
+    )
+
+    response = handle_open_url(
+        {'action': 'open_url', 'credential': 'claude-fre', 'url': localhost_url},
+        credentials,
+        lambda url, browser, profile: opened.append((url, browser, profile)),
+    )
+
+    assert response == {'ok': True}
+    opened_url, browser, profile = opened[0]
+    assert browser == 'chrome'
+    assert profile == 'Profile 2'
+    assert 'redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback' in opened_url
+    # Everything else about the authorization request is preserved untouched.
+    assert 'client_id=abc' in opened_url
+    assert 'code_challenge=xyz' in opened_url
+    assert 'code_challenge_method=S256' in opened_url
+    assert 'state=stateval' in opened_url
+
+
+def test_handle_open_url_leaves_claude_non_localhost_redirect_untouched():
+    credentials = {'claude-fre': {'provider': 'claude'}}
+    opened = []
+    already_fine_url = (
+        'https://claude.com/cai/oauth/authorize?redirect_uri='
+        'https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback&state=stateval'
+    )
+
+    handle_open_url(
+        {'action': 'open_url', 'credential': 'claude-fre', 'url': already_fine_url},
+        credentials,
+        lambda url, browser, profile: opened.append(url),
+    )
+
+    assert opened == [already_fine_url]
+
+
+def test_handle_open_url_does_not_rewrite_non_claude_localhost_redirect():
+    credentials = {'github-dfarrow': {'provider': 'github'}}
+    opened = []
+    localhost_url = 'https://github.com/login/device?redirect_uri=http%3A%2F%2Flocalhost%3A9999%2Fcallback'
+
+    handle_open_url(
+        {'action': 'open_url', 'credential': 'github-dfarrow', 'url': localhost_url},
+        credentials,
+        lambda url, browser, profile: opened.append(url),
+    )
+
+    assert opened == [localhost_url]
+
+
+def test_handle_closes_connection_silently_on_empty_read(caplog):
+    # A bare connect-then-disconnect (e.g. dax.py's _wait_for_tcp readiness
+    # probe) must not be logged as a malformed request - there's no client
+    # data to have been invalid in the first place.
+    handle = _make_handle(
+        credentials={}, token_store=None, token_exchanger=None, cache={},
+        url_opener=lambda url, browser, profile: None,
+    )
+    reader = FakeReader(b'')
+    writer = FakeWriter()
+
+    asyncio.run(handle(reader, writer))
+
+    assert writer.written == b''
+    assert writer.closed is True
+    assert 'invalid JSON' not in caplog.text
+
+
+def test_handle_still_logs_and_responds_to_genuinely_invalid_json():
+    handle = _make_handle(
+        credentials={}, token_store=None, token_exchanger=None, cache={},
+        url_opener=lambda url, browser, profile: None,
+    )
+    reader = FakeReader(b'not json')
+    writer = FakeWriter()
+
+    asyncio.run(handle(reader, writer))
+
+    response = json.loads(writer.written)
+    assert response == {'error': 'invalid_request', 'message': 'Invalid JSON'}
+    assert writer.closed is True
 
 
 def test_handle_list_returns_all_credentials_with_providers():

--- a/tests/test_dax_creds_init.py
+++ b/tests/test_dax_creds_init.py
@@ -66,6 +66,38 @@ def test_creds_remove_rejects_unknown_credential():
         run_creds_remove(config, 'no-such-cred')
 
 
+def test_creds_remove_also_drops_the_config_entry(tmp_path, monkeypatch):
+    """Clearing only Keychain left the definition behind, so a fat-fingered
+    name could never actually be removed."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    kr = FakeKeyring({('dax-creds', 'claud-fre'): 'blob'})
+    config = {'credentials': {'claud-fre': {'provider': 'claude'},
+                              'claude-fre': {'provider': 'claude'}},
+              'projects': {}}
+
+    run_creds_remove(config, 'claud-fre', keyring=kr)
+
+    assert 'claud-fre' not in config['credentials']
+    assert 'claude-fre' in config['credentials']
+    assert 'claud-fre' not in (tmp_path / '.dax.yaml').read_text()
+
+
+def test_creds_remove_refuses_when_a_project_still_references_it(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    kr = FakeKeyring({('dax-creds', 'claude-fre'): 'blob'})
+    config = {'credentials': {'claude-fre': {'provider': 'claude'}},
+              'projects': {'fabric': {'creds': ['claude-fre']},
+                           'dax': {'creds': ['claude-fre']}}}
+
+    with pytest.raises(ValueError, match='dax, fabric'):
+        run_creds_remove(config, 'claude-fre', keyring=kr)
+
+    # Refusal must leave both stores untouched, not half-remove it.
+    assert 'claude-fre' in config['credentials']
+    assert kr.get_password('dax-creds', 'claude-fre') == 'blob'
+    assert not (tmp_path / '.dax.yaml').exists()
+
+
 def test_creds_update_rejects_unknown_credential():
     config = {'credentials': {}}
     with pytest.raises(KeyError, match='no-such-cred'):
@@ -216,6 +248,89 @@ def test_setup_claude_skips_when_already_in_keychain(tmp_path, monkeypatch, caps
 
     out = capsys.readouterr().out
     assert 'already in Keychain' in out
+
+
+def test_creds_remove_can_clear_a_derived_credential(tmp_path, monkeypatch, capsys):
+    """A derived credential has no config entry, so `remove` reported it as
+    unknown and there was no way to clear a bad one."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    kr = FakeKeyring({('dax-creds', 'claude-personal-fabric'): 'shared-grant'})
+    config = {'credentials': {},
+              'projects': {'fabric': {'tenant': 'personal', 'creds': ['claude']}}}
+
+    run_creds_remove(config, 'claude-personal-fabric', keyring=kr)
+
+    assert kr.get_password('dax-creds', 'claude-personal-fabric') is None
+    out = capsys.readouterr().out
+    assert 'derived credential' in out
+    assert 'fabric will be offered a fresh login' in out
+
+
+def test_creds_remove_of_a_derived_credential_writes_no_config(tmp_path, monkeypatch):
+    """Nothing to delete from ~/.dax.yaml, so it must not be rewritten."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    kr = FakeKeyring({('dax-creds', 'claude-personal-fabric'): 'shared-grant'})
+    config = {'credentials': {},
+              'projects': {'fabric': {'tenant': 'personal', 'creds': ['claude']}}}
+
+    run_creds_remove(config, 'claude-personal-fabric', keyring=kr)
+
+    assert not (tmp_path / '.dax.yaml').exists()
+
+
+def test_setup_claude_replace_rewrites_the_keychain_secret(tmp_path, monkeypatch):
+    """Confirming "Overwrite it?" used to rewrite only the YAML metadata, so a
+    rotated credential could not be re-imported without `dax creds remove`."""
+    import json
+    monkeypatch.setenv('HOME', str(tmp_path))
+    rotated = {'claudeAiOauth': {'accessToken': 'sk-ant-oat01-new',
+                                 'refreshToken': 'sk-ant-ort01-new'}}
+    claude_dir = tmp_path / '.claude'
+    claude_dir.mkdir()
+    (claude_dir / '.credentials.json').write_text(json.dumps(rotated))
+
+    kr = FakeKeyring({('dax-creds', 'claude-work'): 'stale-token'})
+    import dax_creds.providers.claude as _cm
+    monkeypatch.setattr(_cm, '_keyring', kr)
+
+    _setup_claude_credential('claude-work', {'provider': 'claude'}, replace=True)
+
+    assert json.loads(kr.get_password('dax-creds', 'claude-work')) == rotated
+
+
+def test_setup_claude_replace_reports_when_nothing_replaced_it(tmp_path, monkeypatch, capsys):
+    """The user asked for a replacement and did not get one — say so, rather
+    than leaving them believing the old secret is gone."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    kr = FakeKeyring({('dax-creds', 'claude-work'): 'stale-token'})
+    import dax_creds.providers.claude as _cm
+    monkeypatch.setattr(_cm, '_keyring', kr)
+
+    _setup_claude_credential('claude-work', {'provider': 'claude'}, replace=True)
+
+    out = capsys.readouterr().out
+    assert 'left in place' in out
+    assert 'dax creds remove claude-work' in out
+    assert kr.get_password('dax-creds', 'claude-work') == 'stale-token'
+
+
+def test_setup_claude_without_replace_still_skips(tmp_path, monkeypatch, capsys):
+    """Ordinary setup must stay a no-op when the secret is already there."""
+    import json
+    monkeypatch.setenv('HOME', str(tmp_path))
+    claude_dir = tmp_path / '.claude'
+    claude_dir.mkdir()
+    (claude_dir / '.credentials.json').write_text(json.dumps(
+        {'claudeAiOauth': {'refreshToken': 'sk-ant-ort01-ondisk'}}))
+
+    kr = FakeKeyring({('dax-creds', 'claude-work'): 'existing-token'})
+    import dax_creds.providers.claude as _cm
+    monkeypatch.setattr(_cm, '_keyring', kr)
+
+    _setup_claude_credential('claude-work', {'provider': 'claude'})
+
+    assert kr.get_password('dax-creds', 'claude-work') == 'existing-token'
+    assert 'already in Keychain' in capsys.readouterr().out
 
 
 def test_save_config_writes_yaml(tmp_path, monkeypatch):

--- a/tests/test_dax_creds_shared_files_sync.py
+++ b/tests/test_dax_creds_shared_files_sync.py
@@ -1,0 +1,151 @@
+"""`sync_claude_shared_files` copies the host's user-level CLAUDE.md/settings.json/
+settings.local.json into a `claude_tenant_state` env's state tree.
+
+Replaces a nested read-only file bind mount (decision B2), abandoned 2026-07-31
+after it turned out not to deliver the host's content at all. A plain byte-diff
+between host and tree can't tell "host moved on since last sync" (safe to
+overwrite) apart from "something changed the tree's copy independently" (unsafe
+to clobber) — that's what the manifest of last-synced hashes is for.
+"""
+from dax_creds.config import (
+    CLAUDE_SHARED_FILES, state_tree_path, sync_claude_shared_files,
+)
+
+
+def _write_host_claude_md(tmp_path, content):
+    (tmp_path / '.claude').mkdir(exist_ok=True)
+    (tmp_path / '.claude' / 'CLAUDE.md').write_text(content)
+
+
+def test_first_sync_copies_the_host_file_into_the_tree(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write_host_claude_md(tmp_path, 'global instructions')
+
+    warnings = sync_claude_shared_files('personal', 'fabric')
+
+    tree = state_tree_path('personal', 'fabric')
+    assert (tree / 'CLAUDE.md').read_text() == 'global instructions'
+    assert warnings == []
+
+
+def test_absent_host_file_is_skipped_without_creating_anything(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+
+    warnings = sync_claude_shared_files('personal', 'fabric')
+
+    tree = state_tree_path('personal', 'fabric')
+    assert not tree.exists() or list(tree.iterdir()) == []
+    assert warnings == []
+
+
+def test_second_sync_is_a_no_op_when_nothing_changed(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write_host_claude_md(tmp_path, 'v1')
+    sync_claude_shared_files('personal', 'fabric')
+
+    tree_file = state_tree_path('personal', 'fabric') / 'CLAUDE.md'
+    mtime_before = tree_file.stat().st_mtime_ns
+
+    warnings = sync_claude_shared_files('personal', 'fabric')
+
+    assert tree_file.stat().st_mtime_ns == mtime_before
+    assert warnings == []
+
+
+def test_host_update_is_picked_up_when_tree_copy_is_untouched(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write_host_claude_md(tmp_path, 'v1')
+    sync_claude_shared_files('personal', 'fabric')
+
+    _write_host_claude_md(tmp_path, 'v2')
+    warnings = sync_claude_shared_files('personal', 'fabric')
+
+    tree_file = state_tree_path('personal', 'fabric') / 'CLAUDE.md'
+    assert tree_file.read_text() == 'v2'
+    assert warnings == []
+
+
+def test_independently_edited_tree_copy_is_left_alone_and_warned(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write_host_claude_md(tmp_path, 'v1')
+    sync_claude_shared_files('personal', 'fabric')
+
+    tree_file = state_tree_path('personal', 'fabric') / 'CLAUDE.md'
+    tree_file.write_text('edited independently in a container')
+    _write_host_claude_md(tmp_path, 'v2')
+
+    warnings = sync_claude_shared_files('personal', 'fabric')
+
+    assert tree_file.read_text() == 'edited independently in a container'
+    assert warnings == ['CLAUDE.md']
+
+
+def test_force_overwrites_drifted_tree_copy_with_the_host_version(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write_host_claude_md(tmp_path, 'v1')
+    sync_claude_shared_files('personal', 'fabric')
+
+    tree_file = state_tree_path('personal', 'fabric') / 'CLAUDE.md'
+    tree_file.write_text('edited independently in a container')
+    _write_host_claude_md(tmp_path, 'v2')
+
+    warnings = sync_claude_shared_files('personal', 'fabric', force=True)
+
+    assert tree_file.read_text() == 'v2'
+    assert warnings == []
+
+
+def test_force_resyncs_after_a_previous_drift_warning(tmp_path, monkeypatch):
+    """Once forced, the manifest reflects the adopted content, so a later
+    ordinary sync doesn't immediately re-flag it as drifted."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write_host_claude_md(tmp_path, 'v1')
+    sync_claude_shared_files('personal', 'fabric')
+    (state_tree_path('personal', 'fabric') / 'CLAUDE.md').write_text('drifted')
+    sync_claude_shared_files('personal', 'fabric', force=True)
+
+    warnings = sync_claude_shared_files('personal', 'fabric')
+
+    assert warnings == []
+
+
+def test_manifest_lives_beside_the_tree_not_inside_it(tmp_path, monkeypatch):
+    """It must not appear inside the tree the container mounts at ~/.claude."""
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write_host_claude_md(tmp_path, 'v1')
+
+    sync_claude_shared_files('personal', 'fabric')
+
+    tree = state_tree_path('personal', 'fabric')
+    assert not any(p.name.endswith('.json') for p in tree.iterdir())
+    manifest = tree.parent / 'fabric.shared-files.json'
+    assert manifest.is_file()
+
+
+def test_two_envs_get_independent_manifests(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    _write_host_claude_md(tmp_path, 'v1')
+    sync_claude_shared_files('personal', 'fabric')
+
+    (state_tree_path('personal', 'fabric') / 'CLAUDE.md').write_text('drifted for fabric only')
+    _write_host_claude_md(tmp_path, 'v2')
+
+    fabric_warnings = sync_claude_shared_files('personal', 'fabric')
+    dax_warnings = sync_claude_shared_files('personal', 'dax')
+
+    assert fabric_warnings == ['CLAUDE.md']
+    assert dax_warnings == []
+    assert (state_tree_path('personal', 'dax') / 'CLAUDE.md').read_text() == 'v2'
+
+
+def test_all_three_shared_filenames_are_covered(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    (tmp_path / '.claude').mkdir()
+    for f in CLAUDE_SHARED_FILES:
+        (tmp_path / '.claude' / f).write_text(f'host {f}')
+
+    sync_claude_shared_files('personal', 'fabric')
+
+    tree = state_tree_path('personal', 'fabric')
+    for f in CLAUDE_SHARED_FILES:
+        assert (tree / f).read_text() == f'host {f}'

--- a/tests/test_dax_creds_tenant.py
+++ b/tests/test_dax_creds_tenant.py
@@ -1,0 +1,510 @@
+from dax_creds.tenant import (
+    Resolution,
+    resolve_tenant,
+    all_tenant_projects,
+    resolve_for_cwd,
+    TENANT_FILE,
+)
+
+
+def _declare(path, tenant):
+    path.mkdir(parents=True, exist_ok=True)
+    (path / TENANT_FILE).write_text(tenant)
+
+
+# --- depth boundary: claude only ever starts at the root or one level down -
+
+def test_resolve_tenant_refuses_more_than_one_level_deep_single_tenant(tmp_path):
+    repo = tmp_path / 'discernment'
+    _declare(repo, 'personal')  # would otherwise resolve fine
+    deep = repo / 'src' / 'nested'
+    deep.mkdir(parents=True)
+
+    result = resolve_tenant(deep, repo, multi_tenant=False)
+
+    assert result.refuse
+    assert result.tenant is None
+    assert 'more than one level below' in result.detail
+
+
+def test_resolve_tenant_refuses_more_than_one_level_deep_multi_tenant(tmp_path):
+    repo = tmp_path / 'discernment'
+    repo.mkdir()
+    deep = repo / 'project_a' / 'nested'
+    _declare(deep, 'ysecurity')  # even a directly-labeled dir, if too deep, refuses
+
+    result = resolve_tenant(deep, repo, multi_tenant=True)
+
+    assert result.refuse
+
+
+def test_resolve_tenant_refuses_when_cwd_unrelated_to_repo_root(tmp_path):
+    repo = tmp_path / 'repo'
+    repo.mkdir()
+    unrelated = tmp_path / 'somewhere-else'
+    unrelated.mkdir()
+
+    result = resolve_tenant(unrelated, repo, multi_tenant=False)
+
+    assert result.refuse
+
+
+# --- single-tenant mode: tenant always comes from the root, only the root --
+
+def test_single_tenant_resolves_at_root(tmp_path):
+    repo = tmp_path / 'fabric'
+    _declare(repo, 'personal')
+
+    result = resolve_tenant(repo, repo, multi_tenant=False)
+
+    assert result == Resolution(tenant='personal', project='fabric',
+                                 refuse=False, detail=result.detail)
+
+
+def test_single_tenant_refuses_at_immediate_child(tmp_path):
+    # The root is the sandbox - a single-tenant project has no legal cwd
+    # other than the root itself, even one level down.
+    repo = tmp_path / 'fabric'
+    _declare(repo, 'personal')
+    subdir = repo / 'src'
+    subdir.mkdir()
+
+    result = resolve_tenant(subdir, repo, multi_tenant=False)
+
+    assert result.refuse
+    assert result.tenant is None
+    assert 'project root' in result.detail
+
+
+def test_single_tenant_refuses_at_child_even_with_its_own_tenant_file(tmp_path):
+    # A child's own .dax-tenant grants nothing in this mode - only the root
+    # is ever a legal place to start, regardless of what files exist below it.
+    repo = tmp_path / 'fabric'
+    _declare(repo, 'personal')
+    subdir = repo / 'src'
+    _declare(subdir, 'someone-else')
+
+    result = resolve_tenant(subdir, repo, multi_tenant=False)
+
+    assert result.refuse
+
+
+def test_single_tenant_undeclared_at_root_refuses(tmp_path):
+    # No automatic unattributed/<reponame> fallback (dropped 2026-07-28):
+    # an undeclared root refuses, with a hint at how to declare it, rather
+    # than silently pooling into a default tenant.
+    repo = tmp_path / 'iandidit'
+    repo.mkdir()
+
+    result = resolve_tenant(repo, repo, multi_tenant=False)
+
+    assert result.refuse
+    assert result.tenant is None
+    assert 'dax tenant set' in result.detail
+
+
+def test_single_tenant_refuses_at_child_even_when_root_undeclared(tmp_path):
+    # cwd-is-root-only is checked before the undeclared-root refusal - an
+    # undeclared root doesn't loosen where claude may start.
+    repo = tmp_path / 'iandidit'
+    subdir = repo / 'src'
+    subdir.mkdir(parents=True)
+
+    result = resolve_tenant(subdir, repo, multi_tenant=False)
+
+    assert result.refuse
+
+
+def test_single_tenant_empty_root_file_counts_as_undeclared(tmp_path):
+    repo = tmp_path / 'repo'
+    repo.mkdir()
+    (repo / TENANT_FILE).write_text('   \n')
+
+    result = resolve_tenant(repo, repo, multi_tenant=False)
+
+    assert result.refuse
+    assert result.tenant is None
+
+
+# --- multi-tenant mode: tenant always comes from an immediate child -------
+
+def test_multi_tenant_undeclared_root_refuses(tmp_path):
+    # Root is now its own project even in multi-tenant mode (2026-07-28) -
+    # but still refuses like anywhere else in this table when undeclared,
+    # rather than falling back to unattributed or the old "root never
+    # resolves" rule.
+    repo = tmp_path / 'discernment'
+    _declare(repo / 'project_ysecurity_comp_model', 'ysecurity')
+
+    result = resolve_tenant(repo, repo, multi_tenant=True)
+
+    assert result.refuse
+    assert result.tenant is None
+    assert 'dax tenant set' in result.detail
+
+
+def test_multi_tenant_root_resolves_when_declared(tmp_path):
+    # The repo root is its own project, distinct from any customer
+    # engagement under it - working on discernment's own tooling needs its
+    # own tenant and its own isolated state.
+    repo = tmp_path / 'discernment'
+    _declare(repo, 'personal')
+    _declare(repo / 'project_ysecurity_comp_model', 'ysecurity')
+
+    result = resolve_tenant(repo, repo, multi_tenant=True)
+
+    assert not result.refuse
+    assert result.tenant == 'personal'
+    assert result.project == 'discernment'
+
+
+def test_multi_tenant_resolves_mapped_child(tmp_path):
+    repo = tmp_path / 'discernment'
+    sub_a = repo / 'project_ysecurity_comp_model'
+    _declare(sub_a, 'ysecurity')
+    _declare(repo / 'project_augment', 'augment')
+
+    result = resolve_tenant(sub_a, repo, multi_tenant=True)
+
+    assert result.tenant == 'ysecurity'
+    assert result.project == 'project_ysecurity_comp_model'
+    assert not result.refuse
+
+
+def test_multi_tenant_refuses_unmapped_child(tmp_path):
+    repo = tmp_path / 'discernment'
+    _declare(repo / 'project_ysecurity_comp_model', 'ysecurity')
+    unmapped = repo / 'project_someone_new'
+    unmapped.mkdir(parents=True)
+
+    result = resolve_tenant(unmapped, repo, multi_tenant=True)
+
+    assert result.refuse
+    assert str(unmapped) in result.detail
+
+
+def test_multi_tenant_has_no_unattributed_fallback(tmp_path):
+    # Fail toward over-isolation: an explicitly flagged multi-tenant repo
+    # never silently pools into unattributed/, even with nothing labeled yet.
+    repo = tmp_path / 'discernment'
+    child = repo / 'project_new'
+    child.mkdir(parents=True)
+
+    result = resolve_tenant(child, repo, multi_tenant=True)
+
+    assert result.refuse
+    assert result.tenant != 'unattributed'
+
+
+# --- multi-tenant with tenant_subdir: labeled dirs one level further in ----
+#
+# discernment's actual tenant subdirectories sit under processes/, not
+# directly under the repo root - this is the one-off accommodation for that,
+# not a generalized arbitrary-depth mechanism.
+
+def test_multi_tenant_with_subdir_resolves_mapped_child(tmp_path):
+    repo = tmp_path / 'discernment'
+    _declare(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
+
+    result = resolve_tenant(repo / 'processes' / 'project_ysecurity_comp_model',
+                             repo, multi_tenant=True, tenant_subdir='processes')
+
+    assert result.tenant == 'ysecurity'
+    assert result.project == 'project_ysecurity_comp_model'
+    assert not result.refuse
+
+
+def test_multi_tenant_with_subdir_refuses_at_true_repo_root_when_undeclared(tmp_path):
+    repo = tmp_path / 'discernment'
+    _declare(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
+
+    result = resolve_tenant(repo, repo, multi_tenant=True, tenant_subdir='processes')
+
+    assert result.refuse
+
+
+def test_multi_tenant_with_subdir_root_resolves_when_declared(tmp_path):
+    # The root-is-its-own-project rule applies regardless of whether
+    # tenant_subdir is set - discernment's own tooling work still needs its
+    # own tenant even though its engagements live under processes/.
+    repo = tmp_path / 'discernment'
+    _declare(repo, 'personal')
+    _declare(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
+
+    result = resolve_tenant(repo, repo, multi_tenant=True, tenant_subdir='processes')
+
+    assert not result.refuse
+    assert result.tenant == 'personal'
+    assert result.project == 'discernment'
+
+
+def test_multi_tenant_with_subdir_refuses_at_the_subdir_itself(tmp_path):
+    repo = tmp_path / 'discernment'
+    _declare(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
+
+    result = resolve_tenant(repo / 'processes', repo, multi_tenant=True, tenant_subdir='processes')
+
+    assert result.refuse
+
+
+def test_multi_tenant_with_subdir_refuses_sibling_top_level_dir(tmp_path):
+    # A directory that exists at the repo root but isn't the configured
+    # tenant_subdir - e.g. discernment's other top-level content - must
+    # still refuse, not be treated as if it were under processes/.
+    repo = tmp_path / 'discernment'
+    _declare(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
+    (repo / 'docs').mkdir(parents=True)
+
+    result = resolve_tenant(repo / 'docs', repo, multi_tenant=True, tenant_subdir='processes')
+
+    assert result.refuse
+
+
+def test_multi_tenant_with_subdir_refuses_unmapped_child(tmp_path):
+    repo = tmp_path / 'discernment'
+    _declare(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
+    unmapped = repo / 'processes' / 'project_someone_new'
+    unmapped.mkdir(parents=True)
+
+    result = resolve_tenant(unmapped, repo, multi_tenant=True, tenant_subdir='processes')
+
+    assert result.refuse
+    assert str(unmapped) in result.detail
+
+
+def test_all_tenant_projects_multi_tenant_with_subdir(tmp_path):
+    repo = tmp_path / 'discernment'
+    _declare(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
+    _declare(repo / 'processes' / 'project_augment', 'augment')
+    _declare(repo / 'project_at_root_should_be_ignored', 'should-not-count')
+
+    pairs = all_tenant_projects(repo, multi_tenant=True, tenant_subdir='processes')
+
+    assert pairs == {
+        ('ysecurity', 'project_ysecurity_comp_model'),
+        ('augment', 'project_augment'),
+    }
+
+
+def test_resolve_for_cwd_multi_tenant_with_subdir_mapped_child(tmp_path):
+    home = tmp_path / 'home'
+    repo = home / 'discernment'
+    _declare(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
+
+    result = resolve_for_cwd(repo / 'processes' / 'project_ysecurity_comp_model', home,
+                              multi_tenant=True, project_name='discernment',
+                              tenant_subdir='processes')
+
+    assert result.tenant == 'ysecurity'
+    assert result.project == 'project_ysecurity_comp_model'
+
+
+def test_resolve_for_cwd_multi_tenant_with_subdir_refuses_at_root(tmp_path):
+    home = tmp_path / 'home'
+    repo = home / 'discernment'
+    _declare(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
+
+    result = resolve_for_cwd(repo, home, multi_tenant=True, project_name='discernment',
+                              tenant_subdir='processes')
+
+    assert result.refuse
+
+
+# --- all_tenant_projects: Gate A's mount-scoping question -------------------
+
+def test_all_tenant_projects_single_tenant_declared(tmp_path):
+    repo = tmp_path / 'fabric'
+    _declare(repo, 'personal')
+
+    assert all_tenant_projects(repo, multi_tenant=False) == {('personal', 'fabric')}
+
+
+def test_all_tenant_projects_single_tenant_undeclared(tmp_path):
+    # No mount to scope for an undeclared project - dax run's classification
+    # step (Gate A) should always resolve this before mounts are computed;
+    # an empty result here means that step was skipped, not a default to
+    # fall back to.
+    repo = tmp_path / 'fabric'
+    repo.mkdir()
+
+    assert all_tenant_projects(repo, multi_tenant=False) == set()
+
+
+def test_all_tenant_projects_multi_tenant(tmp_path):
+    repo = tmp_path / 'discernment'
+    _declare(repo / 'project_ysecurity_comp_model', 'ysecurity')
+    _declare(repo / 'project_augment', 'augment')
+
+    pairs = all_tenant_projects(repo, multi_tenant=True)
+
+    assert pairs == {
+        ('ysecurity', 'project_ysecurity_comp_model'),
+        ('augment', 'project_augment'),
+    }
+
+
+def test_all_tenant_projects_multi_tenant_includes_declared_root(tmp_path):
+    # Gate A must mount the root's own state tree too, alongside every
+    # labeled engagement, now that the root resolves as its own project.
+    repo = tmp_path / 'discernment'
+    _declare(repo, 'personal')
+    _declare(repo / 'project_ysecurity_comp_model', 'ysecurity')
+
+    pairs = all_tenant_projects(repo, multi_tenant=True)
+
+    assert pairs == {
+        ('personal', 'discernment'),
+        ('ysecurity', 'project_ysecurity_comp_model'),
+    }
+
+
+def test_all_tenant_projects_multi_tenant_skips_git_and_node_modules(tmp_path):
+    repo = tmp_path / 'discernment'
+    _declare(repo / '.git', 'should-not-count')
+    _declare(repo / 'node_modules', 'should-not-count-either')
+    _declare(repo / 'project_ysecurity_comp_model', 'ysecurity')
+
+    assert all_tenant_projects(repo, multi_tenant=True) == {
+        ('ysecurity', 'project_ysecurity_comp_model')}
+
+
+def test_all_tenant_projects_multi_tenant_empty_when_nothing_labeled(tmp_path):
+    repo = tmp_path / 'discernment'
+    repo.mkdir()
+    (repo / 'project_new').mkdir()
+
+    assert all_tenant_projects(repo, multi_tenant=True) == set()
+
+
+# --- resolve_for_cwd: Gate B's entry point ----------------------------------
+
+def test_resolve_for_cwd_single_tenant_at_root(tmp_path):
+    home = tmp_path / 'home'
+    repo = home / 'fabric'
+    _declare(repo, 'personal')
+
+    result = resolve_for_cwd(repo, home, multi_tenant=False, project_name='fabric')
+
+    assert result.tenant == 'personal'
+    assert result.project == 'fabric'
+
+
+def test_resolve_for_cwd_single_tenant_refuses_at_immediate_child(tmp_path):
+    home = tmp_path / 'home'
+    repo = home / 'fabric'
+    _declare(repo, 'personal')
+    subdir = repo / 'src'
+    subdir.mkdir(parents=True)
+
+    result = resolve_for_cwd(subdir, home, multi_tenant=False, project_name='fabric')
+
+    assert result.refuse
+
+
+def test_resolve_for_cwd_multi_tenant_mapped_child(tmp_path):
+    home = tmp_path / 'home'
+    repo = home / 'discernment'
+    _declare(repo / 'project_ysecurity_comp_model', 'ysecurity')
+    _declare(repo / 'project_augment', 'augment')
+
+    result = resolve_for_cwd(repo / 'project_ysecurity_comp_model', home,
+                              multi_tenant=True, project_name='discernment')
+
+    assert result.tenant == 'ysecurity'
+    assert result.project == 'project_ysecurity_comp_model'
+
+
+def test_resolve_for_cwd_multi_tenant_refuses_at_repo_root(tmp_path):
+    home = tmp_path / 'home'
+    repo = home / 'discernment'
+    _declare(repo / 'project_ysecurity_comp_model', 'ysecurity')
+
+    result = resolve_for_cwd(repo, home, multi_tenant=True, project_name='discernment')
+
+    assert result.refuse
+
+
+def test_resolve_for_cwd_refuses_when_cwd_is_home_itself(tmp_path):
+    home = tmp_path / 'home'
+    home.mkdir()
+
+    result = resolve_for_cwd(home, home, multi_tenant=False, project_name='fabric')
+
+    assert result.refuse
+    assert result.tenant is None
+
+
+def test_resolve_for_cwd_refuses_when_cwd_outside_home(tmp_path):
+    home = tmp_path / 'home'
+    home.mkdir()
+    outside = tmp_path / 'not-home' / 'fabric'
+    outside.mkdir(parents=True)
+
+    result = resolve_for_cwd(outside, home, multi_tenant=False, project_name='fabric')
+
+    assert result.refuse
+
+
+def test_resolve_for_cwd_refuses_more_than_one_level_deep(tmp_path):
+    # Two levels deep refuses via the outer depth bound - a stricter check
+    # than the single-tenant root-only rule, but both land on refuse here.
+    home = tmp_path / 'home'
+    repo = home / 'fabric'
+    _declare(repo, 'personal')
+    deep = repo / 'src' / 'nested'
+    deep.mkdir(parents=True)
+
+    result = resolve_for_cwd(deep, home, multi_tenant=False, project_name='fabric')
+
+    assert result.refuse
+
+
+# --- resolve_for_cwd: cwd under an unrelated $HOME-level mount --------------
+#
+# $HOME legitimately has other directory-level mounts sitting right alongside
+# a project's own (~/.claude, ~/.augment, ~/.aws - see .dax.yaml.example).
+# Without checking the expected project_name, a user who `cd`s into one of
+# those and runs claude there would have it treated as if it *were* the
+# project root - undeclared there, so it would silently resolve to
+# unattributed/.claude instead of refusing. These pin that it refuses.
+
+def test_resolve_for_cwd_refuses_in_unrelated_home_level_mount(tmp_path):
+    home = tmp_path / 'home'
+    repo = home / 'fabric'
+    _declare(repo, 'personal')
+    other_mount = home / '.claude'  # e.g. claudedir - not a project at all
+    other_mount.mkdir(parents=True)
+
+    result = resolve_for_cwd(other_mount, home, multi_tenant=False, project_name='fabric')
+
+    assert result.refuse
+    assert result.tenant != 'unattributed'
+
+
+def test_resolve_for_cwd_refuses_in_unrelated_mount_even_if_it_has_a_tenant_file(tmp_path):
+    # Not just the undeclared case - even a stray .dax-tenant file sitting in
+    # an unrelated mount (leftover, mistake, or a prior project's artifact)
+    # must not be treated as this container's resolution.
+    home = tmp_path / 'home'
+    repo = home / 'fabric'
+    _declare(repo, 'personal')
+    other_mount = home / '.aws'
+    _declare(other_mount, 'someone-else')
+
+    result = resolve_for_cwd(other_mount, home, multi_tenant=False, project_name='fabric')
+
+    assert result.refuse
+    assert result.tenant != 'someone-else'
+
+
+def test_resolve_for_cwd_refuses_when_top_level_dir_does_not_exist(tmp_path):
+    # The project_name mismatch check applies even when nothing has been
+    # mounted at that path at all - no crash, just a clean refuse.
+    home = tmp_path / 'home'
+    home.mkdir()
+
+    result = resolve_for_cwd(home / 'nonexistent', home, multi_tenant=False,
+                              project_name='fabric')
+
+    assert result.refuse
+    assert 'not inside the mounted project' in result.detail

--- a/tests/test_dax_env_cmds.py
+++ b/tests/test_dax_env_cmds.py
@@ -6,8 +6,11 @@ just to edit a single string.
 """
 import pytest
 
-from dax_creds.config import ENV_FIELDS, env_field_help, load_dax_config
-from dax_creds.init import run_env_set, run_env_show
+from dax_creds.config import (
+    ENV_FIELDS, env_field_help, load_dax_config, state_tree_path,
+    sync_claude_shared_files,
+)
+from dax_creds.init import run_env_accept_shared_files, run_env_set, run_env_show
 
 
 CONFIG = """\
@@ -233,3 +236,33 @@ def test_env_set_features_validation_is_skipped_without_a_list(home):
 def test_features_is_a_documented_field():
     assert 'features' in ENV_FIELDS
     assert 'features' in env_field_help()
+
+
+# --- env accept-shared-files -------------------------------------------------
+#
+# The escape hatch for the drift warning `sync_claude_shared_files` prints at
+# `dax run` time: resolving it is always an explicit act, never automatic.
+
+def test_accept_shared_files_requires_a_tenant(home):
+    with pytest.raises(ValueError, match='no tenant'):
+        run_env_accept_shared_files(load_dax_config(), 'fabric')
+
+
+def test_accept_shared_files_unknown_env_raises(home):
+    with pytest.raises(KeyError, match='fabric'):
+        run_env_accept_shared_files(load_dax_config(), 'nope')
+
+
+def test_accept_shared_files_adopts_the_host_version_over_drift(home):
+    run_env_set(load_dax_config(), 'fabric', 'tenant', 'personal')
+    (home / '.claude').mkdir()
+    (home / '.claude' / 'CLAUDE.md').write_text('v1')
+    sync_claude_shared_files('personal', 'fabric')
+
+    tree_file = state_tree_path('personal', 'fabric') / 'CLAUDE.md'
+    tree_file.write_text('edited independently in a container')
+    (home / '.claude' / 'CLAUDE.md').write_text('v2')
+
+    run_env_accept_shared_files(load_dax_config(), 'fabric')
+
+    assert tree_file.read_text() == 'v2'

--- a/tests/test_dax_env_cmds.py
+++ b/tests/test_dax_env_cmds.py
@@ -293,6 +293,61 @@ def test_show_does_not_flag_mounts_when_the_feature_is_active(home, capsys):
     assert 'inactive' not in out
 
 
+# --- env set substrate -------------------------------------------------------
+#
+# A single path, unlike the generic `mounts` list: dax needs to know
+# specifically which mount holds shared/wire.sh and shared/new-process.sh, not
+# just that something extra is mounted (docs/design/VALIDATION.md).
+
+def test_env_set_substrate(home):
+    run_env_set(load_dax_config(), 'fabric', 'substrate', '~/virgil')
+
+    assert load_dax_config()['projects']['fabric']['substrate'] == '~/virgil'
+
+
+def test_substrate_is_a_documented_field():
+    assert 'substrate' in ENV_FIELDS
+    assert 'substrate' in env_field_help()
+
+
+def test_show_lists_substrate_when_set(home, capsys):
+    run_env_set(load_dax_config(), 'fabric', 'substrate', '~/virgil')
+    capsys.readouterr()
+
+    run_env_show(load_dax_config(), 'fabric')
+
+    out = capsys.readouterr().out
+    assert '~/virgil' in out
+
+
+def test_show_omits_substrate_line_when_unset(home, capsys):
+    run_env_show(load_dax_config(), 'fabric')
+
+    assert 'substrate' not in capsys.readouterr().out
+
+
+def test_show_flags_substrate_set_without_the_feature_active(home, capsys):
+    run_env_set(load_dax_config(), 'fabric', 'substrate', '~/virgil')
+    capsys.readouterr()
+
+    run_env_show(load_dax_config(), 'fabric')
+
+    out = capsys.readouterr().out
+    assert 'inactive' in out
+
+
+def test_show_does_not_flag_substrate_when_the_feature_is_active(home, capsys):
+    config = load_dax_config()
+    run_env_set(config, 'fabric', 'substrate', '~/virgil')
+    run_env_set(config, 'fabric', 'features', 'claude,substrate')
+    capsys.readouterr()
+
+    run_env_show(load_dax_config(), 'fabric')
+
+    out = capsys.readouterr().out
+    assert 'inactive' not in out
+
+
 # --- env accept-shared-files -------------------------------------------------
 #
 # The escape hatch for the drift warning `sync_claude_shared_files` prints at

--- a/tests/test_dax_env_cmds.py
+++ b/tests/test_dax_env_cmds.py
@@ -180,3 +180,56 @@ def test_field_help_documents_every_settable_field():
     text = env_field_help()
     for field, description in ENV_FIELDS.items():
         assert field in text and description in text
+
+
+# --- env set features -------------------------------------------------------
+#
+# Added once per-env features became load-bearing: `claude_tenant_state` is opted
+# into per env, and switching it on means moving `claude` off the global list and
+# onto the envs that still want the shared mount — four edits, which is YAML
+# surgery without this.
+
+def test_env_set_features_replaces_the_list(home):
+    config = {'projects': {'fabric': {'dir': '/repos/fabric'}}}
+
+    run_env_set(config, 'fabric', 'features', 'claude_tenant_state',
+                valid_features={'claude', 'claude_tenant_state', 'ssh'})
+
+    assert config['projects']['fabric']['features'] == ['claude_tenant_state']
+
+
+def test_env_set_features_accepts_a_comma_separated_list(home):
+    config = {'projects': {'fabric': {'dir': '/repos/fabric'}}}
+
+    run_env_set(config, 'fabric', 'features', 'claude, ssh',
+                valid_features={'claude', 'claude_tenant_state', 'ssh'})
+
+    assert config['projects']['fabric']['features'] == ['claude', 'ssh']
+
+
+def test_env_set_features_rejects_a_misspelled_feature(home):
+    """A misspelled feature in a config is silently ignored at launch — the same
+    failure mode a typo'd credential name had, where `claud-fre` sat unused for
+    weeks."""
+    config = {'projects': {'fabric': {'dir': '/repos/fabric'}}}
+
+    with pytest.raises(ValueError) as excinfo:
+        run_env_set(config, 'fabric', 'features', 'claude_tenant_stat',
+                    valid_features={'claude', 'claude_tenant_state'})
+
+    assert 'not a dax feature' in excinfo.value.args[0]
+    assert 'features' not in config['projects']['fabric']
+
+
+def test_env_set_features_validation_is_skipped_without_a_list(home):
+    """The valid set comes from dax.py, so callers that have none still work."""
+    config = {'projects': {'fabric': {'dir': '/repos/fabric'}}}
+
+    run_env_set(config, 'fabric', 'features', 'anything')
+
+    assert config['projects']['fabric']['features'] == ['anything']
+
+
+def test_features_is_a_documented_field():
+    assert 'features' in ENV_FIELDS
+    assert 'features' in env_field_help()

--- a/tests/test_dax_env_cmds.py
+++ b/tests/test_dax_env_cmds.py
@@ -1,0 +1,182 @@
+"""Tests for `dax env show` / `dax env set`.
+
+These exist so changing one field on a registered env doesn't require walking
+`dax init`'s full wizard (image -> credential checkbox -> new-credential loop)
+just to edit a single string.
+"""
+import pytest
+
+from dax_creds.config import ENV_FIELDS, env_field_help, load_dax_config
+from dax_creds.init import run_env_set, run_env_show
+
+
+CONFIG = """\
+# hand-maintained
+credentials:
+  claude-personal-fabric:
+    provider: claude
+  github-dfarrow:
+    provider: github
+
+features:
+- claude
+#- claude_tenant_state
+
+projects:
+  fabric:
+    dir: /Users/dfarrow/src/fabric
+    image: dax-base
+    creds:
+    - claude-personal-fabric
+  legacy:
+    dir: /Users/dfarrow/src/legacy
+    image: dax-base
+    multi_tenant: true
+    tenant_subdir: processes
+"""
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    (tmp_path / '.dax.yaml').write_text(CONFIG)
+    return tmp_path
+
+
+# --- set -------------------------------------------------------------------
+
+def test_set_tenant_persists_to_disk(home):
+    run_env_set(load_dax_config(), 'fabric', 'tenant', 'personal')
+
+    assert load_dax_config()['projects']['fabric']['tenant'] == 'personal'
+
+
+def test_set_preserves_comments(home):
+    """The whole point of the ruamel prerequisite — `set` is a routine writer."""
+    run_env_set(load_dax_config(), 'fabric', 'tenant', 'personal')
+
+    written = (home / '.dax.yaml').read_text()
+    assert '#- claude_tenant_state' in written
+    assert '# hand-maintained' in written
+
+
+def test_set_creds_splits_a_comma_list(home):
+    run_env_set(load_dax_config(), 'fabric', 'creds',
+                'claude-personal-fabric, github-dfarrow')
+
+    assert load_dax_config()['projects']['fabric']['creds'] == [
+        'claude-personal-fabric', 'github-dfarrow']
+
+
+def test_set_creds_rejects_undefined_credential(home):
+    with pytest.raises(ValueError, match='bogus'):
+        run_env_set(load_dax_config(), 'fabric', 'creds', 'claude-personal-fabric,bogus')
+
+    assert 'bogus' not in (home / '.dax.yaml').read_text()
+
+
+def test_set_unknown_env_names_the_known_ones(home):
+    with pytest.raises(KeyError) as excinfo:
+        run_env_set(load_dax_config(), 'nope', 'tenant', 'x')
+
+    assert 'fabric' in excinfo.value.args[0] and 'legacy' in excinfo.value.args[0]
+
+
+def test_set_unknown_field_lists_valid_fields(home):
+    with pytest.raises(ValueError) as excinfo:
+        run_env_set(load_dax_config(), 'fabric', 'nonsense', 'x')
+
+    message = excinfo.value.args[0]
+    for field in ENV_FIELDS:
+        assert field in message
+
+
+def test_set_does_not_write_when_it_rejects(home):
+    before = (home / '.dax.yaml').read_text()
+
+    with pytest.raises(ValueError):
+        run_env_set(load_dax_config(), 'fabric', 'nonsense', 'x')
+
+    assert (home / '.dax.yaml').read_text() == before
+
+
+# --- show ------------------------------------------------------------------
+
+def test_show_reports_unset_tenant(home, capsys):
+    run_env_show(load_dax_config(), 'fabric')
+
+    assert '(unset)' in capsys.readouterr().out
+
+
+def test_show_reports_tenant_and_state_path(home, capsys):
+    config = load_dax_config()
+    run_env_set(config, 'fabric', 'tenant', 'personal')
+    run_env_show(load_dax_config(), 'fabric')
+
+    out = capsys.readouterr().out
+    assert 'personal' in out
+    assert 'state/dax/tenants/personal/fabric' in out
+    assert 'not created yet' in out
+
+
+def test_show_flags_deprecated_multi_tenant_fields(home, capsys):
+    run_env_show(load_dax_config(), 'legacy')
+
+    out = capsys.readouterr().out
+    assert 'multi_tenant' in out and 'tenant_subdir' in out
+    assert 'deprecated' in out
+
+
+def test_show_unknown_env_raises(home):
+    with pytest.raises(KeyError):
+        run_env_show(load_dax_config(), 'nope')
+
+
+# --- bare provider tokens --------------------------------------------------
+
+def test_set_accepts_a_bare_provider_token(home):
+    run_env_set(load_dax_config(), 'fabric', 'creds', 'claude,github-dfarrow')
+
+    assert load_dax_config()['projects']['fabric']['creds'] == ['claude', 'github-dfarrow']
+
+
+def test_show_resolves_a_bare_token_to_the_derived_name(home, capsys):
+    run_env_set(load_dax_config(), 'fabric', 'tenant', 'personal')
+    run_env_set(load_dax_config(), 'fabric', 'creds', 'claude')
+    capsys.readouterr()  # drop the `set` echoes
+
+    run_env_show(load_dax_config(), 'fabric')
+
+    out = capsys.readouterr().out
+    assert '-> claude-personal-fabric' in out
+    # This fixture already registers claude-personal-fabric, so it is not flagged.
+    assert 'not registered yet' not in out
+
+
+def test_show_flags_a_derived_name_that_is_not_registered(home, capsys):
+    run_env_set(load_dax_config(), 'fabric', 'tenant', 'ysecurity')
+    run_env_set(load_dax_config(), 'fabric', 'creds', 'claude')
+    capsys.readouterr()
+
+    run_env_show(load_dax_config(), 'fabric')
+
+    out = capsys.readouterr().out
+    assert '-> claude-ysecurity-fabric' in out
+    assert 'not registered yet' in out
+
+
+def test_show_explains_a_bare_token_that_cannot_resolve(home, capsys):
+    """No tenant means no derivable name — say so here, not at launch."""
+    run_env_set(load_dax_config(), 'fabric', 'creds', 'claude')
+    run_env_show(load_dax_config(), 'fabric')
+
+    out = capsys.readouterr().out
+    assert 'unresolved' in out and 'no tenant' in out
+
+
+# --- field help ------------------------------------------------------------
+
+def test_field_help_documents_every_settable_field():
+    text = env_field_help()
+    for field, description in ENV_FIELDS.items():
+        assert field in text and description in text

--- a/tests/test_dax_env_cmds.py
+++ b/tests/test_dax_env_cmds.py
@@ -238,6 +238,61 @@ def test_features_is_a_documented_field():
     assert 'features' in env_field_help()
 
 
+# --- env set mounts ----------------------------------------------------------
+#
+# For migrating discernment's processes: each process becomes its own env, and
+# needs the discernment sidecar repo mounted alongside its own — as a sibling
+# under $HOME (feature_mounts), not nested inside another mount.
+
+def test_env_set_mounts_splits_a_comma_list(home):
+    run_env_set(load_dax_config(), 'fabric', 'mounts', '~/discernment, ~/other')
+
+    assert load_dax_config()['projects']['fabric']['mounts'] == ['~/discernment', '~/other']
+
+
+def test_mounts_is_a_documented_field():
+    assert 'mounts' in ENV_FIELDS
+    assert 'mounts' in env_field_help()
+
+
+def test_show_lists_mounts_when_set(home, capsys):
+    run_env_set(load_dax_config(), 'fabric', 'mounts', '~/discernment')
+    capsys.readouterr()
+
+    run_env_show(load_dax_config(), 'fabric')
+
+    out = capsys.readouterr().out
+    assert '~/discernment' in out
+
+
+def test_show_omits_mounts_line_when_unset(home, capsys):
+    run_env_show(load_dax_config(), 'fabric')
+
+    assert 'mounts' not in capsys.readouterr().out
+
+
+def test_show_flags_mounts_set_without_the_feature_active(home, capsys):
+    run_env_set(load_dax_config(), 'fabric', 'mounts', '~/discernment')
+    capsys.readouterr()
+
+    run_env_show(load_dax_config(), 'fabric')
+
+    out = capsys.readouterr().out
+    assert 'inactive' in out
+
+
+def test_show_does_not_flag_mounts_when_the_feature_is_active(home, capsys):
+    config = load_dax_config()
+    run_env_set(config, 'fabric', 'mounts', '~/discernment')
+    run_env_set(config, 'fabric', 'features', 'claude,mounts')
+    capsys.readouterr()
+
+    run_env_show(load_dax_config(), 'fabric')
+
+    out = capsys.readouterr().out
+    assert 'inactive' not in out
+
+
 # --- env accept-shared-files -------------------------------------------------
 #
 # The escape hatch for the drift warning `sync_claude_shared_files` prints at

--- a/tests/test_dax_envs_list.py
+++ b/tests/test_dax_envs_list.py
@@ -1,0 +1,188 @@
+"""Tests for the merged `dax envs list`.
+
+It outer-joins ~/.dax.yaml's projects against a walk of
+~/.local/state/dax/tenants/, because an env can be orphaned from either
+direction — a registry entry with no state tree, or a state tree with no
+registry entry. The second kind is invisible to every other command, and is
+what the deletion-grouping rationale needs to see.
+"""
+import os
+import time
+
+import pytest
+
+from dax_creds.init import _human_age, run_envs_list
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    # Registry dirs must exist or every row is flagged [!], which is noise here.
+    (tmp_path / 'src' / 'fabric').mkdir(parents=True)
+    monkeypatch.setattr('dax_creds.init._is_container_running', lambda name: False)
+    return tmp_path
+
+
+def _tree(home, tenant, project, size=1000):
+    path = home / '.local' / 'state' / 'dax' / 'tenants' / tenant / project
+    path.mkdir(parents=True)
+    (path / '.claude.json').write_bytes(b'x' * size)
+    return path
+
+
+def _rows(out):
+    """Data rows only — the name also appears inside the dir column, so
+    substring counting over the whole output overcounts."""
+    return [line for line in out.splitlines() if line.startswith('  [')
+            and 'state tree' not in line and 'directory missing' not in line]
+
+
+def _config(home, **overrides):
+    project = {'dir': str(home / 'src' / 'fabric'), 'image': 'dax-base', 'creds': []}
+    project.update(overrides)
+    return {'projects': {'fabric': project}}
+
+
+def test_tenant_column_comes_from_the_registry(home, capsys):
+    run_envs_list(_config(home, tenant='personal'))
+
+    out = capsys.readouterr().out
+    assert 'tenant' in out and 'personal' in out
+
+
+def test_state_size_shown_when_the_tree_exists(home, capsys):
+    _tree(home, 'personal', 'fabric', size=2048)
+
+    run_envs_list(_config(home, tenant='personal'))
+
+    assert '2K' in capsys.readouterr().out
+
+
+def test_missing_tree_shows_a_dash_not_an_orphan(home, capsys):
+    run_envs_list(_config(home, tenant='personal'))
+
+    out = capsys.readouterr().out
+    assert '[?]' not in out
+
+
+def test_matched_tree_is_claimed_and_not_listed_twice(home, capsys):
+    _tree(home, 'personal', 'fabric')
+
+    run_envs_list(_config(home, tenant='personal'))
+
+    out = capsys.readouterr().out
+    assert len(_rows(out)) == 1
+    assert '[?]' not in out
+
+
+def test_orphaned_tree_is_surfaced(home, capsys):
+    _tree(home, 'ysecurity', 'acme-process')
+
+    run_envs_list(_config(home, tenant='personal'))
+
+    out = capsys.readouterr().out
+    assert 'acme-process' in out
+    assert '[?]' in out
+    assert 'orphaned state tree' in out
+
+
+def test_env_without_a_tenant_cannot_claim_a_tree(home, capsys):
+    """No declared tenant means no path to look under, so the tree is unattributed."""
+    _tree(home, 'personal', 'fabric')
+
+    run_envs_list(_config(home))  # no tenant
+
+    rows = _rows(capsys.readouterr().out)
+    assert len(rows) == 2  # the registry row, plus the tree it could not claim
+    assert sum(1 for r in rows if r.startswith('  [?]')) == 1
+
+
+def test_orphans_are_listed_even_when_the_registry_is_empty(home, capsys):
+    """Deregistering everything is exactly when every tree becomes an orphan."""
+    _tree(home, 'personal', 'gone')
+
+    run_envs_list({'projects': {}})
+
+    out = capsys.readouterr().out
+    assert 'gone' in out and '[?]' in out
+
+
+def test_reports_nothing_at_all_when_there_is_nothing(home, capsys):
+    run_envs_list({'projects': {}})
+
+    assert 'No environments registered' in capsys.readouterr().out
+
+
+def test_legend_only_lists_markers_actually_present(home, capsys):
+    run_envs_list(_config(home, tenant='personal'))
+
+    out = capsys.readouterr().out
+    assert 'orphaned state tree' not in out
+    assert 'directory missing' not in out
+
+
+# --- last used -------------------------------------------------------------
+
+def test_recently_touched_tree_reads_as_fresh(home, capsys):
+    _tree(home, 'personal', 'fabric')
+
+    run_envs_list(_config(home, tenant='personal'))
+
+    out = capsys.readouterr().out
+    assert 'used' in out
+    assert 'now' in out
+
+
+def test_old_tree_reports_its_age(home, capsys):
+    tree = _tree(home, 'ysecurity', 'stale')
+    old = time.time() - 30 * 86400
+    os.utime(tree / '.claude.json', (old, old))
+
+    run_envs_list(_config(home, tenant='personal'))
+
+    assert '4w' in capsys.readouterr().out
+
+
+def test_age_uses_newest_file_not_the_directory(home, capsys):
+    """A directory's mtime only moves when entries are added or removed, so an
+    edit in place would otherwise look ancient."""
+    tree = _tree(home, 'ysecurity', 'mixed')
+    old = time.time() - 200 * 86400
+    os.utime(tree / '.claude.json', (old, old))
+    (tree / 'recent.jsonl').write_text('x')
+
+    run_envs_list(_config(home, tenant='personal'))
+
+    row = [l for l in _rows(capsys.readouterr().out) if 'mixed' in l][0]
+    assert row.rstrip().endswith('now'), row
+
+
+def test_env_without_a_tree_shows_no_age(home, capsys):
+    run_envs_list(_config(home, tenant='personal'))
+
+    row = [l for l in _rows(capsys.readouterr().out) if 'fabric' in l][0]
+    assert row.rstrip().endswith('-')
+
+
+@pytest.mark.parametrize('seconds,expected', [
+    (10, 'now'),
+    (5 * 60, '5m'),
+    (3 * 3600, '3h'),
+    (3 * 86400, '3d'),
+    (30 * 86400, '4w'),
+    (400 * 86400, '1y'),
+])
+def test_human_age_units(seconds, expected):
+    now = 1_000_000_000.0
+    assert _human_age(now - seconds, now=now) == expected
+
+
+def test_human_age_of_never_used_tree():
+    assert _human_age(0) == '-'
+
+
+def test_missing_project_directory_is_flagged(home, capsys):
+    run_envs_list(_config(home, dir=str(home / 'src' / 'vanished')))
+
+    out = capsys.readouterr().out
+    assert '[!]' in out and 'directory missing' in out

--- a/tests/test_dax_migrate_env_state.py
+++ b/tests/test_dax_migrate_env_state.py
@@ -1,0 +1,186 @@
+"""Tests for `tools/migrate_env_state.py`'s pure logic.
+
+Imported via importlib since it's a standalone host-only script under `tools/`,
+not part of the installed `dax_creds` package. Only `path_to_key`, `discover`,
+`filter_history`, and `copy_projects` are covered here — `plan()`/`main()` shell
+out to `docker ps` and read `~/.dax.yaml`, and are exercised instead by the
+scripted dry runs in docs/testing/2026-07-31-migrate-env-to-state-tree.md.
+
+`home`/`tmp_path` isolation matters doubly here: this script's whole job is
+reading a real `~/.claude`, so a leaked real `HOME` wouldn't just risk a
+destructive write (the usual worry — see conftest.py) but would also silently
+mix real transcript data into test assertions.
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / 'tools' / 'migrate_env_state.py'
+_spec = importlib.util.spec_from_file_location('migrate_env_state', _SCRIPT)
+migrate_env_state = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(migrate_env_state)
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    return tmp_path
+
+
+def _write_history(home, projects):
+    (home / '.claude').mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps({'project': p}) for p in projects]
+    (home / '.claude' / 'history.jsonl').write_text('\n'.join(lines) + '\n')
+
+
+def _make_project_dir(home, key, sessions=1):
+    d = home / '.claude' / 'projects' / key
+    d.mkdir(parents=True, exist_ok=True)
+    for i in range(sessions):
+        (d / f'session-{i}.jsonl').write_text('{}\n')
+    return d
+
+
+class TestPathToKey:
+
+    def test_mangles_slashes_to_dashes(self):
+        assert migrate_env_state.path_to_key('/home/dfarrow/dax') == '-home-dfarrow-dax'
+
+    def test_strips_trailing_slash(self):
+        assert migrate_env_state.path_to_key('/home/dfarrow/dax/') == '-home-dfarrow-dax'
+
+
+class TestDiscover:
+    """Against the real shape found in ~/.claude/projects/ on 2026-08-01: a
+    process migrating out of a larger host tree leaves its own nested key plus
+    ancestor keys shared with whatever else lived under that tree."""
+
+    def test_finds_a_forgotten_legacy_leaf_key(self, home):
+        _make_project_dir(home, '-home-dfarrow-self-employment-setup')
+        _make_project_dir(home, '-home-dfarrow-work-processes-self-employment-setup')
+
+        leaf_others, ancestors = migrate_env_state.discover(
+            'self-employment-setup', ['-home-dfarrow-self-employment-setup'])
+
+        assert leaf_others == ['-home-dfarrow-work-processes-self-employment-setup']
+        assert ancestors == {}
+
+    def test_finds_ancestor_keys_of_a_migrated_legacy_key(self, home):
+        _make_project_dir(home, '-home-dfarrow')
+        _make_project_dir(home, '-home-dfarrow-work')
+        _make_project_dir(home, '-home-dfarrow-work-processes')
+        _make_project_dir(home, '-home-dfarrow-work-processes-self-employment-setup')
+
+        leaf_others, ancestors = migrate_env_state.discover(
+            'self-employment-setup',
+            ['-home-dfarrow-self-employment-setup',
+             '-home-dfarrow-work-processes-self-employment-setup'])
+
+        assert set(ancestors) == {
+            '-home-dfarrow', '-home-dfarrow-work', '-home-dfarrow-work-processes'}
+        assert ancestors['-home-dfarrow-work-processes'] == {
+            '-home-dfarrow-work-processes-self-employment-setup'}
+
+    def test_no_false_positive_leaf_without_a_dash_boundary(self, home):
+        # 'network' ends with the letters "work" but not the dash-delimited
+        # suffix '-work' — must not be mistaken for a legacy key of env 'work'.
+        _make_project_dir(home, '-home-dfarrow-network')
+
+        leaf_others, _ = migrate_env_state.discover('work', ['-home-dfarrow-work'])
+
+        assert leaf_others == []
+
+    def test_already_requested_keys_are_not_reported_as_forgotten(self, home):
+        _make_project_dir(home, '-home-dfarrow-self-employment-setup')
+
+        leaf_others, _ = migrate_env_state.discover(
+            'self-employment-setup', ['-home-dfarrow-self-employment-setup'])
+
+        assert leaf_others == []
+
+
+class TestFilterHistory:
+
+    def test_keeps_only_exact_cwd_matches(self, home):
+        _write_history(home, [
+            '/home/dfarrow/self-employment-setup',
+            '/home/dfarrow/work/processes/self-employment-setup',
+            '/home/dfarrow/work',  # ancestor — must never be pulled in
+        ])
+        tree = home / 'tree'
+
+        migrate_env_state.filter_history(
+            ['/home/dfarrow/self-employment-setup',
+             '/home/dfarrow/work/processes/self-employment-setup'],
+            tree, apply_it=True)
+
+        kept = [json.loads(l)['project']
+                for l in (tree / 'history.jsonl').read_text().splitlines()]
+        assert set(kept) == {
+            '/home/dfarrow/self-employment-setup',
+            '/home/dfarrow/work/processes/self-employment-setup',
+        }
+
+    def test_dry_run_writes_nothing(self, home):
+        _write_history(home, ['/home/dfarrow/dax'])
+        tree = home / 'tree'
+
+        migrate_env_state.filter_history(['/home/dfarrow/dax'], tree, apply_it=False)
+
+        assert not (tree / 'history.jsonl').exists()
+
+
+class TestCopyProjects:
+
+    def test_each_key_lands_in_its_own_directory_not_merged(self, home):
+        _make_project_dir(home, '-home-dfarrow-self-employment-setup', sessions=2)
+        _make_project_dir(
+            home, '-home-dfarrow-work-processes-self-employment-setup', sessions=1)
+        tree = home / 'tree'
+
+        migrate_env_state.copy_projects(
+            ['-home-dfarrow-self-employment-setup',
+             '-home-dfarrow-work-processes-self-employment-setup'],
+            tree, apply_it=True, force=False)
+
+        canonical = tree / 'projects' / '-home-dfarrow-self-employment-setup'
+        legacy = tree / 'projects' / '-home-dfarrow-work-processes-self-employment-setup'
+        assert len(list(canonical.glob('*.jsonl'))) == 2
+        assert len(list(legacy.glob('*.jsonl'))) == 1
+
+    def test_dry_run_writes_nothing(self, home):
+        _make_project_dir(home, '-home-dfarrow-dax')
+        tree = home / 'tree'
+
+        migrate_env_state.copy_projects(
+            ['-home-dfarrow-dax'], tree, apply_it=False, force=False)
+
+        assert not tree.exists()
+
+    def test_refuses_to_overwrite_existing_destination_without_force(self, home):
+        _make_project_dir(home, '-home-dfarrow-dax')
+        tree = home / 'tree'
+        dst = tree / 'projects' / '-home-dfarrow-dax'
+        dst.mkdir(parents=True)
+        (dst / 'stale.jsonl').write_text('old')
+
+        migrate_env_state.copy_projects(
+            ['-home-dfarrow-dax'], tree, apply_it=True, force=False)
+
+        assert (dst / 'stale.jsonl').read_text() == 'old'
+        assert not (dst / 'session-0.jsonl').exists()
+
+    def test_force_overwrites_existing_destination(self, home):
+        _make_project_dir(home, '-home-dfarrow-dax')
+        tree = home / 'tree'
+        dst = tree / 'projects' / '-home-dfarrow-dax'
+        dst.mkdir(parents=True)
+        (dst / 'stale.jsonl').write_text('old')
+
+        migrate_env_state.copy_projects(
+            ['-home-dfarrow-dax'], tree, apply_it=True, force=True)
+
+        assert not (dst / 'stale.jsonl').exists()
+        assert (dst / 'session-0.jsonl').exists()

--- a/tests/test_dax_process_cmds.py
+++ b/tests/test_dax_process_cmds.py
@@ -1,0 +1,403 @@
+"""Tests for `dax process new` (docs/design/VALIDATION.md's dax contract,
+items 2 and 4): scaffold a new substrate-backed process directory and
+register it as a dax env.
+
+Every field is either given on the command line or interactively prompted —
+dax never lets new-process.sh's own basic prompting fire, and never silently
+defaults a field the user didn't supply. Mirrors the `monkeypatch.setattr`
+style tests/test_dax_tenant_cmds.py already uses for `_prompt_tenant` rather
+than mocking questionary internals directly.
+
+Every process directory used below lives under the fake $HOME
+(`home / 'proc'`, never a bare `tmp_path / 'proc'`): `_check_process_dir`
+refuses anything outside $HOME, the same way `dax run` would refuse to
+launch it later.
+"""
+import argparse
+
+import pytest
+import yaml
+
+from dax import _read_process_types, _run_process_new
+from dax_creds.config import load_dax_config
+
+
+TYPES_TSV = """\
+# comment line, ignored
+commitment\tdiscernment\tCareer, role, or partnership decisions
+ops\tops\tStructural or operational setup for a new way of working
+"""
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    home = tmp_path / 'home'
+    home.mkdir()
+    (home / '.dax.yaml').write_text('projects: {}\n')
+    monkeypatch.setenv('HOME', str(home))
+    return home
+
+
+@pytest.fixture
+def substrate(tmp_path):
+    root = tmp_path / 'virgil'
+    (root / 'shared').mkdir(parents=True)
+    (root / 'shared' / 'process-types.tsv').write_text(TYPES_TSV)
+    # The real new-process.sh; here it's just a script recording invocation
+    # and always succeeding, since new-process.sh's own behavior is not what
+    # this file tests (docs/design/scripts/new-process.sh is untracked, not
+    # available at test time).
+    script = root / 'shared' / 'new-process.sh'
+    script.write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$(dirname "$0")/../../last-call.txt"\n')
+    script.chmod(0o755)
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _confirm_proceed(monkeypatch):
+    """The "Proceed?" gate defaults to True across this file — tests that
+    care about the decline path or --dry-run override this explicitly."""
+    monkeypatch.setattr('dax_creds.init._q_confirm', lambda prompt, default=False: True)
+
+
+def _args(**overrides):
+    base = dict(name='demo', dir=None, tenant=None, substrate=None,
+                title=None, type=None, git=False, no_git=False, dry_run=False)
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _last_call(tmp_path):
+    return (tmp_path / 'last-call.txt').read_text().splitlines()
+
+
+# --- fully flag-driven: no field-resolution prompting -----------------------
+
+def test_fully_flag_driven_invokes_new_process_sh_with_resolved_flags(
+        home, substrate, tmp_path, monkeypatch):
+    def fail_if_prompted(*a, **k):
+        raise AssertionError('should not prompt when every flag is given')
+    monkeypatch.setattr('dax._prompt_tenant', fail_if_prompted)
+    monkeypatch.setattr('dax_creds.init._prompt', fail_if_prompted)
+    monkeypatch.setattr('dax_creds.init._q_select', fail_if_prompted)
+
+    process_dir = home / 'proc'
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir=str(process_dir), tenant='acme', substrate=str(substrate),
+        title='Demo', type='ops', git=False, no_git=True))
+
+    call = _last_call(tmp_path)
+    assert call == ['--dir', str(process_dir), '--title', 'Demo',
+                     '--type', 'ops', '--no-git']
+
+
+def test_registers_project_with_resolved_fields(home, substrate, tmp_path):
+    process_dir = home / 'proc'
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir=str(process_dir), tenant='acme', substrate=str(substrate),
+        title='Demo', type='ops', no_git=True))
+
+    project = load_dax_config()['projects']['demo']
+    assert project['dir'] == str(process_dir)
+    assert project['tenant'] == 'acme'
+    assert project['substrate'] == str(substrate)
+    assert project['creds'] == ['claude']
+
+
+def test_features_always_ends_up_substrate_and_claude_tenant_state(
+        home, substrate, tmp_path):
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir=str(home / 'proc'), tenant='acme', substrate=str(substrate),
+        title='Demo', type='ops', no_git=True))
+
+    project = load_dax_config()['projects']['demo']
+    assert project['features'] == ['substrate', 'claude_tenant_state']
+
+
+def test_git_flag_is_passed_through(home, substrate, tmp_path):
+    process_dir = home / 'proc'
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir=str(process_dir), tenant='acme', substrate=str(substrate),
+        title='Demo', type='ops', git=True))
+
+    assert '--git' in _last_call(tmp_path)
+
+
+def test_git_and_no_git_together_is_an_error(home, substrate, tmp_path, capsys):
+    config = load_dax_config()
+    with pytest.raises(SystemExit):
+        _run_process_new(config, _args(
+            dir=str(home / 'proc'), tenant='acme', substrate=str(substrate),
+            title='Demo', type='ops', git=True, no_git=True))
+    assert 'not both' in capsys.readouterr().out
+
+
+# --- prompting for missing fields -------------------------------------------
+
+def test_missing_dir_is_prompted(home, substrate, tmp_path, monkeypatch):
+    monkeypatch.setattr('dax_creds.init._prompt',
+                        lambda prompt, default=None: str(home / 'prompted-dir')
+                        if prompt == 'Process directory' else default)
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        tenant='acme', substrate=str(substrate), title='Demo', type='ops', no_git=True))
+
+    assert load_dax_config()['projects']['demo']['dir'] == str(home / 'prompted-dir')
+
+
+def test_missing_tenant_uses_prompt_tenant(home, substrate, tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr('dax._prompt_tenant', lambda subdir, known: calls.append(subdir) or 'prompted-tenant')
+
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir=str(home / 'proc'), substrate=str(substrate), title='Demo',
+        type='ops', no_git=True))
+
+    assert load_dax_config()['projects']['demo']['tenant'] == 'prompted-tenant'
+    assert len(calls) == 1
+
+
+def test_missing_substrate_prompt_defaults_to_top_level_config(
+        home, substrate, tmp_path, monkeypatch):
+    config = load_dax_config()
+    config['substrate'] = str(substrate)
+
+    seen_defaults = {}
+
+    def fake_prompt(prompt, default=None):
+        seen_defaults[prompt] = default
+        if prompt == 'Substrate path':
+            return default
+        if prompt == 'Process directory':
+            return str(home / 'proc')
+        if prompt == 'Process title':
+            return 'Demo'
+        return default
+    monkeypatch.setattr('dax_creds.init._prompt', fake_prompt)
+
+    _run_process_new(config, _args(tenant='acme', type='ops', no_git=True))
+
+    assert seen_defaults['Substrate path'] == str(substrate)
+
+
+def test_missing_title_is_prompted(home, substrate, tmp_path, monkeypatch):
+    monkeypatch.setattr('dax_creds.init._prompt',
+                        lambda prompt, default=None: 'Prompted Title'
+                        if prompt == 'Process title' else default)
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir=str(home / 'proc'), tenant='acme', substrate=str(substrate),
+        type='ops', no_git=True))
+
+    call = _last_call(tmp_path)
+    assert 'Prompted Title' in call
+
+
+def test_missing_type_is_selected_from_tsv(home, substrate, tmp_path, monkeypatch):
+    monkeypatch.setattr('dax_creds.init._q_select', lambda prompt, choices: choices[0].value)
+
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir=str(home / 'proc'), tenant='acme', substrate=str(substrate),
+        title='Demo', no_git=True))
+
+    call = _last_call(tmp_path)
+    assert 'commitment' in call  # first row of TYPES_TSV
+
+
+def test_missing_git_decision_is_confirmed(home, substrate, tmp_path, monkeypatch):
+    confirms = []
+    monkeypatch.setattr('dax_creds.init._q_confirm', lambda prompt, default=False:
+                        confirms.append(prompt) or True)
+
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir=str(home / 'proc'), tenant='acme', substrate=str(substrate),
+        title='Demo', type='ops'))
+
+    assert '--git' in _last_call(tmp_path)
+    assert 'git?' in confirms  # distinct from the later "Proceed?" confirm
+
+
+# --- confirmation summary + dry run ------------------------------------------
+
+def test_dry_run_prints_summary_and_changes_nothing(home, substrate, tmp_path, capsys):
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir=str(home / 'proc'), tenant='acme', substrate=str(substrate),
+        title='Demo', type='ops', no_git=True, dry_run=True))
+
+    out = capsys.readouterr().out
+    assert str(home / 'proc') in out
+    assert str(substrate) in out
+    assert 'acme' in out
+    assert 'dry run' in out
+    assert not (tmp_path / 'last-call.txt').exists()
+    assert 'demo' not in load_dax_config().get('projects', {})
+
+
+def test_declining_the_proceed_prompt_changes_nothing(
+        home, substrate, tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr('dax_creds.init._q_confirm', lambda prompt, default=False: False)
+
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir=str(home / 'proc'), tenant='acme', substrate=str(substrate),
+        title='Demo', type='ops', no_git=True))
+
+    assert 'aborted' in capsys.readouterr().out
+    assert not (tmp_path / 'last-call.txt').exists()
+    assert 'demo' not in load_dax_config().get('projects', {})
+
+
+def test_summary_uses_full_resolved_paths_not_relative_shorthand(
+        home, substrate, tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(home)
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir='proc', tenant='acme', substrate=str(substrate),
+        title='Demo', type='ops', no_git=True, dry_run=True))
+
+    out = capsys.readouterr().out
+    assert str(home / 'proc') in out
+    assert './proc' not in out
+
+
+# --- guardrails: bad directory choices ---------------------------------------
+
+def test_relative_dir_is_resolved_to_absolute(home, substrate, tmp_path, monkeypatch):
+    monkeypatch.chdir(home)
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir='proc', tenant='acme', substrate=str(substrate),
+        title='Demo', type='ops', no_git=True))
+
+    assert load_dax_config()['projects']['demo']['dir'] == str(home / 'proc')
+
+
+def test_dir_outside_home_is_refused(home, substrate, tmp_path, capsys):
+    outside = tmp_path / 'outside-home'
+    outside.mkdir()
+    config = load_dax_config()
+    with pytest.raises(SystemExit):
+        _run_process_new(config, _args(
+            dir=str(outside), tenant='acme', substrate=str(substrate),
+            title='Demo', type='ops', no_git=True))
+
+    assert 'not under your home directory' in capsys.readouterr().out
+    assert 'demo' not in load_dax_config().get('projects', {})
+
+
+def test_dir_colliding_with_existing_project_is_refused(home, substrate, tmp_path, capsys):
+    existing_dir = home / 'existing'
+    existing_dir.mkdir()
+    config = load_dax_config()
+    config['projects']['other'] = {'dir': str(existing_dir), 'creds': []}
+
+    with pytest.raises(SystemExit):
+        _run_process_new(config, _args(
+            dir=str(existing_dir), tenant='acme', substrate=str(substrate),
+            title='Demo', type='ops', no_git=True))
+
+    assert 'already registered as project' in capsys.readouterr().out
+
+
+def test_dir_nested_inside_existing_project_is_refused(home, substrate, tmp_path, capsys):
+    existing_dir = home / 'existing'
+    existing_dir.mkdir()
+    config = load_dax_config()
+    config['projects']['other'] = {'dir': str(existing_dir), 'creds': []}
+
+    with pytest.raises(SystemExit):
+        _run_process_new(config, _args(
+            dir=str(existing_dir / 'nested'), tenant='acme', substrate=str(substrate),
+            title='Demo', type='ops', no_git=True))
+
+    assert 'inside already-registered project' in capsys.readouterr().out
+
+
+def test_dir_enclosing_an_existing_project_is_refused(home, substrate, tmp_path, capsys):
+    existing_dir = home / 'parent' / 'existing'
+    existing_dir.mkdir(parents=True)
+    config = load_dax_config()
+    config['projects']['other'] = {'dir': str(existing_dir), 'creds': []}
+
+    with pytest.raises(SystemExit):
+        _run_process_new(config, _args(
+            dir=str(home / 'parent'), tenant='acme', substrate=str(substrate),
+            title='Demo', type='ops', no_git=True))
+
+    assert 'would enclose already-registered project' in capsys.readouterr().out
+
+
+def test_non_empty_dir_is_noted_but_not_blocked(home, substrate, tmp_path, capsys):
+    process_dir = home / 'proc'
+    process_dir.mkdir()
+    (process_dir / 'something.txt').write_text('pre-existing')
+
+    config = load_dax_config()
+    _run_process_new(config, _args(
+        dir=str(process_dir), tenant='acme', substrate=str(substrate),
+        title='Demo', type='ops', no_git=True))
+
+    assert 'demo' in load_dax_config().get('projects', {})
+
+
+# --- validation and failure handling -----------------------------------------
+
+def test_unknown_type_flag_is_rejected(home, substrate, tmp_path, capsys):
+    config = load_dax_config()
+    with pytest.raises(SystemExit):
+        _run_process_new(config, _args(
+            dir=str(home / 'proc'), tenant='acme', substrate=str(substrate),
+            title='Demo', type='not-a-real-type', no_git=True))
+
+    assert 'unknown type' in capsys.readouterr().out
+    assert 'demo' not in load_dax_config().get('projects', {})
+
+
+def test_missing_process_types_tsv_errors_clearly(home, tmp_path, capsys):
+    bad_substrate = tmp_path / 'not-a-substrate'
+    bad_substrate.mkdir()
+    config = load_dax_config()
+    with pytest.raises(SystemExit):
+        _run_process_new(config, _args(
+            dir=str(home / 'proc'), tenant='acme', substrate=str(bad_substrate),
+            title='Demo', type='ops', no_git=True))
+
+    assert 'process-types.tsv' in capsys.readouterr().out
+
+
+def test_new_process_sh_failure_aborts_registration(home, tmp_path, monkeypatch, capsys):
+    root = tmp_path / 'virgil'
+    (root / 'shared').mkdir(parents=True)
+    (root / 'shared' / 'process-types.tsv').write_text(TYPES_TSV)
+    script = root / 'shared' / 'new-process.sh'
+    script.write_text('#!/bin/sh\nexit 1\n')
+    script.chmod(0o755)
+
+    config = load_dax_config()
+    with pytest.raises(SystemExit):
+        _run_process_new(config, _args(
+            dir=str(home / 'proc'), tenant='acme', substrate=str(root),
+            title='Demo', type='ops', no_git=True))
+
+    assert 'new-process.sh failed' in capsys.readouterr().out
+    assert 'demo' not in load_dax_config().get('projects', {})
+
+
+def test_read_process_types_ignores_comments(substrate):
+    types = _read_process_types(substrate)
+    assert ('ops', 'ops', 'Structural or operational setup for a new way of working') in types
+    assert not any(t[0].startswith('#') for t in types)
+
+
+def test_read_process_types_errors_when_tsv_missing(tmp_path):
+    with pytest.raises(ValueError, match='process-types.tsv'):
+        _read_process_types(tmp_path / 'nope')

--- a/tests/test_dax_process_destroy_cmds.py
+++ b/tests/test_dax_process_destroy_cmds.py
@@ -1,0 +1,224 @@
+"""Tests for `dax process destroy` (docs/design/VALIDATION.md's `destroy-process`,
+item 6): tear down a registered process's directory, Claude state tree, any
+derived credential, and its ~/.dax.yaml entry.
+
+Generalized past substrate processes specifically — plain projects (no
+`substrate`/`claude_tenant_state`) are valid destroy targets too, since the
+cleanup is the same either way.
+"""
+import argparse
+import subprocess
+
+import pytest
+
+from dax import _run_process_destroy
+from dax_creds.config import load_dax_config, state_tree_path, _shared_files_manifest_path
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    home = tmp_path / 'home'
+    home.mkdir()
+    (home / '.dax.yaml').write_text('projects: {}\n')
+    monkeypatch.setenv('HOME', str(home))
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _no_running_containers(monkeypatch):
+    """Real `docker ps` isn't available in the test sandbox; default every
+    candidate to "not running" unless a test overrides this explicitly."""
+    monkeypatch.setattr('dax_creds.init._is_container_running', lambda name: False)
+
+
+@pytest.fixture(autouse=True)
+def _confirm_destroy(monkeypatch):
+    """Types DESTROY at the confirmation prompt by default — tests that care
+    about declining override this explicitly."""
+    monkeypatch.setattr('builtins.input', lambda *a, **k: 'DESTROY')
+
+
+def _register(home, name, tenant='acme', creds=None, make_dir=True, make_state=True):
+    config = load_dax_config()
+    process_dir = home / name
+    if make_dir:
+        process_dir.mkdir(exist_ok=True)
+    config.setdefault('projects', {})[name] = {
+        'dir': str(process_dir),
+        'tenant': tenant,
+        'creds': creds if creds is not None else ['claude'],
+        'image': 'dax-base',
+    }
+    from dax_creds.init import save_config
+    save_config(config)
+
+    if tenant and make_state:
+        state = state_tree_path(tenant, name)
+        state.mkdir(parents=True, exist_ok=True)
+        (state / '.credentials.json').write_text('{}')
+
+    return process_dir, load_dax_config()
+
+
+def _args(name=None, dry_run=False):
+    return argparse.Namespace(name=name or [], dry_run=dry_run)
+
+
+def test_destroy_single_name_removes_everything(home, monkeypatch):
+    process_dir, config = _register(home, 'demo')
+    removed = []
+    monkeypatch.setattr('dax_creds.init.run_creds_remove',
+                        lambda cfg, cred_name: removed.append(cred_name))
+
+    state = state_tree_path('acme', 'demo')
+    manifest = _shared_files_manifest_path('acme', 'demo')
+    manifest.write_text('{}')
+
+    _run_process_destroy(config, _args(['demo']))
+
+    assert not process_dir.exists()
+    assert not state.exists()
+    assert not manifest.exists()
+    assert 'demo' not in load_dax_config().get('projects', {})
+    assert removed == ['claude-acme-demo']
+
+
+def test_destroy_multiple_names_in_one_call(home):
+    dir_a, config = _register(home, 'proc-a')
+    dir_b, config = _register(home, 'proc-b')
+
+    _run_process_destroy(config, _args(['proc-a', 'proc-b']))
+
+    assert not dir_a.exists()
+    assert not dir_b.exists()
+    projects = load_dax_config().get('projects', {})
+    assert 'proc-a' not in projects
+    assert 'proc-b' not in projects
+
+
+def test_no_args_uses_checkbox_picker(home, monkeypatch):
+    dir_a, config = _register(home, 'proc-a')
+    dir_b, config = _register(home, 'proc-b')
+
+    monkeypatch.setattr('dax_creds.init._q_checkbox', lambda prompt, choices: ['proc-a'])
+
+    _run_process_destroy(config, _args())
+
+    assert not dir_a.exists()
+    assert dir_b.exists()
+    projects = load_dax_config().get('projects', {})
+    assert 'proc-a' not in projects
+    assert 'proc-b' in projects
+
+
+def test_no_args_nothing_selected_changes_nothing(home, monkeypatch):
+    process_dir, config = _register(home, 'demo')
+    monkeypatch.setattr('dax_creds.init._q_checkbox', lambda prompt, choices: [])
+
+    _run_process_destroy(config, _args())
+
+    assert process_dir.exists()
+    assert 'demo' in load_dax_config().get('projects', {})
+
+
+def test_no_registered_envs_at_all(home, capsys):
+    config = load_dax_config()
+    _run_process_destroy(config, _args())
+    assert 'no registered envs' in capsys.readouterr().out
+
+
+def test_dry_run_touches_nothing(home, capsys):
+    process_dir, config = _register(home, 'demo')
+
+    _run_process_destroy(config, _args(['demo'], dry_run=True))
+
+    out = capsys.readouterr().out
+    assert str(process_dir) in out
+    assert 'dry run' in out
+    assert process_dir.exists()
+    assert state_tree_path('acme', 'demo').exists()
+    assert 'demo' in load_dax_config().get('projects', {})
+
+
+def test_declining_confirmation_changes_nothing(home, monkeypatch, capsys):
+    process_dir, config = _register(home, 'demo')
+    monkeypatch.setattr('builtins.input', lambda *a, **k: 'not destroy')
+
+    _run_process_destroy(config, _args(['demo']))
+
+    assert 'aborted' in capsys.readouterr().out
+    assert process_dir.exists()
+    assert 'demo' in load_dax_config().get('projects', {})
+
+
+def test_refuses_if_container_is_running(home, monkeypatch, capsys):
+    process_dir, config = _register(home, 'demo')
+    monkeypatch.setattr('dax_creds.init._is_container_running', lambda name: True)
+
+    with pytest.raises(SystemExit):
+        _run_process_destroy(config, _args(['demo']))
+
+    out = capsys.readouterr().out
+    assert 'stop it first' in out
+    assert process_dir.exists()
+    assert 'demo' in load_dax_config().get('projects', {})
+
+
+def test_unknown_name_aborts_before_anything(home, capsys):
+    process_dir, config = _register(home, 'demo')
+
+    with pytest.raises(SystemExit):
+        _run_process_destroy(config, _args(['demo', 'not-a-real-env']))
+
+    assert 'not registered' in capsys.readouterr().out
+    assert process_dir.exists()
+    assert 'demo' in load_dax_config().get('projects', {})
+
+
+def test_uncommitted_git_changes_are_warned_not_blocked(home, capsys):
+    process_dir, config = _register(home, 'demo')
+    subprocess.run(['git', 'init', '-q'], cwd=process_dir, check=True)
+    (process_dir / 'dirty.txt').write_text('uncommitted')
+
+    _run_process_destroy(config, _args(['demo']))
+
+    out = capsys.readouterr().out
+    assert 'uncommitted git change' in out
+    assert not process_dir.exists()
+    assert 'demo' not in load_dax_config().get('projects', {})
+
+
+def test_already_deleted_directory_still_cleans_up_rest(home):
+    process_dir, config = _register(home, 'demo')
+    process_dir.rmdir()
+
+    _run_process_destroy(config, _args(['demo']))
+
+    assert not state_tree_path('acme', 'demo').exists()
+    assert 'demo' not in load_dax_config().get('projects', {})
+
+
+def test_no_tenant_skips_state_tree_cleanly(home, capsys):
+    process_dir, config = _register(home, 'demo', tenant=None, creds=[], make_state=False)
+
+    _run_process_destroy(config, _args(['demo']))
+
+    assert not process_dir.exists()
+    assert 'demo' not in load_dax_config().get('projects', {})
+
+
+def test_explicit_credential_is_never_auto_removed(home, monkeypatch):
+    process_dir, config = _register(home, 'demo', creds=['github-dfarrow'])
+    config.setdefault('credentials', {})['github-dfarrow'] = {'provider': 'github'}
+    from dax_creds.init import save_config
+    save_config(config)
+    config = load_dax_config()
+
+    removed = []
+    monkeypatch.setattr('dax_creds.init.run_creds_remove',
+                        lambda cfg, cred_name: removed.append(cred_name))
+
+    _run_process_destroy(config, _args(['demo']))
+
+    assert removed == []
+    assert 'github-dfarrow' in load_dax_config().get('credentials', {})

--- a/tests/test_dax_tenant_cmds.py
+++ b/tests/test_dax_tenant_cmds.py
@@ -1,0 +1,492 @@
+import argparse
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+import yaml
+
+from dax import (
+    cmd_tenant,
+    cmd_tenants,
+    _known_tenant_names,
+    _prompt_tenant,
+    _ensure_tenants_classified,
+    _NEW_TENANT_CHOICE,
+)
+
+
+def _write_dax_yaml(home, projects):
+    with open(home / '.dax.yaml', 'w') as f:
+        yaml.dump({'projects': projects}, f)
+
+
+def _declare(path, tenant):
+    path.mkdir(parents=True, exist_ok=True)
+    (path / '.dax-tenant').write_text(tenant)
+
+
+def _mark_used(state_dir):
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / '.claude.json').write_text('{}')
+
+
+# --- dax tenant set: unchanged, just declares -------------------------------
+
+def test_cmd_tenant_set_writes_dax_tenant_file(tmp_path):
+    subdir = tmp_path / 'project_ysecurity'
+    subdir.mkdir()
+    args = argparse.Namespace(tenant_command='set', subdir=str(subdir), tenant='ysecurity')
+
+    cmd_tenant(args)
+
+    assert (subdir / '.dax-tenant').read_text() == 'ysecurity'
+
+
+def test_cmd_tenant_set_overwrites_existing_declaration(tmp_path):
+    subdir = tmp_path / 'project_a'
+    subdir.mkdir()
+    (subdir / '.dax-tenant').write_text('old-tenant')
+    args = argparse.Namespace(tenant_command='set', subdir=str(subdir), tenant='new-tenant')
+
+    cmd_tenant(args)
+
+    assert (subdir / '.dax-tenant').read_text() == 'new-tenant'
+
+
+def test_cmd_tenant_set_errors_on_nonexistent_dir(tmp_path, capsys):
+    missing = tmp_path / 'does-not-exist'
+    args = argparse.Namespace(tenant_command='set', subdir=str(missing), tenant='ysecurity')
+
+    with pytest.raises(SystemExit):
+        cmd_tenant(args)
+
+    assert 'not a directory' in capsys.readouterr().out
+
+
+# --- dax tenants: registry- and declaration-driven table --------------------
+
+def test_cmd_tenants_shows_single_tenant_project_with_path(tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    repo = tmp_path / 'repos' / 'fabric'
+    _declare(repo, 'personal')
+    _write_dax_yaml(home, {'fabric': {'dir': str(repo)}})
+    monkeypatch.setenv('HOME', str(home))
+
+    cmd_tenants(argparse.Namespace())
+
+    out = capsys.readouterr().out
+    lines = [l for l in out.splitlines() if l]
+    assert lines[0].split() == ['TENANT', 'PROJECT', 'SESSION', 'PATH']
+    assert any(line.split() == ['personal', 'fabric', 'no', str(repo)] for line in lines[1:])
+
+
+def test_cmd_tenants_shows_multi_tenant_projects_with_paths(tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    repo = tmp_path / 'repos' / 'discernment'
+    _declare(repo / 'project_ysecurity_comp_model', 'ysecurity')
+    _declare(repo / 'project_augment', 'augment')
+    _write_dax_yaml(home, {'discernment': {'dir': str(repo), 'multi_tenant': True}})
+    monkeypatch.setenv('HOME', str(home))
+
+    cmd_tenants(argparse.Namespace())
+
+    out = capsys.readouterr().out
+    assert str(repo / 'project_ysecurity_comp_model') in out
+    assert str(repo / 'project_augment') in out
+    assert 'ysecurity' in out
+    assert 'augment' in out
+
+
+def test_cmd_tenants_shows_declared_multi_tenant_root_at_repo_root_path(
+        tmp_path, monkeypatch, capsys):
+    # The root's own project entry must show the true repo root as its path,
+    # not tenant_base/<reponame> (which would be nonsensical, e.g.
+    # discernment/processes/discernment).
+    home = tmp_path / 'home'
+    home.mkdir()
+    repo = tmp_path / 'repos' / 'discernment'
+    _declare(repo, 'personal')
+    _declare(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
+    _write_dax_yaml(home, {
+        'discernment': {'dir': str(repo), 'multi_tenant': True, 'tenant_subdir': 'processes'},
+    })
+    monkeypatch.setenv('HOME', str(home))
+
+    cmd_tenants(argparse.Namespace())
+
+    lines = [l.split() for l in capsys.readouterr().out.splitlines()]
+    assert ['personal', 'discernment', 'no', str(repo)] in lines
+    assert ['ysecurity', 'project_ysecurity_comp_model', 'no',
+            str(repo / 'processes' / 'project_ysecurity_comp_model')] in lines
+
+
+def test_cmd_tenants_multi_tenant_with_tenant_subdir_shows_full_path(tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    repo = tmp_path / 'repos' / 'discernment'
+    _declare(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
+    _write_dax_yaml(home, {
+        'discernment': {'dir': str(repo), 'multi_tenant': True, 'tenant_subdir': 'processes'},
+    })
+    monkeypatch.setenv('HOME', str(home))
+
+    cmd_tenants(argparse.Namespace())
+
+    out = capsys.readouterr().out
+    assert str(repo / 'processes' / 'project_ysecurity_comp_model') in out
+
+
+def test_cmd_tenants_marks_session_yes_when_state_exists(tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    repo = tmp_path / 'repos' / 'fabric'
+    _declare(repo, 'personal')
+    _write_dax_yaml(home, {'fabric': {'dir': str(repo)}})
+    _mark_used(home / '.local' / 'state' / 'dax' / 'tenants' / 'personal' / 'fabric')
+    monkeypatch.setenv('HOME', str(home))
+
+    cmd_tenants(argparse.Namespace())
+
+    out = capsys.readouterr().out
+    lines = [l.split() for l in out.splitlines()]
+    assert ['personal', 'fabric', 'yes', str(repo)] in lines
+
+
+def test_cmd_tenants_recognizes_credentials_json_as_used_too(tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    repo = tmp_path / 'repos' / 'fabric'
+    _declare(repo, 'personal')
+    _write_dax_yaml(home, {'fabric': {'dir': str(repo)}})
+    state_dir = home / '.local' / 'state' / 'dax' / 'tenants' / 'personal' / 'fabric'
+    state_dir.mkdir(parents=True)
+    (state_dir / '.credentials.json').write_text('{}')
+    monkeypatch.setenv('HOME', str(home))
+
+    cmd_tenants(argparse.Namespace())
+
+    out = capsys.readouterr().out
+    lines = [l.split() for l in out.splitlines()]
+    assert ['personal', 'fabric', 'yes', str(repo)] in lines
+
+
+def test_cmd_tenants_skips_projects_whose_dir_does_not_exist_on_this_machine(
+        tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    _write_dax_yaml(home, {'ghost': {'dir': str(tmp_path / 'nonexistent')}})
+    monkeypatch.setenv('HOME', str(home))
+
+    cmd_tenants(argparse.Namespace())
+
+    out = capsys.readouterr().out
+    assert 'no projects resolve to a tenant yet' in out
+
+
+def test_cmd_tenants_handles_no_dax_yaml(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv('HOME', str(tmp_path / 'empty-home'))
+
+    cmd_tenants(argparse.Namespace())  # must not raise
+
+    assert 'no ~/.dax.yaml found' in capsys.readouterr().out
+
+
+def test_cmd_tenants_columns_are_aligned_to_fixed_width(tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    short_repo = tmp_path / 'repos' / 'a'
+    long_repo = tmp_path / 'repos' / 'a-much-longer-project-name'
+    _declare(short_repo, 'x')
+    _declare(long_repo, 'personal')
+    _write_dax_yaml(home, {
+        'a': {'dir': str(short_repo)},
+        'b': {'dir': str(long_repo)},
+    })
+    monkeypatch.setenv('HOME', str(home))
+
+    cmd_tenants(argparse.Namespace())
+
+    lines = [l for l in capsys.readouterr().out.splitlines() if l]  # blank separators excluded
+    project_col_start = lines[0].index('PROJECT')
+    # every row's PROJECT column must start at the same character offset
+    assert all(len(line) > project_col_start for line in lines)
+    project_values = {'a', 'a-much-longer-project-name'}
+    for line in lines[1:]:
+        for value in project_values:
+            if line[project_col_start:].startswith(value):
+                break
+        else:
+            pytest.fail('row {!r} does not have its PROJECT column aligned'.format(line))
+
+
+def test_cmd_tenants_blank_line_separates_tenant_groups(tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    repo_a = tmp_path / 'repos' / 'fabric'
+    repo_b = tmp_path / 'repos' / 'discernment'
+    _declare(repo_a, 'personal')
+    _declare(repo_b / 'project_ysecurity_comp_model', 'ysecurity')
+    _declare(repo_b / 'project_augment', 'augment')
+    _write_dax_yaml(home, {
+        'fabric': {'dir': str(repo_a)},
+        'discernment': {'dir': str(repo_b), 'multi_tenant': True},
+    })
+    monkeypatch.setenv('HOME', str(home))
+
+    cmd_tenants(argparse.Namespace())
+
+    lines = capsys.readouterr().out.splitlines()
+    assert lines[0] == ''  # leading blank line before the whole report
+    assert lines[-1] == ''  # trailing blank line after it
+    assert lines[1].split()[0] == 'TENANT'
+
+    # Between the header and the trailing blank: one group per tenant (3
+    # tenants - augment, personal, ysecurity), separated by exactly one blank
+    # line each - never within a tenant's own rows.
+    body = lines[2:-1]
+    blank_indices = [i for i, l in enumerate(body) if l == '']
+    assert len(blank_indices) == 2
+    for i in blank_indices:
+        assert body[i - 1].split()[0] != body[i + 1].split()[0]
+
+
+# --- _known_tenant_names -----------------------------------------------------
+
+def test_known_tenant_names_empty_when_no_dax_yaml(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path / 'empty-home'))
+
+    assert _known_tenant_names() == set()
+
+
+def test_known_tenant_names_across_single_and_multi_tenant_projects(tmp_path, monkeypatch):
+    home = tmp_path / 'home'
+    home.mkdir()
+    fabric = tmp_path / 'repos' / 'fabric'
+    discernment = tmp_path / 'repos' / 'discernment'
+    _declare(fabric, 'personal')
+    _declare(discernment / 'project_ysecurity_comp_model', 'ysecurity')
+    _write_dax_yaml(home, {
+        'fabric': {'dir': str(fabric)},
+        'discernment': {'dir': str(discernment), 'multi_tenant': True},
+    })
+    monkeypatch.setenv('HOME', str(home))
+
+    assert _known_tenant_names() == {'personal', 'ysecurity'}
+
+
+# --- _prompt_tenant -----------------------------------------------------------
+
+def test_prompt_tenant_picks_from_known_list(tmp_path):
+    picked = []
+
+    def fake_select(prompt, choices, default):
+        picked.append((prompt, choices, default))
+        return 'ysecurity'
+
+    result = _prompt_tenant(tmp_path / 'sub', {'ysecurity', 'personal'}, _select=fake_select)
+
+    assert result == 'ysecurity'
+    prompt, choices, default = picked[0]
+    assert set(choices) == {'ysecurity', 'personal', _NEW_TENANT_CHOICE}
+    assert default is None
+
+
+def test_prompt_tenant_new_tenant_choice_falls_through_to_text_prompt(tmp_path):
+    text_calls = []
+
+    def fake_text(prompt, default):
+        text_calls.append((prompt, default))
+        return 'brand-new-tenant'
+
+    result = _prompt_tenant(
+        tmp_path / 'sub', {'ysecurity'},
+        _select=lambda p, c, d: _NEW_TENANT_CHOICE, _text=fake_text)
+
+    assert result == 'brand-new-tenant'
+    assert len(text_calls) == 1
+
+
+def test_prompt_tenant_uses_text_prompt_when_nothing_known_yet(tmp_path):
+    result = _prompt_tenant(tmp_path / 'sub', set(), _text=lambda p, d: 'first-tenant')
+
+    assert result == 'first-tenant'
+
+
+def test_prompt_tenant_passes_current_value_as_select_default(tmp_path):
+    captured = {}
+
+    def fake_select(prompt, choices, default):
+        captured['default'] = default
+        return default
+
+    _prompt_tenant(tmp_path / 'sub', {'ysecurity', 'personal'}, default='personal',
+                    _select=fake_select)
+
+    assert captured['default'] == 'personal'
+
+
+def test_prompt_tenant_raises_on_cancelled_select(tmp_path):
+    with pytest.raises(KeyboardInterrupt):
+        _prompt_tenant(tmp_path / 'sub', {'ysecurity'}, _select=lambda p, c, d: None)
+
+
+def test_prompt_tenant_raises_on_empty_text(tmp_path):
+    with pytest.raises(KeyboardInterrupt):
+        _prompt_tenant(tmp_path / 'sub', set(), _text=lambda p, d: '   ')
+
+
+# --- _ensure_tenants_classified ----------------------------------------------
+
+def test_ensure_tenants_classified_single_tenant_prompts_when_undeclared(
+        tmp_path, monkeypatch):
+    repo = tmp_path / 'fabric'
+    repo.mkdir()
+    monkeypatch.setattr('dax._prompt_tenant', lambda subdir, known, default=None: 'personal')
+
+    _ensure_tenants_classified({'cwd': str(repo), 'multi_tenant': False})
+
+    assert (repo / '.dax-tenant').read_text() == 'personal'
+
+
+def test_ensure_tenants_classified_single_tenant_skips_when_already_declared(
+        tmp_path, monkeypatch):
+    repo = tmp_path / 'fabric'
+    _declare(repo, 'personal')
+
+    def fail_if_called(*a, **k):
+        raise AssertionError('should not prompt for an already-declared root')
+
+    monkeypatch.setattr('dax._prompt_tenant', fail_if_called)
+
+    _ensure_tenants_classified({'cwd': str(repo), 'multi_tenant': False})
+
+    assert (repo / '.dax-tenant').read_text() == 'personal'
+
+
+def test_ensure_tenants_classified_multi_tenant_classifies_root_and_children(
+        tmp_path, monkeypatch):
+    repo = tmp_path / 'discernment'
+    (repo / 'processes' / 'project_a').mkdir(parents=True)
+    (repo / 'processes' / 'project_b').mkdir(parents=True)
+    prompted = []
+
+    def fake_prompt(subdir, known, default=None):
+        prompted.append(subdir)
+        return 'tenant-for-{}'.format(subdir.name)
+
+    monkeypatch.setattr('dax._prompt_tenant', fake_prompt)
+
+    _ensure_tenants_classified({
+        'cwd': str(repo), 'multi_tenant': True, 'tenant_subdir': 'processes',
+    })
+
+    assert (repo / '.dax-tenant').read_text() == 'tenant-for-discernment'
+    assert (repo / 'processes' / 'project_a' / '.dax-tenant').read_text() == 'tenant-for-project_a'
+    assert (repo / 'processes' / 'project_b' / '.dax-tenant').read_text() == 'tenant-for-project_b'
+    assert len(prompted) == 3
+
+
+def test_ensure_tenants_classified_multi_tenant_skips_already_declared_children(
+        tmp_path, monkeypatch):
+    repo = tmp_path / 'discernment'
+    _declare(repo, 'personal')
+    _declare(repo / 'processes' / 'project_a', 'ysecurity')
+    new_child = repo / 'processes' / 'project_b'
+    new_child.mkdir(parents=True)
+
+    monkeypatch.setattr('dax._prompt_tenant', lambda subdir, known, default=None: 'augment')
+
+    _ensure_tenants_classified({
+        'cwd': str(repo), 'multi_tenant': True, 'tenant_subdir': 'processes',
+    })
+
+    assert (repo / '.dax-tenant').read_text() == 'personal'  # untouched
+    assert (repo / 'processes' / 'project_a' / '.dax-tenant').read_text() == 'ysecurity'  # untouched
+    assert new_child.joinpath('.dax-tenant').read_text() == 'augment'  # filled in
+
+
+def test_ensure_tenants_classified_reclassify_all_reprompts_existing(tmp_path, monkeypatch):
+    repo = tmp_path / 'fabric'
+    _declare(repo, 'old-tenant')
+    seen_defaults = []
+
+    def fake_prompt(subdir, known, default=None):
+        seen_defaults.append(default)
+        return 'new-tenant'
+
+    monkeypatch.setattr('dax._prompt_tenant', fake_prompt)
+
+    _ensure_tenants_classified({'cwd': str(repo), 'multi_tenant': False}, reclassify_all=True)
+
+    assert seen_defaults == ['old-tenant']
+    assert (repo / '.dax-tenant').read_text() == 'new-tenant'
+
+
+def test_ensure_tenants_classified_skips_not_a_project_subdir_entries(tmp_path, monkeypatch):
+    repo = tmp_path / 'discernment'
+    _declare(repo, 'personal')
+    (repo / 'processes' / '.git').mkdir(parents=True)
+    (repo / 'processes' / 'node_modules').mkdir(parents=True)
+
+    def fail_if_called_for_vendor_dirs(subdir, known, default=None):
+        if subdir.name in ('.git', 'node_modules'):
+            raise AssertionError('must not classify vendor/tooling directories')
+        return 'ysecurity'
+
+    monkeypatch.setattr('dax._prompt_tenant', fail_if_called_for_vendor_dirs)
+
+    _ensure_tenants_classified({
+        'cwd': str(repo), 'multi_tenant': True, 'tenant_subdir': 'processes',
+    })
+
+    assert not (repo / 'processes' / '.git' / '.dax-tenant').exists()
+    assert not (repo / 'processes' / 'node_modules' / '.dax-tenant').exists()
+
+
+# --- dax tenant classify ------------------------------------------------------
+
+def test_cmd_tenant_classify_errors_when_not_registered(tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    repo = tmp_path / 'unregistered'
+    repo.mkdir()
+    _write_dax_yaml(home, {})
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(repo)
+
+    args = argparse.Namespace(tenant_command='classify')
+    with pytest.raises(SystemExit):
+        cmd_tenant(args)
+
+    assert 'not a registered dax project' in capsys.readouterr().out
+
+
+def test_cmd_tenant_classify_invokes_reclassify_all_with_project_settings(
+        tmp_path, monkeypatch):
+    home = tmp_path / 'home'
+    home.mkdir()
+    repo = tmp_path / 'repos' / 'discernment'
+    repo.mkdir(parents=True)
+    _write_dax_yaml(home, {
+        'discernment': {'dir': str(repo), 'multi_tenant': True, 'tenant_subdir': 'processes'},
+    })
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(repo)
+
+    captured = {}
+
+    def fake_ensure(config, reclassify_all=False):
+        captured['config'] = config
+        captured['reclassify_all'] = reclassify_all
+
+    monkeypatch.setattr('dax._ensure_tenants_classified', fake_ensure)
+
+    cmd_tenant(argparse.Namespace(tenant_command='classify'))
+
+    assert captured['reclassify_all'] is True
+    assert captured['config']['cwd'] == str(repo)
+    assert captured['config']['multi_tenant'] is True
+    assert captured['config']['tenant_subdir'] == 'processes'

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -134,6 +134,28 @@ def test_feature_mounts_warns_if_none_defined(capsys):
     assert 'no mounts defined' in capsys.readouterr().out
 
 
+def test_feature_mounts_supports_an_explicit_container_name(monkeypatch):
+    """host:container_name — the escape hatch for mounting a host directory
+    under a name other than its own basename, e.g. the host's real ~/.claude
+    mounted alongside (not instead of) an env's claude_tenant_state tree,
+    which already owns ~/.claude itself."""
+    monkeypatch.setenv('HOME', '/Users/dfarrow')
+    config = {'mounts': ['~/.claude:host-claude'], '_container_home': '/home/dfarrow'}
+    opts = feature_mounts(config)
+    assert opts == ['--volume=/Users/dfarrow/.claude:/home/dfarrow/host-claude']
+
+
+def test_feature_mounts_explicit_name_does_not_affect_other_entries(monkeypatch):
+    monkeypatch.setenv('HOME', '/Users/dfarrow')
+    config = {
+        'mounts': ['~/.claude:host-claude', '~/discernment'],
+        '_container_home': '/home/dfarrow',
+    }
+    opts = feature_mounts(config)
+    assert '--volume=/Users/dfarrow/.claude:/home/dfarrow/host-claude' in opts
+    assert '--volume=/Users/dfarrow/discernment:/home/dfarrow/discernment' in opts
+
+
 def test_feature_ssh_returns_agent_forwarding(tmp_path, monkeypatch):
     sock = tmp_path / 'ssh-auth.sock'
     sock.touch()

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -10,6 +10,7 @@ from dax import (
     feature_dotfiles,
     feature_ports,
     feature_mounts,
+    feature_substrate,
     feature_msf,
     feature_ovpn,
     feature_X11,
@@ -154,6 +155,28 @@ def test_feature_mounts_explicit_name_does_not_affect_other_entries(monkeypatch)
     opts = feature_mounts(config)
     assert '--volume=/Users/dfarrow/.claude:/home/dfarrow/host-claude' in opts
     assert '--volume=/Users/dfarrow/discernment:/home/dfarrow/discernment' in opts
+
+
+def test_feature_substrate_mounts_and_sets_env_var(monkeypatch):
+    monkeypatch.setenv('HOME', '/Users/dfarrow')
+    config = {'substrate': '~/virgil', '_container_home': '/home/dfarrow'}
+    opts = feature_substrate(config)
+    assert '--volume=/Users/dfarrow/virgil:/home/dfarrow/virgil' in opts
+    assert '-e' in opts
+    assert 'SUBSTRATE_ROOT=/home/dfarrow/virgil' in opts
+
+
+def test_feature_substrate_is_not_fooled_by_a_trailing_slash(monkeypatch):
+    monkeypatch.setenv('HOME', '/Users/dfarrow')
+    config = {'substrate': '~/virgil/', '_container_home': '/home/dfarrow'}
+    opts = feature_substrate(config)
+    assert '--volume=/Users/dfarrow/virgil/:/home/dfarrow/virgil' in opts
+
+
+def test_feature_substrate_warns_if_none_configured(capsys):
+    opts = feature_substrate({})
+    assert opts == []
+    assert 'no substrate configured' in capsys.readouterr().out
 
 
 def test_feature_ssh_returns_agent_forwarding(tmp_path, monkeypatch):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -13,18 +13,32 @@ from dax import (
     feature_ovpn,
     feature_X11,
     feature_webpreview,
+    feature_claude_tenant_state,
     _find_preview_port,
+    _format_docker_cmd,
 )
 
 
 def test_feature_workdir_mounts_cwd():
     config = {
         'cwd': '/Users/davefarrow/work/project',
-        'workdir': {'container': 'work'},
+        'workdir_name': 'project',
         '_container_home': '/home/davefarrow',
     }
     opts = feature_workdir(config)
-    assert '--volume=/Users/davefarrow/work/project:/home/davefarrow/work' in opts
+    assert '--volume=/Users/davefarrow/work/project:/home/davefarrow/project' in opts
+
+
+def test_feature_workdir_mount_name_handles_dots_and_spaces():
+    # workdir_name itself is computed by dir_basename() in load_config() (see
+    # test_config.py); this just confirms feature_workdir uses it verbatim.
+    config = {
+        'cwd': '/Users/davefarrow/work/my.project (copy)',
+        'workdir_name': 'my.project (copy)',
+        '_container_home': '/home/davefarrow',
+    }
+    opts = feature_workdir(config)
+    assert '--volume=/Users/davefarrow/work/my.project (copy):/home/davefarrow/my.project (copy)' in opts
 
 
 def test_feature_optdir_mounts_volume():
@@ -109,13 +123,13 @@ def test_feature_webpreview_uses_explicit_port(monkeypatch):
         'cwd': '/home/user/project',
         'webpreview': {'port': 9000},
         '_container_home': '/home/user',
-        'workdir': {'container': 'work'},
+        'workdir_name': 'project',
     }
     opts = feature_webpreview(config)
     assert '-p' in opts
     assert '9000:9000' in opts
     assert 'DAX_PREVIEW_PORT=9000' in config['_shell_cmd']
-    assert 'DAX_PREVIEW_DIR=/home/user/work' in config['_shell_cmd']
+    assert 'DAX_PREVIEW_DIR=/home/user/project' in config['_shell_cmd']
 
 
 def test_feature_webpreview_auto_assigns_port(monkeypatch):
@@ -123,14 +137,14 @@ def test_feature_webpreview_auto_assigns_port(monkeypatch):
     config = {
         'cwd': '/home/user/project',
         '_container_home': '/home/user',
-        'workdir': {'container': 'work'},
+        'workdir_name': 'project',
     }
     opts = feature_webpreview(config)
     assert '-p' in opts
     port_mapping = next(o for o in opts if ':' in o and o != '-p')
     host_port = int(port_mapping.split(':')[0])
     assert 8000 <= host_port < 9000
-    assert 'DAX_PREVIEW_DIR=/home/user/work' in config['_shell_cmd']
+    assert 'DAX_PREVIEW_DIR=/home/user/project' in config['_shell_cmd']
 
 
 def test_find_preview_port_is_deterministic():
@@ -157,6 +171,129 @@ def test_find_preview_port_different_dirs_differ():
         dax._is_port_free = orig
 
 
+# --- feature_claude_tenant_state --------------------------------------------
+#
+# Unlike every other feature_* function above, this one genuinely needs a real
+# directory tree (it calls dax_creds.tenant.all_tenant_projects, which scans
+# for .dax-tenant files) - synthetic in-memory config dicts alone aren't
+# enough, hence tmp_path here where the rest of this file doesn't need it.
+# The resolution logic itself is fully covered in tests/test_dax_creds_tenant.py;
+# these tests are about the argv/env-var construction on top of it.
+
+def _declare_tenant(path, tenant):
+    path.mkdir(parents=True, exist_ok=True)
+    (path / '.dax-tenant').write_text(tenant)
+
+
+def test_feature_claude_tenant_state_single_tenant_undeclared_mounts_nothing(
+        tmp_path, monkeypatch):
+    # No automatic unattributed/<reponame> fallback (dropped 2026-07-28) -
+    # dax run's classification step should always resolve this before mounts
+    # are computed, so an undeclared repo reaching here mounts nothing at
+    # all rather than a default location.
+    monkeypatch.setenv('HOME', str(tmp_path / 'realhome'))
+    repo = tmp_path / 'doot'
+    repo.mkdir()
+    config = {
+        'cwd': str(repo),
+        'workdir_name': 'doot',
+        '_container_home': '/home/dfarrow',
+    }
+
+    opts = feature_claude_tenant_state(config)
+
+    assert 'DAX_TENANT_STATE=1' in opts
+    assert 'DAX_PROJECT_NAME=doot' in opts
+    assert not any(o.startswith('DAX_MULTI_TENANT') for o in opts)
+    assert not any(o.startswith('--volume=') for o in opts)
+
+
+def test_feature_claude_tenant_state_single_tenant_declared(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path / 'realhome'))
+    repo = tmp_path / 'fabric'
+    _declare_tenant(repo, 'personal')
+    config = {
+        'cwd': str(repo),
+        'workdir_name': 'fabric',
+        '_container_home': '/home/dfarrow',
+    }
+
+    opts = feature_claude_tenant_state(config)
+
+    host_dir = tmp_path / 'realhome' / '.local' / 'state' / 'dax' / 'tenants' / 'personal' / 'fabric'
+    container_dir = '/home/dfarrow/.local/state/dax/tenants/personal/fabric'
+    assert '--volume={}:{}'.format(host_dir, container_dir) in opts
+
+
+def test_feature_claude_tenant_state_multi_tenant_mounts_each_mapped_child(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path / 'realhome'))
+    repo = tmp_path / 'discernment'
+    _declare_tenant(repo / 'project_ysecurity_comp_model', 'ysecurity')
+    _declare_tenant(repo / 'project_augment', 'augment')
+    config = {
+        'cwd': str(repo),
+        'workdir_name': 'discernment',
+        '_container_home': '/home/dfarrow',
+        'multi_tenant': True,
+    }
+
+    opts = feature_claude_tenant_state(config)
+
+    assert 'DAX_MULTI_TENANT=1' in opts
+    for tenant, project in [('ysecurity', 'project_ysecurity_comp_model'),
+                            ('augment', 'project_augment')]:
+        host_dir = (tmp_path / 'realhome' / '.local' / 'state' / 'dax' / 'tenants'
+                    / tenant / project)
+        container_dir = '/home/dfarrow/.local/state/dax/tenants/{}/{}'.format(tenant, project)
+        assert '--volume={}:{}'.format(host_dir, container_dir) in opts
+
+
+def test_feature_claude_tenant_state_multi_tenant_with_tenant_subdir(tmp_path, monkeypatch):
+    # discernment's actual tenant subdirectories sit under processes/, not
+    # directly under the repo root - config['tenant_subdir'] is how that
+    # reaches all_tenant_projects(), and DAX_TENANT_SUBDIR is how it reaches
+    # the wrapper/CLI in the container.
+    monkeypatch.setenv('HOME', str(tmp_path / 'realhome'))
+    repo = tmp_path / 'discernment'
+    _declare_tenant(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
+    _declare_tenant(repo / 'project_at_root_should_be_ignored', 'should-not-count')
+    config = {
+        'cwd': str(repo),
+        'workdir_name': 'discernment',
+        '_container_home': '/home/dfarrow',
+        'multi_tenant': True,
+        'tenant_subdir': 'processes',
+    }
+
+    opts = feature_claude_tenant_state(config)
+
+    assert 'DAX_MULTI_TENANT=1' in opts
+    assert 'DAX_TENANT_SUBDIR=processes' in opts
+    host_dir = (tmp_path / 'realhome' / '.local' / 'state' / 'dax' / 'tenants'
+                / 'ysecurity' / 'project_ysecurity_comp_model')
+    container_dir = '/home/dfarrow/.local/state/dax/tenants/ysecurity/project_ysecurity_comp_model'
+    assert '--volume={}:{}'.format(host_dir, container_dir) in opts
+    assert not any('should-not-count' in o for o in opts)
+
+
+def test_feature_claude_tenant_state_multi_tenant_no_mounts_when_nothing_labeled(
+        tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path / 'realhome'))
+    repo = tmp_path / 'discernment'
+    (repo / 'project_new').mkdir(parents=True)
+    config = {
+        'cwd': str(repo),
+        'workdir_name': 'discernment',
+        '_container_home': '/home/dfarrow',
+        'multi_tenant': True,
+    }
+
+    opts = feature_claude_tenant_state(config)
+
+    assert not any(o.startswith('--volume=') for o in opts)
+    assert 'DAX_TENANT_STATE=1' in opts
+
+
 def test_find_preview_port_skips_busy_ports(monkeypatch):
     import hashlib
     cwd = '/home/user/project'
@@ -167,3 +304,47 @@ def test_find_preview_port_skips_busy_ports(monkeypatch):
     monkeypatch.setattr('dax._is_port_free', lambda p: p != first)
     port = _find_preview_port(cwd)
     assert port == second
+
+
+# --- _format_docker_cmd -----------------------------------------------------
+
+def test_format_docker_cmd_puts_self_contained_tokens_on_their_own_line():
+    lines = _format_docker_cmd(['docker', 'run', '-it', '--rm']).split('\n  ')
+    assert lines == ['docker', 'run', '-it', '--rm']
+
+
+def test_format_docker_cmd_pairs_two_token_flags_with_their_value():
+    lines = _format_docker_cmd(['-e', 'DAX_TENANT_STATE=1', '--name', 'fabric']).split('\n  ')
+    assert lines == ['-e DAX_TENANT_STATE=1', '--name fabric']
+
+
+def test_format_docker_cmd_leaves_combined_volume_flag_alone():
+    # --volume=host:container is already one token - must not be merged with
+    # whatever token happens to come after it.
+    lines = _format_docker_cmd(['--volume=/a:/b', '-e', 'X=1']).split('\n  ')
+    assert lines == ['--volume=/a:/b', '-e X=1']
+
+
+def test_format_docker_cmd_pairs_bare_volume_flag_with_its_value():
+    # Some features build --volume/-v as two separate tokens instead of the
+    # combined form - both shapes coexist in this codebase.
+    lines = _format_docker_cmd(['--volume', '/a:/b', '-v', '/c:/d']).split('\n  ')
+    assert lines == ['--volume /a:/b', '-v /c:/d']
+
+
+def test_format_docker_cmd_realistic_mixed_command():
+    cmd = [
+        'docker', 'run', '-it', '--rm', '--platform=linux/amd64',
+        '--name', 'fatsec-fabric', '-h', 'fatsec-fabric.fatsec.docker',
+        '--volume=/Users/dfarrow/fatsec/fabric:/home/dfarrow/fabric',
+        '-e', 'DAX_TENANT_STATE=1', '-e', 'DAX_PROJECT_NAME=fabric',
+        'dax:latest', '/bin/sh', '-c', 'exec /bin/zsh',
+    ]
+    lines = _format_docker_cmd(cmd).split('\n  ')
+    assert lines == [
+        'docker', 'run', '-it', '--rm', '--platform=linux/amd64',
+        '--name fatsec-fabric', '-h fatsec-fabric.fatsec.docker',
+        '--volume=/Users/dfarrow/fatsec/fabric:/home/dfarrow/fabric',
+        '-e DAX_TENANT_STATE=1', '-e DAX_PROJECT_NAME=fabric',
+        'dax:latest', '/bin/sh', '-c exec /bin/zsh',
+    ]

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -9,6 +9,7 @@ from dax import (
     feature_ssh,
     feature_dotfiles,
     feature_ports,
+    feature_mounts,
     feature_msf,
     feature_ovpn,
     feature_X11,
@@ -97,6 +98,40 @@ def test_feature_ports_returns_port_flags():
     assert '-p' in opts
     assert '8080:80' in opts
     assert '8443:443' in opts
+
+
+def test_feature_mounts_mounts_each_path_as_a_home_sibling(monkeypatch):
+    monkeypatch.setenv('HOME', '/Users/dfarrow')
+    config = {
+        'mounts': ['~/discernment', '/Users/dfarrow/fatsec/some-process'],
+        '_container_home': '/home/dfarrow',
+    }
+    opts = feature_mounts(config)
+    assert '--volume=/Users/dfarrow/discernment:/home/dfarrow/discernment' in opts
+    assert '--volume=/Users/dfarrow/fatsec/some-process:/home/dfarrow/some-process' in opts
+
+
+def test_feature_mounts_not_nested_under_the_workdir_mount(monkeypatch):
+    """The whole point: a sibling under $HOME, never a path inside another
+    mount — that nesting is the class of bug sync_claude_shared_files exists
+    to route around."""
+    monkeypatch.setenv('HOME', '/Users/dfarrow')
+    config = {'mounts': ['~/discernment'], '_container_home': '/home/dfarrow'}
+    opts = feature_mounts(config)
+    assert opts == ['--volume=/Users/dfarrow/discernment:/home/dfarrow/discernment']
+
+
+def test_feature_mounts_is_not_fooled_by_a_trailing_slash(monkeypatch):
+    monkeypatch.setenv('HOME', '/Users/dfarrow')
+    config = {'mounts': ['~/discernment/'], '_container_home': '/home/dfarrow'}
+    opts = feature_mounts(config)
+    assert '--volume=/Users/dfarrow/discernment/:/home/dfarrow/discernment' in opts
+
+
+def test_feature_mounts_warns_if_none_defined(capsys):
+    opts = feature_mounts({})
+    assert opts == []
+    assert 'no mounts defined' in capsys.readouterr().out
 
 
 def test_feature_ssh_returns_agent_forwarding(tmp_path, monkeypatch):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -13,7 +13,6 @@ from dax import (
     feature_ovpn,
     feature_X11,
     feature_webpreview,
-    feature_claude_tenant_state,
     _find_preview_port,
     _format_docker_cmd,
 )
@@ -171,127 +170,13 @@ def test_find_preview_port_different_dirs_differ():
         dax._is_port_free = orig
 
 
-# --- feature_claude_tenant_state --------------------------------------------
-#
-# Unlike every other feature_* function above, this one genuinely needs a real
-# directory tree (it calls dax_creds.tenant.all_tenant_projects, which scans
-# for .dax-tenant files) - synthetic in-memory config dicts alone aren't
-# enough, hence tmp_path here where the rest of this file doesn't need it.
-# The resolution logic itself is fully covered in tests/test_dax_creds_tenant.py;
-# these tests are about the argv/env-var construction on top of it.
-
-def _declare_tenant(path, tenant):
-    path.mkdir(parents=True, exist_ok=True)
-    (path / '.dax-tenant').write_text(tenant)
-
-
-def test_feature_claude_tenant_state_single_tenant_undeclared_mounts_nothing(
-        tmp_path, monkeypatch):
-    # No automatic unattributed/<reponame> fallback (dropped 2026-07-28) -
-    # dax run's classification step should always resolve this before mounts
-    # are computed, so an undeclared repo reaching here mounts nothing at
-    # all rather than a default location.
-    monkeypatch.setenv('HOME', str(tmp_path / 'realhome'))
-    repo = tmp_path / 'doot'
-    repo.mkdir()
-    config = {
-        'cwd': str(repo),
-        'workdir_name': 'doot',
-        '_container_home': '/home/dfarrow',
-    }
-
-    opts = feature_claude_tenant_state(config)
-
-    assert 'DAX_TENANT_STATE=1' in opts
-    assert 'DAX_PROJECT_NAME=doot' in opts
-    assert not any(o.startswith('DAX_MULTI_TENANT') for o in opts)
-    assert not any(o.startswith('--volume=') for o in opts)
-
-
-def test_feature_claude_tenant_state_single_tenant_declared(tmp_path, monkeypatch):
-    monkeypatch.setenv('HOME', str(tmp_path / 'realhome'))
-    repo = tmp_path / 'fabric'
-    _declare_tenant(repo, 'personal')
-    config = {
-        'cwd': str(repo),
-        'workdir_name': 'fabric',
-        '_container_home': '/home/dfarrow',
-    }
-
-    opts = feature_claude_tenant_state(config)
-
-    host_dir = tmp_path / 'realhome' / '.local' / 'state' / 'dax' / 'tenants' / 'personal' / 'fabric'
-    container_dir = '/home/dfarrow/.local/state/dax/tenants/personal/fabric'
-    assert '--volume={}:{}'.format(host_dir, container_dir) in opts
-
-
-def test_feature_claude_tenant_state_multi_tenant_mounts_each_mapped_child(tmp_path, monkeypatch):
-    monkeypatch.setenv('HOME', str(tmp_path / 'realhome'))
-    repo = tmp_path / 'discernment'
-    _declare_tenant(repo / 'project_ysecurity_comp_model', 'ysecurity')
-    _declare_tenant(repo / 'project_augment', 'augment')
-    config = {
-        'cwd': str(repo),
-        'workdir_name': 'discernment',
-        '_container_home': '/home/dfarrow',
-        'multi_tenant': True,
-    }
-
-    opts = feature_claude_tenant_state(config)
-
-    assert 'DAX_MULTI_TENANT=1' in opts
-    for tenant, project in [('ysecurity', 'project_ysecurity_comp_model'),
-                            ('augment', 'project_augment')]:
-        host_dir = (tmp_path / 'realhome' / '.local' / 'state' / 'dax' / 'tenants'
-                    / tenant / project)
-        container_dir = '/home/dfarrow/.local/state/dax/tenants/{}/{}'.format(tenant, project)
-        assert '--volume={}:{}'.format(host_dir, container_dir) in opts
-
-
-def test_feature_claude_tenant_state_multi_tenant_with_tenant_subdir(tmp_path, monkeypatch):
-    # discernment's actual tenant subdirectories sit under processes/, not
-    # directly under the repo root - config['tenant_subdir'] is how that
-    # reaches all_tenant_projects(), and DAX_TENANT_SUBDIR is how it reaches
-    # the wrapper/CLI in the container.
-    monkeypatch.setenv('HOME', str(tmp_path / 'realhome'))
-    repo = tmp_path / 'discernment'
-    _declare_tenant(repo / 'processes' / 'project_ysecurity_comp_model', 'ysecurity')
-    _declare_tenant(repo / 'project_at_root_should_be_ignored', 'should-not-count')
-    config = {
-        'cwd': str(repo),
-        'workdir_name': 'discernment',
-        '_container_home': '/home/dfarrow',
-        'multi_tenant': True,
-        'tenant_subdir': 'processes',
-    }
-
-    opts = feature_claude_tenant_state(config)
-
-    assert 'DAX_MULTI_TENANT=1' in opts
-    assert 'DAX_TENANT_SUBDIR=processes' in opts
-    host_dir = (tmp_path / 'realhome' / '.local' / 'state' / 'dax' / 'tenants'
-                / 'ysecurity' / 'project_ysecurity_comp_model')
-    container_dir = '/home/dfarrow/.local/state/dax/tenants/ysecurity/project_ysecurity_comp_model'
-    assert '--volume={}:{}'.format(host_dir, container_dir) in opts
-    assert not any('should-not-count' in o for o in opts)
-
-
-def test_feature_claude_tenant_state_multi_tenant_no_mounts_when_nothing_labeled(
-        tmp_path, monkeypatch):
-    monkeypatch.setenv('HOME', str(tmp_path / 'realhome'))
-    repo = tmp_path / 'discernment'
-    (repo / 'project_new').mkdir(parents=True)
-    config = {
-        'cwd': str(repo),
-        'workdir_name': 'discernment',
-        '_container_home': '/home/dfarrow',
-        'multi_tenant': True,
-    }
-
-    opts = feature_claude_tenant_state(config)
-
-    assert not any(o.startswith('--volume=') for o in opts)
-    assert 'DAX_TENANT_STATE=1' in opts
+# feature_claude_tenant_state moved to
+# tests/test_dax_claude_tenant_state_mount.py when decision B changed what it
+# builds. The five tests that lived here covered the multi-tenant shape: a
+# directory scan for `.dax-tenant` files, one mount per (tenant, project) pair
+# found, and the DAX_MULTI_TENANT/DAX_TENANT_SUBDIR env vars. None of that
+# survives — each env is single-tenant, the tenant is a declared label on the
+# env's ~/.dax.yaml entry, and the tree mounts at ~/.claude itself.
 
 
 def test_find_preview_port_skips_busy_ports(monkeypatch):

--- a/tools/migrate_env_state.py
+++ b/tools/migrate_env_state.py
@@ -35,6 +35,52 @@ hand before shutdown — see the runbook. Without it the wrapper seeds
 `{"hasCompletedOnboarding": true}`, which costs re-consent and replayed tips and
 nothing else.
 
+## State strewn across more than one key
+
+The simple case — this env has *always* run in a dax container — has exactly one
+`projects/` key: `-<home>-<user>-<env_name>`, because `workdir_name` (dax's mount
+basename) never changes. `project_key()` below builds exactly that.
+
+That assumption breaks for state accumulated **before** containerization, i.e. a
+directory that used to be a plain nested subdirectory of a larger host tree and
+is only now becoming its own registered env (checked against the real
+`~/.claude/projects/` on 2026-08-01 while planning discernment's per-process
+repo split — see `docs/design/2026-07-27-tenant-isolation.md`). Concretely, for a
+process that used to live at `~/work/processes/<name>`:
+
+  * its own sessions were recorded under the *literal nested path's* key,
+    `-home-<user>-work-processes-<name>` — not the flat key this script assumes.
+  * sessions run with cwd at an ancestor of that path (`~/work/processes`,
+    `~/work` itself — before the user `cd`'d into the specific process
+    directory, or during general non-process-specific work) recorded under
+    *those* keys instead, and those directories are shared across every process
+    that was ever a child of them. There is no reliable way to attribute one
+    line of that data to a single process without reading its content, so this
+    script never tries — it only ever copies data whose key already names, in
+    full, a directory the caller identifies as this process's own.
+
+`--legacy-cwd PATH` (repeatable) is how the caller supplies those exact
+historical paths — this script cannot infer them, since a rename or restructure
+is exactly what makes the nested path different from the new one. Each legacy
+cwd's `projects/<key>/` copies into the tree as its own directory, same as the
+canonical key, and its own `history.jsonl` lines are filtered in by exact match
+on the literal path. It is a straight copy, not a merge into the canonical
+key's directory: Claude Code's `/resume` is scoped to the container's *current*
+cwd, so a legacy directory won't show up there regardless — flattening it in
+would misrepresent old sessions as having happened at the new cwd for no
+resumability gain, while a separate directory keeps the provenance honest and
+still gets the data off the machine's one shared `~/.claude` and into the tree
+before the source is deleted.
+
+Every run also prints a **discovery report** (no flag needed — it costs one
+directory listing and one `history.jsonl` scan): any other `projects/` key that
+ends with this env's name but wasn't passed via `--legacy-cwd` (a candidate the
+caller may have forgotten), and any ancestor key of a key actually being
+migrated (a real `projects/` directory that is itself a dash-prefix of a
+migrated key — i.e., it holds sessions from a shared parent cwd). Ancestor data
+is reported, never copied: it is the commingled case above. The report exists
+so silence never gets mistaken for "nothing else was there."
+
 Full runbook: docs/testing/2026-07-31-migrate-env-to-state-tree.md
 """
 import argparse
@@ -43,6 +89,7 @@ import os
 import shutil
 import subprocess
 import sys
+from collections import defaultdict
 from pathlib import Path
 
 CONTAINER_HOME = '/home'  # container-side $HOME parent; cwd keys are built from it
@@ -81,6 +128,17 @@ def container_name_for(dir_path):
     return str(dir_path).replace(home, '').lstrip('/').replace('/', '-')
 
 
+def path_to_key(path):
+    """Claude Code's `projects/` directory-key mangling for an absolute cwd.
+
+    Ambiguous to reverse (a literal dash in a directory name is indistinguishable
+    from a mangled slash), which is exactly why ancestor/leaf detection below
+    only ever compares against keys that actually exist on disk, never tries to
+    decode one back into a hypothetical path.
+    """
+    return '-' + str(path).strip('/').replace('/', '-')
+
+
 def is_running(name):
     try:
         out = subprocess.run(
@@ -91,13 +149,80 @@ def is_running(name):
         return False
 
 
-def project_key(user, env_name):
-    """Claude Code's `projects/` directory name for this env's container cwd.
+def all_project_keys():
+    d = Path.home() / '.claude' / 'projects'
+    if not d.is_dir():
+        return []
+    return sorted(p.name for p in d.iterdir() if p.is_dir())
 
-    Stable across the migration: `workdir_name` does not change, so the container
-    cwd stays $HOME/<env> and Claude Code keeps using the same key.
+
+def history_project_paths():
+    """Map every `projects/` key seen in history.jsonl back to its literal cwd(s).
+
+    Built from real recorded data rather than guessed, since key mangling can't
+    be reversed reliably — this is how the discovery report can show an actual
+    path for an ancestor key instead of just the opaque dashed name.
     """
-    return f'-{CONTAINER_HOME.strip("/")}-{user}-{env_name}'
+    src = Path.home() / '.claude' / 'history.jsonl'
+    paths = defaultdict(set)
+    counts = defaultdict(int)
+    if not src.exists():
+        return paths, counts
+    for line in src.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            project = json.loads(line).get('project')
+        except ValueError:
+            continue
+        if not project:
+            continue
+        key = path_to_key(project)
+        paths[key].add(project)
+        counts[key] += 1
+    return paths, counts
+
+
+def discover(env_name, source_keys):
+    """Other keys worth the caller's attention: forgotten leaves, commingled ancestors."""
+    keys = all_project_keys()
+    source_set = set(source_keys)
+    suffix = '-' + env_name.replace('/', '-')
+    leaf_others = [k for k in keys if k not in source_set and k.endswith(suffix)]
+
+    ancestors = {}
+    for k in source_keys:
+        anc = [o for o in keys if o != k and k.startswith(o + '-')]
+        for o in anc:
+            ancestors.setdefault(o, set()).add(k)
+
+    return leaf_others, ancestors
+
+
+def print_discovery_report(env_name, source_keys):
+    leaf_others, ancestors = discover(env_name, source_keys)
+    paths, counts = history_project_paths()
+
+    if leaf_others:
+        print("  [?] other projects/ keys end with this env's name but were not")
+        print('      requested — pass --legacy-cwd <path> to include them:')
+        for k in leaf_others:
+            known = ', '.join(sorted(paths.get(k, ()))) or '(no history.jsonl lines — path unknown)'
+            print(f'      {k}   {known}')
+
+    if ancestors:
+        print('  [?] ancestor directories exist — sessions recorded at a shared')
+        print('      parent cwd, commingled across whatever else lived under it.')
+        print('      NOT migrated automatically; read them before deciding:')
+        for anc_key, children in sorted(ancestors.items()):
+            known = ', '.join(sorted(paths.get(anc_key, ()))) or '(path unknown)'
+            n = counts.get(anc_key, 0)
+            for_ = ', '.join(sorted(children))
+            print(f'      {anc_key}   {known}  ({n} history.jsonl lines, parent of {for_})')
+
+    if leaf_others or ancestors:
+        print()
 
 
 def plan(env_name, args):
@@ -119,17 +244,32 @@ def plan(env_name, args):
              f'copied\n      mid-session is torn.')
 
     user = args.user or container_user()
-    key = project_key(user, env_name)
-    src_projects = Path.home() / '.claude' / 'projects' / key
+    canonical_cwd = f'{CONTAINER_HOME}/{user}/{env_name}'
+
+    legacy_cwds = list(args.legacy_cwd or [])
+    cwds = [canonical_cwd] + legacy_cwds
+    pairs = [(c, path_to_key(c)) for c in cwds]
+
+    seen = set()
+    keys = []
+    for _, k in pairs:
+        if k not in seen:
+            seen.add(k)
+            keys.append(k)
+
     tree = Path.home() / '.local' / 'state' / 'dax' / 'tenants' / tenant / env_name
 
     print(f'\n  env        {env_name}  (tenant: {tenant})')
     print(f'  container  {container}  [stopped]')
-    print(f'  cwd key    {key}')
     print(f'  tree       {tree}')
+    for c, k in pairs:
+        tag = 'canonical' if c == canonical_cwd else 'legacy'
+        print(f'  {tag:9}  {c}  ({k})')
     print()
 
-    return config, project, tree, src_projects, key
+    print_discovery_report(env_name, keys)
+
+    return config, project, tree, cwds, keys
 
 
 def check_credential(tree, apply_it, clear):
@@ -152,49 +292,56 @@ def check_credential(tree, apply_it, clear):
         print('       would delete.')
 
 
-def copy_projects(src, tree, apply_it, force):
-    dst = tree / 'projects' / src.name
-    if not src.exists():
-        print(f'  [--] no transcripts at {src} — nothing to copy')
-        return
-    size = sum(f.stat().st_size for f in src.rglob('*') if f.is_file())
-    sessions = len(list(src.glob('*.jsonl')))
-    memory = (src / 'memory').is_dir()
-    print(f'  [->] {src.name}: {sessions} session(s), '
-          f'{size / 1e6:.1f}MB{", memory/" if memory else ""}')
-    print(f'       -> {dst}')
-    if dst.exists() and not force:
-        print('  [!!] destination already exists. Re-run with --force to overwrite,')
-        print('       or move it aside — merging two transcript sets is not safe.')
-        return
-    if not apply_it:
-        return
-    if dst.exists():
-        shutil.rmtree(dst)
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(src, dst, symlinks=True)
-    print('       copied.')
+def copy_projects(keys, tree, apply_it, force):
+    src_root = Path.home() / '.claude' / 'projects'
+    for key in keys:
+        src = src_root / key
+        dst = tree / 'projects' / key
+        if not src.exists():
+            print(f'  [--] no transcripts at {src} — nothing to copy')
+            continue
+        size = sum(f.stat().st_size for f in src.rglob('*') if f.is_file())
+        sessions = len(list(src.glob('*.jsonl')))
+        memory = (src / 'memory').is_dir()
+        print(f'  [->] {key}: {sessions} session(s), '
+              f'{size / 1e6:.1f}MB{", memory/" if memory else ""}')
+        print(f'       -> {dst}')
+        if dst.exists() and not force:
+            print('  [!!] destination already exists. Re-run with --force to overwrite,')
+            print('       or move it aside — merging two transcript sets is not safe.')
+            continue
+        if not apply_it:
+            continue
+        if dst.exists():
+            shutil.rmtree(dst)
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(src, dst, symlinks=True)
+        print('       copied.')
 
 
-def filter_history(env_name, user, tree, apply_it):
+def filter_history(cwds, tree, apply_it):
     src = Path.home() / '.claude' / 'history.jsonl'
     dst = tree / 'history.jsonl'
     if not src.exists():
         print('  [--] no shared history.jsonl')
         return
-    env_cwd = f'{CONTAINER_HOME}/{user}/{env_name}'
+    cwd_set = set(cwds)
     kept, total = [], 0
+    per_cwd = defaultdict(int)
     for line in src.read_text().splitlines():
         if not line.strip():
             continue
         total += 1
         try:
-            if json.loads(line).get('project') == env_cwd:
-                kept.append(line)
+            project = json.loads(line).get('project')
         except ValueError:
             continue
-    print(f'  [->] history.jsonl: {len(kept)} of {total} lines are {env_cwd}')
-    print(f'       -> {dst}')
+        if project in cwd_set:
+            kept.append(line)
+            per_cwd[project] += 1
+    for c in cwds:
+        print(f'  [->] history.jsonl: {per_cwd.get(c, 0)} lines are {c}')
+    print(f'       {len(kept)} of {total} total -> {dst}')
     if dst.exists():
         print(f'  [!!] {dst} already exists and would be replaced.')
     if apply_it:
@@ -238,17 +385,26 @@ def main():
     ap.add_argument('--clear-credential', action='store_true',
                     help='delete a credentials file found in the tree')
     ap.add_argument('--user', help='container username (default: host username)')
+    ap.add_argument('--legacy-cwd', action='append', metavar='PATH',
+                    help='an additional historical absolute cwd this env used '
+                         'before it had its own container (repeatable) — e.g. a '
+                         'nested path from before a directory split. Its '
+                         'projects/ key and matching history.jsonl lines are '
+                         'copied alongside the canonical key, kept in its own '
+                         "directory rather than merged (Claude Code's /resume "
+                         'is scoped to the current cwd, so merging would not '
+                         'make it resumable anyway).')
     args = ap.parse_args()
 
-    config, project, tree, src_projects, key = plan(args.env, args)
+    config, project, tree, cwds, keys = plan(args.env, args)
     user = args.user or container_user()
 
     if not args.apply:
         print('  DRY RUN — nothing will be written. Re-run with --apply.\n')
 
-    copy_projects(src_projects, tree, args.apply, args.force)
+    copy_projects(keys, tree, args.apply, args.force)
     print()
-    filter_history(args.env, user, tree, args.apply)
+    filter_history(cwds, tree, args.apply)
     print()
     check_credential(tree, args.apply, args.clear_credential)
     print()
@@ -258,12 +414,13 @@ def main():
     print(f'    dax env set {args.env} features claude_tenant_state')
     print(f'    cd {project.get("dir", "<env dir>")} && dax -t run')
     print(f'  Then inside the container:')
-    print(f'    ls ~/.claude/projects/   # only {key}')
+    print(f'    ls ~/.claude/projects/   # {", ".join(keys)}')
     print(f'    ls ~/.claude.json        # must NOT exist')
     print(f'    claude                   # /resume lists the migrated sessions')
     print(f'\n  The source is left in place. Remove it only after a successful '
           f'session\n  and a container restart:')
-    print(f'    rm -rf ~/.claude/projects/{key}')
+    for key in keys:
+        print(f'    rm -rf ~/.claude/projects/{key}')
     return 0
 
 

--- a/tools/migrate_env_state.py
+++ b/tools/migrate_env_state.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Move one env's accumulated Claude state into its own state tree.
+
+Run on the **host**, where both the shared `~/.claude` and the state trees live.
+A container cannot migrate itself: only the env that owns a tree ever has it
+mounted, and the source directory it is copying *from* is the very thing it is
+writing to.
+
+    python3 tools/migrate_env_state.py dax            # dry run — shows the plan
+    python3 tools/migrate_env_state.py dax --apply
+
+Dry run is the default because every step writes into a tree that a live session
+would then adopt. Nothing here touches `~/.dax.yaml`: switching the env over is
+one `dax env set` call, printed at the end, kept manual because config edits are
+the part with real blast radius (a test without HOME isolation destroyed that file
+on 2026-07-31).
+
+What moves, and why each is safe to separate — measured, not assumed:
+
+  * `projects/<mangled-cwd>/` — the directory name *is* the container cwd, so it
+    is already exactly one env's transcripts plus its auto-memory directory.
+  * `history.jsonl` — every line carries a `project` field, so it is filtered
+    rather than copied. Copying it whole would pool every other env's prompts into
+    this tree, which is the failure the isolation exists to prevent.
+
+What does not move: `CLAUDE.md`, `settings.json`, `settings.local.json` are
+user-level and the feature mounts them read-only into every tree. `file-history/`
+is keyed by session UUID and mappable, but it is edit-undo history and not worth
+the step. Caches regenerate.
+
+`.claude.json` is deliberately **not** handled here. The copy worth having lives
+inside the env's running container (35K of trust, allowedTools, and tips history,
+already scoped to that one project) and dies with it, so it has to be taken by
+hand before shutdown — see the runbook. Without it the wrapper seeds
+`{"hasCompletedOnboarding": true}`, which costs re-consent and replayed tips and
+nothing else.
+
+Full runbook: docs/testing/2026-07-31-migrate-env-to-state-tree.md
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+CONTAINER_HOME = '/home'  # container-side $HOME parent; cwd keys are built from it
+
+
+def fail(msg):
+    print(f'  [!] {msg}')
+    sys.exit(1)
+
+
+def load_config():
+    path = Path.home() / '.dax.yaml'
+    if not path.exists():
+        fail(f'no {path}')
+    try:
+        import yaml
+    except ImportError:
+        fail('pyyaml required: pip install pyyaml')
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def container_user():
+    """The username inside the container, which is what the cwd key is built from.
+
+    Mirrors dax.py's `_get_username()`. Deriving it from `Path.home().name` instead
+    happens to work when the host home directory is named after the user, which is
+    a coincidence rather than a rule — and getting it wrong builds a `projects/`
+    key that matches nothing, so the migration silently copies zero transcripts.
+    """
+    return os.environ.get('USER') or os.environ.get('LOGNAME') or Path.home().name
+
+
+def container_name_for(dir_path):
+    """Mirrors dax.py's `envname`: the dir path under $HOME, slashes to dashes."""
+    home = str(Path.home())
+    return str(dir_path).replace(home, '').lstrip('/').replace('/', '-')
+
+
+def is_running(name):
+    try:
+        out = subprocess.run(
+            ['docker', 'ps', '--filter', f'name={name}', '--format', '{{.Names}}'],
+            capture_output=True, text=True, timeout=5)
+        return name in out.stdout.split()
+    except Exception:
+        return False
+
+
+def project_key(user, env_name):
+    """Claude Code's `projects/` directory name for this env's container cwd.
+
+    Stable across the migration: `workdir_name` does not change, so the container
+    cwd stays $HOME/<env> and Claude Code keeps using the same key.
+    """
+    return f'-{CONTAINER_HOME.strip("/")}-{user}-{env_name}'
+
+
+def plan(env_name, args):
+    config = load_config()
+    projects = config.get('projects') or {}
+    if env_name not in projects:
+        known = ', '.join(sorted(projects)) or '(none)'
+        fail(f'no env named {env_name!r}. Known: {known}')
+
+    project = projects[env_name]
+    tenant = project.get('tenant')
+    if not tenant:
+        fail(f'env {env_name!r} has no tenant, so it has no tree path.\n'
+             f'      Set one first: dax env set {env_name} tenant <name>')
+
+    container = container_name_for(project.get('dir', ''))
+    if is_running(container):
+        fail(f'container {container!r} is running. Stop it first — a transcript '
+             f'copied\n      mid-session is torn.')
+
+    user = args.user or container_user()
+    key = project_key(user, env_name)
+    src_projects = Path.home() / '.claude' / 'projects' / key
+    tree = Path.home() / '.local' / 'state' / 'dax' / 'tenants' / tenant / env_name
+
+    print(f'\n  env        {env_name}  (tenant: {tenant})')
+    print(f'  container  {container}  [stopped]')
+    print(f'  cwd key    {key}')
+    print(f'  tree       {tree}')
+    print()
+
+    return config, project, tree, src_projects, key
+
+
+def check_credential(tree, apply_it, clear):
+    cred = tree / '.credentials.json'
+    if not cred.exists():
+        print('  [ok] no credential in the tree — it will bootstrap from Keychain')
+        return
+    # Blocks the bootstrap rather than merely being stale: the wrapper injects
+    # only when the file is absent or empty (-s), never when it is invalid.
+    print(f'  [!!] {cred} exists.')
+    print('       This BLOCKS the Keychain bootstrap: the wrapper injects only when')
+    print('       the file is absent or empty, not when it is stale or invalid.')
+    if not clear:
+        print('       Re-run with --clear-credential, or delete it by hand.')
+        return
+    if apply_it:
+        cred.unlink()
+        print('       deleted.')
+    else:
+        print('       would delete.')
+
+
+def copy_projects(src, tree, apply_it, force):
+    dst = tree / 'projects' / src.name
+    if not src.exists():
+        print(f'  [--] no transcripts at {src} — nothing to copy')
+        return
+    size = sum(f.stat().st_size for f in src.rglob('*') if f.is_file())
+    sessions = len(list(src.glob('*.jsonl')))
+    memory = (src / 'memory').is_dir()
+    print(f'  [->] {src.name}: {sessions} session(s), '
+          f'{size / 1e6:.1f}MB{", memory/" if memory else ""}')
+    print(f'       -> {dst}')
+    if dst.exists() and not force:
+        print('  [!!] destination already exists. Re-run with --force to overwrite,')
+        print('       or move it aside — merging two transcript sets is not safe.')
+        return
+    if not apply_it:
+        return
+    if dst.exists():
+        shutil.rmtree(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(src, dst, symlinks=True)
+    print('       copied.')
+
+
+def filter_history(env_name, user, tree, apply_it):
+    src = Path.home() / '.claude' / 'history.jsonl'
+    dst = tree / 'history.jsonl'
+    if not src.exists():
+        print('  [--] no shared history.jsonl')
+        return
+    env_cwd = f'{CONTAINER_HOME}/{user}/{env_name}'
+    kept, total = [], 0
+    for line in src.read_text().splitlines():
+        if not line.strip():
+            continue
+        total += 1
+        try:
+            if json.loads(line).get('project') == env_cwd:
+                kept.append(line)
+        except ValueError:
+            continue
+    print(f'  [->] history.jsonl: {len(kept)} of {total} lines are {env_cwd}')
+    print(f'       -> {dst}')
+    if dst.exists():
+        print(f'  [!!] {dst} already exists and would be replaced.')
+    if apply_it:
+        tree.mkdir(parents=True, exist_ok=True)
+        dst.write_text('\n'.join(kept) + ('\n' if kept else ''))
+        print('       written.')
+
+
+def check_claude_json(tree, user, env_name):
+    path = tree / '.claude.json'
+    if not path.exists():
+        print('  [--] no .claude.json in the tree. The wrapper will seed')
+        print('       {"hasCompletedOnboarding": true} — costs re-consent and tips.')
+        print('       To keep the real one, copy it out of the container BEFORE')
+        print('       shutdown (see the runbook) — it dies with the container.')
+        return
+    try:
+        keys = list((json.loads(path.read_text()).get('projects') or {}))
+    except ValueError:
+        print(f'  [!!] {path} is not valid JSON')
+        return
+    expected = f'{CONTAINER_HOME}/{user}/{env_name}'
+    extra = [k for k in keys if k != expected]
+    if extra:
+        print(f'  [!!] {path} carries other projects: {", ".join(extra)}')
+        print('       It came from a shared-mount host rather than this container,')
+        print("       so it would pull other envs' state into this tree.")
+    else:
+        print(f'  [ok] .claude.json present, scoped to {expected}')
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Move an env's Claude state into its own tree.",
+        epilog='Dry run by default. See '
+               'docs/testing/2026-07-31-migrate-env-to-state-tree.md')
+    ap.add_argument('env', help='env name as registered in ~/.dax.yaml')
+    ap.add_argument('--apply', action='store_true', help='actually write')
+    ap.add_argument('--force', action='store_true',
+                    help='overwrite an existing transcript dir in the tree')
+    ap.add_argument('--clear-credential', action='store_true',
+                    help='delete a credentials file found in the tree')
+    ap.add_argument('--user', help='container username (default: host username)')
+    args = ap.parse_args()
+
+    config, project, tree, src_projects, key = plan(args.env, args)
+    user = args.user or container_user()
+
+    if not args.apply:
+        print('  DRY RUN — nothing will be written. Re-run with --apply.\n')
+
+    copy_projects(src_projects, tree, args.apply, args.force)
+    print()
+    filter_history(args.env, user, tree, args.apply)
+    print()
+    check_credential(tree, args.apply, args.clear_credential)
+    print()
+    check_claude_json(tree, user, args.env)
+
+    print(f'\n  Next, if the above looks right:')
+    print(f'    dax env set {args.env} features claude_tenant_state')
+    print(f'    cd {project.get("dir", "<env dir>")} && dax -t run')
+    print(f'  Then inside the container:')
+    print(f'    ls ~/.claude/projects/   # only {key}')
+    print(f'    ls ~/.claude.json        # must NOT exist')
+    print(f'    claude                   # /resume lists the migrated sessions')
+    print(f'\n  The source is left in place. Remove it only after a successful '
+          f'session\n  and a container restart:')
+    print(f'    rm -rf ~/.claude/projects/{key}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## 💪 What

- Adds per-env Claude credentials (`claude-<tenant>-<project>`, derived naming) so each project mints its own OAuth grant instead of sharing one token across every container, with grant-collision protection refusing to store a token whose grant already exists under another name
- Adds `claude_tenant_state`: mounts each env's own Claude state tree at `~/.claude` (replacing the old shared, multi-tenant `~/.claude` mount), with user-level `CLAUDE.md`/`settings.json`/`settings.local.json` synced in (drift-detected, never silently overwritten) and `commands`/`plugins` mounted straight from the host
- Adds `dax env show`/`dax env set`/`dax envs list` to inspect and edit one or every registered env without walking the full `dax init` wizard
- Adds `feature_mounts` (arbitrary extra host directories per env, `host:container_name` syntax for mounting under an explicit name) and `feature_substrate` (virgil-style substrate repos, exposed as `$SUBSTRATE_ROOT`, with a `claude` wrapper gate that checks wiring before every launch)
- Adds `dax process new`/`dax process destroy` to scaffold and tear down a substrate-backed process end to end — directory, state tree, derived credential, and registry entry, in one command each
- Adds `tools/migrate_env_state.py` to move an env's accumulated Claude session history into its new per-env state tree, including `--legacy-cwd` for state strewn across more than one historical `projects/` key, with a discovery report that surfaces (but never silently copies) commingled ancestor-directory sessions
- Fixes `dax run` silently mis-scoping a container when launched from inside a registered project's subdirectory
- Fixes an abandoned Claude login importing the credential already on disk, which previously overwrote a per-env credential with the shared one on a cancelled login
- Installs `poppler-utils` in the image for PDF reading

## 🤔 Why

- The old model shared one `~/.claude` (and one Claude OAuth grant) across every container — a rotation or session issue in one project could silently affect every other project sharing the mount
- The original multi-tenant model (one project, many tenants) added real complexity for a case that never panned out the way it was designed for; discernment splitting into one repo per process removed the only genuine multi-tenant project, so the code simplified to single-tenant-per-project with `tenant` kept only as a grouping label for state-tree paths
- Making it cheap to spin up a fully isolated, substrate-backed process (`dax process new`) is what unblocks that per-process split in the first place
- Preserving accumulated session history through the transition matters — losing months of prior context every time a process moves to its own env isn't an acceptable cost of the isolation

## 👀 Usage

- `dax env show <name>` / `dax env set <name> <field> <value>` — inspect or edit tenant, dir, image, creds, features, mounts, substrate on one env
- `dax envs list` — merged registry + state-tree view, flags orphaned trees and deregistered entries
- `dax process new <name>` — wizards through directory/tenant/substrate/title/type/git, scaffolds via the substrate's `new-process.sh`, registers with `features: [substrate, claude_tenant_state]`
- `dax process destroy [name...]` — interactive picker or named, typed `DESTROY` to confirm
- `python3 tools/migrate_env_state.py <env> [--legacy-cwd PATH ...]` — dry run by default; copies transcripts/history into the env's new tree

## 👩‍🔬 How to validate

- `dax env show <an-existing-env>` and confirm tenant/state-tree path/mounts print correctly, with the "feature not active" warning when a field is set but its feature isn't
- `dax env set <env> mounts '~/.claude:host-claude'` then `dax -t run` and confirm the dry-run docker command carries the volume under the explicit container name, not the default basename
- `dax process new <name> --dry-run` and review the full absolute-path confirmation summary before anything is created
- `python3 tools/migrate_env_state.py <env>` (no `--apply`) against a real env with some history and read the discovery report — it should call out any other `projects/` key ending in that env's name, and any ancestor key holding commingled sessions, with real paths and line counts
- After a `dax build`, start a `claude_tenant_state` container and confirm `~/.claude/projects/` shows only that env's key, `history.jsonl` only has that env's lines, and `CLAUDE.md`/`settings.json` are present via the sync rather than empty