### PR TITLE
Hardcode baseline features; dax init tenant prompt; shell lands at project mount

### DIFF
--- a/.dax.yaml.example
+++ b/.dax.yaml.example
@@ -1,13 +1,16 @@
 image: dax:latest
 
-features:
-  - workdir
-  - dotfiles
-  - claude
-  - auggie
-  - github
-  - ssh
-  - webpreview
+# workdir, dotfiles, and webpreview are always on — no top-level features:
+# list needed for them. Everything else (claude, claude_tenant_state, auggie,
+# github, ssh, mounts, substrate, ...) is opt-in per project: add it to that
+# project's own `features:` list, a cwd-local .dax.yaml, or pass -f. e.g.:
+#
+# projects:
+#   myproject:
+#     dir: /Users/you/code/myproject
+#     features:
+#       - claude
+#       - ssh
 
 claudedir:
   mount: ~/.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -821,17 +821,19 @@ the shared mount, which is the intended fallback.
   dotfiles/webpreview baked in as a baseline instead), every remaining feature
   is purely per-env opt-in, so there is nothing left to opt *out* of.
 
-- **`dax init` should prompt for `tenant`** at registration time — editing an
-  existing env is now covered by `dax env set`.
+- **~~`dax init` should prompt for `tenant`~~ / ~~`_run_init` matches projects
+  by exact `dir == cwd`~~ — both resolved 2026-08-04, same pass.** `_run_init`
+  now prompts for an optional tenant (blank leaves it unset, same as before)
+  and writes it via `run_env_set` after registering. It also calls
+  `find_enclosing_project` before falling through to registration, refusing
+  with the enclosing project's name/root instead of silently registering a
+  duplicate — the exact blind spot `find_enclosing_project`/Gate 0 already
+  closed for `cmd_run`. 4 new tests (`tests/test_dax_run_init.py`), following
+  `test_dax_creds_add_flow.py`'s scripted-`Answers` pattern rather than
+  mocking questionary directly.
 
 - **Retire `dax tenants` and `dax tenant classify`** — superseded by the merged
   `dax envs list`.
-
-- **`_run_init` matches projects by exact `dir == cwd`** (`dax_creds/init.py`)
-  — the same blind spot `find_enclosing_project` closed for `cmd_run`, so
-  `dax init` from inside a registered project's subdirectory still registers a
-  duplicate project. Worth fixing in the same pass as wiring `tenant` into
-  init.
 
 - **`claude` wrapper doesn't seed `oauthAccount`/`userID`** — cosmetic only
   (omitting it just costs a profile-fetch round trip and the org name in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,38 @@ dax is a Docker-based development environment manager. It reads `~/.dax.yaml`
 features (volume mounts, port mappings, etc.) assembled from named feature
 functions in `dax.py`.
 
+## Baseline features replace the top-level `features:` list
+
+**Settled and built 2026-08-04**, on `feature/baseline-features` (branched
+from `master` after PR #5 merged). `~/.dax.yaml`'s top-level `features:` key
+is gone — it was the actual cause of the "additive-only, no opt-out" backlog
+item: every env inherited whatever was in that list with no way to decline
+one. `workdir`, `dotfiles`, and `webpreview` are wanted by literally every
+env, so they're now an unconditional baseline in `dax.py`
+(`_ALWAYS_ON_FEATURES`) rather than something read from that list at all.
+Everything else that used to live there — `ssh` in particular, per the
+decision to move toward `gh`-based GitHub auth instead of ambient
+host-agent-forwarding — is opt-in only now: a project's own `features:`
+list, a cwd-local `.dax.yaml`, or `-f`. Nobody was trying to opt *out* of
+those, so per-env-additive is fine for them; the problem was only ever the
+global list forcing something on every env at once.
+
+A still-present, non-empty top-level `features:` key is never silently
+dropped: `load_config()` prints what it found and that it's no longer read,
+naming the three baseline features so it's clear nothing needs to move there.
+The real `~/.dax.yaml` had exactly `workdir, dotfiles, ssh, webpreview` (plus
+a commented-out `auggie`) — confirms the change covers the actual live
+config with no surprises, and that key has been removed from it directly
+(via the ruamel round-trip save, not a raw pyyaml rewrite, so comments and
+ordering survive). 4 new tests for the baseline/warning behavior, plus a
+rewrite of `test_dax_claude_mount_exclusivity.py`'s fixtures (they used to
+put `claude`/`claude_tenant_state` in the now-gone global list — every case
+moved to a project's own `features:`, since that's the only source left that
+can carry them). Suite at **511** (from 507). `.dax.yaml.example` and this
+file's own decision-3 mention of "four sources" for feature accumulation are
+both updated to match — it's three now (project, cwd-local, `-f`), plus the
+hardcoded baseline that isn't really a "source" in the old sense at all.
+
 ## Legacy Claude state: migrate the process now, recover history on demand
 
 **Settled 2026-08-02, closing out the `migrate_env_state.py` redesign thread.**
@@ -781,22 +813,13 @@ the shared mount, which is the intended fallback.
   symlinks each skill directory into the state tree at container boot, not a
   second dax-level mount.
 
-- **Per-env features are additive only — no way to opt *out*.** Features
-  accumulate from four sources (global `features:`, the env entry, a `.dax.yaml`
-  in cwd, `-f`) and every one only adds. So an env cannot decline a globally
-  inherited feature, which is why switching one env to `claude_tenant_state`
-  takes four writes: a hand-edit to strip `claude` from the global list, plus
-  three `dax env set … features claude` calls to give it back to the envs that
-  still want it.
-
-  Fit-and-polish fix, deferred: make `claude_tenant_state` **supersede an
-  inherited `claude`** (it was designed as the replacement for that mount, not a
-  peer), printing `claude_tenant_state supersedes claude for <env>` so it is
-  never silent — while still *refusing* when both are listed explicitly on the
-  same env, where the intent is genuinely ambiguous. That reduces the four writes
-  to one and leaves the global list alone. The general form — a `-claude` removal
-  syntax any env could use — is a bigger mechanism and not worth building until
-  something needs it.
+- **~~Per-env features are additive only — no way to opt *out*~~ — resolved
+  2026-08-04** by removing the global `features:` list entirely (see "Baseline
+  features" above), rather than the supersede-`claude` fit-and-polish fix
+  originally sketched here. The problem was the global list forcing something
+  on every env with no way to decline it; with that list gone (workdir/
+  dotfiles/webpreview baked in as a baseline instead), every remaining feature
+  is purely per-env opt-in, so there is nothing left to opt *out* of.
 
 - **`dax init` should prompt for `tenant`** at registration time — editing an
   existing env is now covered by `dax env set`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -835,27 +835,18 @@ the shared mount, which is the intended fallback.
 - **Retire `dax tenants` and `dax tenant classify`** — superseded by the merged
   `dax envs list`.
 
-- **`claude` wrapper doesn't seed `oauthAccount`/`userID`** — cosmetic only
-  (omitting it just costs a profile-fetch round trip and the org name in the
-  first banner, per `docs/design/2026-07-27-tenant-isolation.md`'s seed-key
-  table), but seeding it correctly needs real account data (`emailAddress`,
-  `organizationName`, `accountUuid`), and nothing in `dax_creds/` currently
-  sources or relays that from the host into a container. Would need a new
-  daemon action (or a new credential-envelope field) reading it out of the
-  host's own `~/.claude.json`. Not attempted as part of the tenant-isolation
-  seed-template work — out of scope for a wrapper-only change.
+- **~~Container shell lands in `$HOME`, not the project mount~~ — resolved
+  2026-08-04.** `cmd_run` now passes `-w <container_home>/<workdir_name>` —
+  exactly where `feature_workdir` mounts the project, computed the same way,
+  safe unconditionally since `workdir` is one of the always-on baseline
+  features now (see "Baseline features" above) and so is always mounted
+  there. `-w` added to `_DOCKER_TWO_TOKEN_FLAGS` too, so dry-run output pairs
+  it with its path instead of splitting it across lines.
 
-- **Container shell lands in `$HOME`, not the project mount** — every dax
-  session starts the user at `$HOME`, requiring a manual `cd <project>`
-  before anything useful (including `claude`, once tenant isolation refuses
-  to start there anyway). No `-w`/`--workdir` docker flag exists in `dax.py`
-  today — `Dockerfile.tmpl`'s static `WORKDIR` can't know a per-project mount
-  name at build time. Fix would be a small `cmd_run()` addition using stage
-  3's already-computed `workdir_name`. Landing the shell at the mount root
-  is a strict improvement in both single- and multi-tenant cases (see
-  discussion in `docs/design/2026-07-27-tenant-isolation.md`'s history) but
-  is an ergonomic change orthogonal to the tenant-isolation bug fix itself —
-  deferred, not part of any current stage.
+  (The `claude` wrapper's missing `oauthAccount`/`userID` seeding, previously
+  listed here too, will never be fixed — decided 2026-08-04. Cosmetic only,
+  and correctly seeding it would need new plumbing to source real account
+  data from the host that doesn't exist yet; not worth building.)
 
 ## Notes
 

--- a/dax.py
+++ b/dax.py
@@ -49,6 +49,17 @@ def _get_ca_cert_path():
         return None
 
 
+# Every env wants these, unconditionally — mounting the project itself,
+# dotfiles, and the webpreview server are not optional per-project choices.
+# Baked in here rather than sourced from ~/.dax.yaml's top-level `features:`
+# key (removed 2026-08) because that list was the actual cause of the
+# additive-only, no-opt-out problem: an env could never decline something
+# every other env also got by default. Per-env `features:` (on the project
+# entry, a cwd-local .dax.yaml, or `-f`) remain purely opt-in, which is fine —
+# nobody was ever trying to opt *out* of those.
+_ALWAYS_ON_FEATURES = ('workdir', 'dotfiles', 'webpreview')
+
+
 def load_config():
     home = os.environ['HOME']
     cwd = os.getcwd()
@@ -79,9 +90,18 @@ def load_config():
     from dax_creds.config import dir_basename
     defaults['workdir_name'] = dir_basename(cwd)
 
+    # Never silently dropped: a leftover top-level `features:` key still gets
+    # read here, just to flag it rather than let it quietly stop mattering.
+    legacy_features = defaults.get('features') or []
+    if legacy_features:
+        dax_print("[!] ~/.dax.yaml's top-level `features:` ({}) is no longer read — "
+                  "{} are always on; move anything else to a project's own "
+                  "features:, a cwd-local .dax.yaml, or -f".format(
+                      ', '.join(legacy_features), ', '.join(_ALWAYS_ON_FEATURES)))
+
     local_features = local.pop('features', [])
     defaults.update(local)
-    defaults['features'].extend(local_features)
+    defaults['features'] = list(_ALWAYS_ON_FEATURES) + local_features
 
     return defaults
 
@@ -730,10 +750,8 @@ def cmd_run(args):
                   '~/.claude — pick one.')
         dax_print('    claude_tenant_state replaces the shared mount with this '
                   'env\'s own state tree.')
-        dax_print('    `claude` is probably in the global features list: remove it '
-                  'there and add it')
-        dax_print('    to the envs that still want the shared mount, or drop '
-                  'claude_tenant_state here.')
+        dax_print('    Check this env\'s own `features:` list (and any -f flag) '
+                  'and drop one of the two.')
         sys.exit(1)
 
     for feature in features:

--- a/dax.py
+++ b/dax.py
@@ -600,7 +600,7 @@ def _wait_for_tcp(host, port, timeout=5.0):
     return False
 
 
-_DOCKER_TWO_TOKEN_FLAGS = {'--name', '-h', '-v', '--volume', '-e', '-p', '--group-add', '-c'}
+_DOCKER_TWO_TOKEN_FLAGS = {'--name', '-h', '-v', '--volume', '-e', '-p', '-w', '--group-add', '-c'}
 
 
 def _format_docker_cmd(cmd):
@@ -629,11 +629,16 @@ def cmd_run(args):
     config['_container_home'] = '/home/{}'.format(username)
 
     name = config['envname']
+    # Lands the shell at the project mount instead of $HOME — workdir is one
+    # of the always-on baseline features, so this path is exactly where
+    # feature_workdir mounts it, every time.
+    workdir = os.path.join(_container_home(config), config['workdir_name'])
     cmd = [
         'docker', 'run', '-it', '--rm',
         '--platform=linux/amd64',
         '--name', name,
         '-h', '{}.fatsec.docker'.format(name),
+        '-w', workdir,
     ]
 
     daemon_proc = None

--- a/dax_creds/init.py
+++ b/dax_creds/init.py
@@ -302,6 +302,7 @@ def run_init(config, cwd):
 
 def _run_init(config, cwd):
     import questionary
+    from dax_creds.config import find_enclosing_project
 
     existing_project_name = next(
         (name for name, p in config.get('projects', {}).items()
@@ -315,9 +316,25 @@ def _run_init(config, cwd):
         if not _q_confirm('Update it?', default=False):
             print('Nothing changed.')
             return config
+    else:
+        # The same blind spot `find_enclosing_project`/Gate 0 closed for
+        # `dax run`: an exact-match lookup alone finds nothing for a
+        # subdirectory of an already-registered project and falls straight
+        # through to registering a duplicate rooted there.
+        enclosing = find_enclosing_project(config, cwd)
+        if enclosing is not None:
+            enclosing_name, enclosing_project = enclosing
+            enclosing_dir = Path(enclosing_project['dir']).expanduser()
+            print(f'  {cwd} is inside already-registered project "{enclosing_name}" '
+                  f'at {enclosing_dir}, not its root.')
+            print(f'  Run `dax init` from {enclosing_dir} instead.')
+            return config
 
     default_image = existing_project.get('image') or config.get('defaults', {}).get('image', 'dax-base')
     image = _prompt('Image', default=default_image)
+
+    tenant = _prompt('Tenant (optional grouping label for state-tree paths and '
+                     'credential names)', default=existing_project.get('tenant'))
 
     existing_creds = list(config.get('credentials', {}).keys())
     already_selected = set(existing_project.get('creds', []))
@@ -365,6 +382,8 @@ def _run_init(config, cwd):
     register_project(config, name=project_name, project_dir=cwd,
                      image=image, creds=selected_creds)
     save_config(config)
+    if tenant:
+        run_env_set(config, project_name, 'tenant', tenant)
     print(f'\nRegistered {project_name}. Run `dax run` to launch.')
     return config
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,18 +17,13 @@ def test_load_config_reads_home_defaults(tmp_path, monkeypatch):
     workdir = tmp_path / 'home' / 'work'
     workdir.mkdir()
 
-    defaults = {
-        'image': 'test/dax:latest',
-        'features': ['workdir'],
-    }
-    _write_yaml(home / '.dax.yaml', defaults)
+    _write_yaml(home / '.dax.yaml', {'image': 'test/dax:latest'})
     monkeypatch.setenv('HOME', str(home))
     monkeypatch.chdir(workdir)
 
     config = load_config()
 
     assert config['image'] == 'test/dax:latest'
-    assert 'workdir' in config['features']
 
 
 def test_load_config_merges_local_config(tmp_path, monkeypatch):
@@ -37,15 +32,11 @@ def test_load_config_merges_local_config(tmp_path, monkeypatch):
     workdir = tmp_path / 'home' / 'project'
     workdir.mkdir()
 
-    defaults = {
-        'image': 'test/dax:latest',
-        'features': ['workdir'],
-    }
     local = {
         'features': ['aws'],
         'awsdir': {'host': '/Users/test/.aws', 'container': '/home/test/.aws'},
     }
-    _write_yaml(home / '.dax.yaml', defaults)
+    _write_yaml(home / '.dax.yaml', {'image': 'test/dax:latest'})
     _write_yaml(workdir / '.dax.yaml', local)
     monkeypatch.setenv('HOME', str(home))
     monkeypatch.chdir(workdir)
@@ -54,6 +45,82 @@ def test_load_config_merges_local_config(tmp_path, monkeypatch):
 
     assert 'workdir' in config['features']
     assert 'aws' in config['features']
+
+
+# --- always-on baseline features --------------------------------------------
+#
+# ~/.dax.yaml's top-level `features:` key was removed 2026-08 — it was the
+# actual cause of the additive-only, no-opt-out problem (an env could never
+# decline something every other env also got by default). workdir/dotfiles/
+# webpreview are wanted unconditionally by every env, so they're a baseline in
+# code now rather than something read from that list; anything else optional
+# is per-env (project features:, cwd-local .dax.yaml, or -f) only.
+
+def test_load_config_baseline_features_present_with_no_top_level_features_key(
+        tmp_path, monkeypatch):
+    home = tmp_path / 'home'
+    home.mkdir()
+    workdir = home / 'work'
+    workdir.mkdir()
+
+    _write_yaml(home / '.dax.yaml', {'image': 'test/dax:latest'})
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(workdir)
+
+    config = load_config()
+
+    assert set(config['features']) == {'workdir', 'dotfiles', 'webpreview'}
+
+
+def test_load_config_ignores_a_legacy_top_level_features_list(tmp_path, monkeypatch):
+    home = tmp_path / 'home'
+    home.mkdir()
+    workdir = home / 'work'
+    workdir.mkdir()
+
+    _write_yaml(home / '.dax.yaml', {'image': 'test/dax:latest', 'features': ['claude', 'ssh']})
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(workdir)
+
+    config = load_config()
+
+    assert 'claude' not in config['features']
+    assert 'ssh' not in config['features']
+    assert {'workdir', 'dotfiles', 'webpreview'} <= set(config['features'])
+
+
+def test_load_config_warns_about_a_legacy_top_level_features_list(
+        tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    workdir = home / 'work'
+    workdir.mkdir()
+
+    _write_yaml(home / '.dax.yaml', {'image': 'test/dax:latest', 'features': ['claude']})
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(workdir)
+
+    load_config()
+
+    out = capsys.readouterr().out
+    assert 'no longer read' in out
+    assert 'claude' in out
+
+
+def test_load_config_says_nothing_when_no_legacy_features_list_is_present(
+        tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    workdir = home / 'work'
+    workdir.mkdir()
+
+    _write_yaml(home / '.dax.yaml', {'image': 'test/dax:latest'})
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(workdir)
+
+    load_config()
+
+    assert 'no longer read' not in capsys.readouterr().out
 
 
 def test_load_config_sets_envname(tmp_path, monkeypatch):

--- a/tests/test_dax_claude_mount_exclusivity.py
+++ b/tests/test_dax_claude_mount_exclusivity.py
@@ -2,9 +2,13 @@
 
 Decision B makes the state tree the *replacement* for `feature_claude`'s wholesale
 mount, not an addition to it. Left to Docker the collision is still caught — it
-rejects a duplicate mount point — but the message names neither feature, and
-`claude` is normally inherited from the global `features:` list rather than written
-on the env, so "remove one of them" is not obvious advice.
+rejects a duplicate mount point — but the message names neither feature.
+
+`~/.dax.yaml`'s top-level `features:` key was removed 2026-08 (workdir/dotfiles/
+webpreview are now an always-on baseline in code); `claude`/`claude_tenant_state`
+are opt-in only per env now, via the project's own `features:` list or `-f` — so
+every fixture here puts them there instead of a global list that no longer
+carries anything optional.
 """
 import argparse
 
@@ -18,7 +22,7 @@ def _args():
     return argparse.Namespace(features=None, ports=None, test_only=True)
 
 
-def _setup(tmp_path, monkeypatch, features, project_extra=None):
+def _setup(tmp_path, monkeypatch, project_extra=None):
     home = tmp_path / 'home'
     home.mkdir(exist_ok=True)
     repo = home / 'fabric'
@@ -28,7 +32,7 @@ def _setup(tmp_path, monkeypatch, features, project_extra=None):
     project.update(project_extra or {})
 
     with open(home / '.dax.yaml', 'w') as f:
-        yaml.dump({'image': 'test/dax:latest', 'features': features,
+        yaml.dump({'image': 'test/dax:latest',
                    'claudedir': {'mount': '~/.claude'},
                    'projects': {'fabric': project}}, f)
 
@@ -38,7 +42,7 @@ def _setup(tmp_path, monkeypatch, features, project_extra=None):
 
 
 def test_both_features_together_is_refused(tmp_path, monkeypatch, capsys):
-    _setup(tmp_path, monkeypatch, ['claude', 'claude_tenant_state'])
+    _setup(tmp_path, monkeypatch, project_extra={'features': ['claude', 'claude_tenant_state']})
 
     with pytest.raises(SystemExit) as excinfo:
         cmd_run(_args())
@@ -46,13 +50,11 @@ def test_both_features_together_is_refused(tmp_path, monkeypatch, capsys):
     assert excinfo.value.code == 1
     out = capsys.readouterr().out
     assert 'both mount ~/.claude' in out
-    # The advice has to mention where `claude` actually comes from, or the user
-    # looks at the env entry, finds nothing, and is stuck.
-    assert 'global features list' in out
+    assert "this env's own" in out
 
 
 def test_the_tenant_state_tree_alone_is_fine(tmp_path, monkeypatch, capsys):
-    _setup(tmp_path, monkeypatch, ['claude_tenant_state'])
+    _setup(tmp_path, monkeypatch, project_extra={'features': ['claude_tenant_state']})
 
     cmd_run(_args())
 
@@ -62,7 +64,7 @@ def test_the_tenant_state_tree_alone_is_fine(tmp_path, monkeypatch, capsys):
 
 def test_the_shared_mount_alone_is_still_fine(tmp_path, monkeypatch, capsys):
     """Every env works this way today; opting in is per env and reversible."""
-    _setup(tmp_path, monkeypatch, ['claude'])
+    _setup(tmp_path, monkeypatch, project_extra={'features': ['claude']})
 
     cmd_run(_args())
 
@@ -70,9 +72,9 @@ def test_the_shared_mount_alone_is_still_fine(tmp_path, monkeypatch, capsys):
 
 
 def test_a_command_line_feature_can_collide_too(tmp_path, monkeypatch, capsys):
-    """`-f claude_tenant_state` on an env that inherits `claude` globally is the
+    """`-f claude_tenant_state` on an env whose own features: has `claude` is the
     most likely way to hit this, so the check must run after argv is merged."""
-    _setup(tmp_path, monkeypatch, ['claude'])
+    _setup(tmp_path, monkeypatch, project_extra={'features': ['claude']})
     args = _args()
     args.features = 'claude_tenant_state'
 
@@ -91,31 +93,38 @@ def test_a_command_line_feature_can_collide_too(tmp_path, monkeypatch, capsys):
 # env was impossible.
 
 def test_an_envs_own_features_list_is_honoured(tmp_path, monkeypatch, capsys):
-    _setup(tmp_path, monkeypatch, [],
-           project_extra={'features': ['claude_tenant_state']})
+    _setup(tmp_path, monkeypatch, project_extra={'features': ['claude_tenant_state']})
 
     cmd_run(_args())
 
     assert 'adding claude_tenant_state' in capsys.readouterr().out
 
 
-def test_opting_in_per_env_collides_with_a_globally_inherited_claude(
+def test_opting_in_per_env_collides_with_a_command_line_feature(
         tmp_path, monkeypatch, capsys):
-    """The realistic collision, and the reason the check has to run after the
-    per-env merge rather than on the global list alone."""
-    _setup(tmp_path, monkeypatch, ['claude'],
-           project_extra={'features': ['claude_tenant_state']})
+    """The realistic collision now that there's no global list to inherit
+    `claude` from: an env's own features: opts into claude_tenant_state, and
+    `-f claude` collides with it at launch time."""
+    _setup(tmp_path, monkeypatch, project_extra={'features': ['claude_tenant_state']})
+    args = _args()
+    args.features = 'claude'
 
     with pytest.raises(SystemExit):
-        cmd_run(_args())
+        cmd_run(args)
 
     assert 'both mount ~/.claude' in capsys.readouterr().out
 
 
-def test_a_feature_already_global_is_not_added_twice(tmp_path, monkeypatch, capsys):
-    """A duplicate would emit the same mount twice and Docker would reject it."""
-    _setup(tmp_path, monkeypatch, ['claude_tenant_state'],
-           project_extra={'features': ['claude_tenant_state']})
+def test_a_feature_from_two_sources_is_not_added_twice(tmp_path, monkeypatch, capsys):
+    """A duplicate would emit the same mount twice and Docker would reject it.
+
+    A cwd-local .dax.yaml and the project's own features: are two independent
+    sources that both land in config['features'] — the realistic way to get a
+    duplicate now that there's no global list to double up against."""
+    home, repo = _setup(tmp_path, monkeypatch,
+                         project_extra={'features': ['claude_tenant_state']})
+    with open(repo / '.dax.yaml', 'w') as f:
+        yaml.dump({'features': ['claude_tenant_state']}, f)
 
     cmd_run(_args())
 
@@ -127,8 +136,8 @@ def test_an_env_without_a_tenant_is_refused_before_launch(tmp_path, monkeypatch,
     """The refusal moved here from the container-side wrapper: with Gate B gone
     there is nothing left to resolve at launch, so this is the only place it can
     be caught — and catching it before the container starts is better anyway."""
-    _setup(tmp_path, monkeypatch, ['claude_tenant_state'],
-           project_extra={'tenant': None})
+    _setup(tmp_path, monkeypatch,
+           project_extra={'features': ['claude_tenant_state'], 'tenant': None})
 
     with pytest.raises(SystemExit) as excinfo:
         cmd_run(_args())

--- a/tests/test_dax_cmd_run_workdir.py
+++ b/tests/test_dax_cmd_run_workdir.py
@@ -1,0 +1,38 @@
+"""`dax run` must land the container shell at the project mount, not $HOME.
+
+Backlog item: every session started at $HOME, requiring a manual `cd
+<project>` before anything useful. workdir is one of the always-on baseline
+features (see dax.py's `_ALWAYS_ON_FEATURES`), so the mount path is always
+known ahead of time — `-w` just has to point `docker run` at exactly where
+`feature_workdir` mounts it.
+"""
+import argparse
+import os
+
+import yaml
+
+from dax import cmd_run
+
+
+def _args():
+    return argparse.Namespace(features=None, ports=None, test_only=True)
+
+
+def test_dash_w_lands_the_shell_at_the_workdir_mount(tmp_path, monkeypatch, capsys):
+    home = tmp_path / 'home'
+    home.mkdir()
+    repo = home / 'fabric'
+    repo.mkdir()
+
+    project = {'dir': str(repo), 'tenant': 'personal', 'creds': []}
+    with open(home / '.dax.yaml', 'w') as f:
+        yaml.dump({'image': 'test/dax:latest', 'projects': {'fabric': project}}, f)
+
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(repo)
+
+    cmd_run(_args())
+
+    out = capsys.readouterr().out
+    user = os.environ.get('USER') or os.environ.get('LOGNAME')
+    assert f'-w /home/{user}/fabric' in out

--- a/tests/test_dax_run_init.py
+++ b/tests/test_dax_run_init.py
@@ -1,0 +1,122 @@
+"""`dax init` (`_run_init`, `dax_creds/init.py`): prompts for `tenant` at
+registration time, and refuses to register a duplicate when run from inside
+an already-registered project's subdirectory.
+
+Both were backlog items: `tenant` previously had no path into a project's
+registry entry except the separate `dax env set` command, and `_run_init`
+matched projects by exact `dir == cwd` — the same blind spot
+`find_enclosing_project`/Gate 0 closed for `dax run`, still open here.
+
+Follows tests/test_dax_creds_add_flow.py's `Answers` pattern: scripted
+select/text/confirm/checkbox replies monkeypatched onto the prompt functions,
+so an unexpected prompt raises instead of hanging on a real questionary call.
+"""
+from pathlib import Path
+
+import pytest
+
+import dax_creds.init as init_module
+from dax_creds.config import load_dax_config
+from dax_creds.init import run_init
+
+
+class Answers:
+    def __init__(self, texts=(), confirms=(), checkboxes=()):
+        self.texts = list(texts)
+        self.confirms = list(confirms)
+        self.checkboxes = list(checkboxes)
+
+    def text(self, prompt, default=None):
+        assert self.texts, f'unexpected text prompt: {prompt}'
+        return self.texts.pop(0)
+
+    def confirm(self, prompt, default=False):
+        assert self.confirms, f'unexpected confirm: {prompt}'
+        return self.confirms.pop(0)
+
+    def checkbox(self, prompt, choices):
+        assert self.checkboxes, f'unexpected checkbox: {prompt}'
+        return self.checkboxes.pop(0)
+
+    def select(self, prompt, choices):
+        raise AssertionError(f'unexpected select: {prompt}')
+
+
+@pytest.fixture
+def answers(monkeypatch):
+    a = Answers()
+    monkeypatch.setattr(init_module, '_prompt', a.text)
+    monkeypatch.setattr(init_module, '_q_confirm', a.confirm)
+    monkeypatch.setattr(init_module, '_q_checkbox', a.checkbox)
+    monkeypatch.setattr(init_module, '_q_select', a.select)
+    return a
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    home = tmp_path / 'home'
+    home.mkdir()
+    (home / '.dax.yaml').write_text('projects: {}\n')
+    monkeypatch.setenv('HOME', str(home))
+    return home
+
+
+def test_registration_prompts_for_and_saves_tenant(home, answers):
+    repo = home / 'myproject'
+    repo.mkdir()
+    # image, tenant, then no credentials to select and none to define.
+    answers.texts.extend(['dax-base', 'personal'])
+    answers.checkboxes.append([])
+    answers.confirms.append(False)
+
+    run_init({'projects': {}}, repo)
+
+    config = load_dax_config()
+    assert config['projects']['myproject']['tenant'] == 'personal'
+
+
+def test_leaving_tenant_blank_registers_with_no_tenant(home, answers):
+    repo = home / 'myproject'
+    repo.mkdir()
+    answers.texts.extend(['dax-base', ''])
+    answers.checkboxes.append([])
+    answers.confirms.append(False)
+
+    run_init({'projects': {}}, repo)
+
+    config = load_dax_config()
+    assert 'tenant' not in config['projects']['myproject']
+
+
+def test_refuses_to_register_a_subdirectory_of_an_existing_project(home, answers, capsys):
+    repo = home / 'myproject'
+    repo.mkdir()
+    config = {'projects': {'myproject': {'dir': str(repo), 'creds': []}}}
+
+    subdir = repo / 'nested'
+    subdir.mkdir()
+
+    result = run_init(config, subdir)
+
+    out = capsys.readouterr().out
+    assert 'already-registered project "myproject"' in out
+    assert 'nested' not in result.get('projects', {})
+    assert len(result['projects']) == 1
+
+
+def test_updating_an_existing_project_keeps_its_tenant_as_the_default(home, answers):
+    repo = home / 'myproject'
+    repo.mkdir()
+    config = {'projects': {'myproject': {'dir': str(repo), 'tenant': 'personal', 'creds': []}}}
+    (home / '.dax.yaml').write_text('')
+    from dax_creds.init import save_config
+    save_config(config)
+
+    answers.confirms.append(True)  # "Update it?"
+    answers.texts.extend(['dax-base', 'personal'])  # image, tenant (unchanged)
+    answers.checkboxes.append([])
+    answers.confirms.append(False)  # "Define a new credential?"
+
+    run_init(load_dax_config(), repo)
+
+    assert load_dax_config()['projects']['myproject']['tenant'] == 'personal'

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -297,6 +297,11 @@ def test_format_docker_cmd_pairs_bare_volume_flag_with_its_value():
     assert lines == ['--volume /a:/b', '-v /c:/d']
 
 
+def test_format_docker_cmd_pairs_workdir_flag_with_its_path():
+    lines = _format_docker_cmd(['-w', '/home/dfarrow/fabric', 'dax:latest']).split('\n  ')
+    assert lines == ['-w /home/dfarrow/fabric', 'dax:latest']
+
+
 def test_format_docker_cmd_realistic_mixed_command():
     cmd = [
         'docker', 'run', '-it', '--rm', '--platform=linux/amd64',


### PR DESCRIPTION
## 💪 What

- Removes `~/.dax.yaml`'s top-level `features:` list — `workdir`, `dotfiles`, and `webpreview` are now an unconditional baseline in code (`_ALWAYS_ON_FEATURES`), not something read from that list. Everything else optional (`claude`, `claude_tenant_state`, `ssh`, `mounts`, `substrate`, ...) is per-env only: a project's own `features:`, a cwd-local `.dax.yaml`, or `-f`
- Warns rather than silently ignoring a leftover non-empty top-level `features:` key, naming what it found and that it's no longer read
- Adds a `tenant` prompt to `dax init` at registration time (optional, blank leaves it unset), writing it via the existing `run_env_set`
- Fixes `dax init` silently registering a duplicate project when run from inside an already-registered project's subdirectory — it now checks `find_enclosing_project` first and refuses, closing the same blind spot `find_enclosing_project`/Gate 0 already closed for `dax run`
- Lands the container shell at the project mount (`-w <container_home>/<workdir_name>`) instead of `$HOME`, since the mount path is always known now that `workdir` is a baseline feature
- Drops the `claude` wrapper's missing `oauthAccount`/`userID` seeding from the backlog for good — decided it will never be fixed (cosmetic only, needs plumbing that doesn't exist)

## 🤔 Why

- The global `features:` list was the actual cause of the "additive-only, no opt-out" problem: every env inherited whatever was in it with no way to decline one, which made switching a single env onto `claude_tenant_state` take four separate config writes. Removing the list instead of patching around it eliminates the problem rather than working around it
- Moving toward `gh`-based GitHub auth instead of ambient host-agent-forwarding made `ssh` no longer worth defaulting on for every env — it's still available per-env whenever actually needed
- `dax init`'s exact-match blind spot is the same class of bug Gate 0 fixed for `dax run` a few weeks ago; leaving it unfixed for `init` specifically was an oversight worth closing while `_run_init` was already being touched for the tenant prompt
- Landing the shell at the project mount removes a manual `cd` from literally every session

## 👀 Usage

- Existing `~/.dax.yaml` files with a top-level `features:` list still load fine — the key is just ignored, with a warning printed at `dax run` time telling you what was in it and where to move it if it isn't already covered by the baseline
- `dax init` now asks for a tenant; press enter to skip if you don't have one yet, same as skipping credentials
- No user-facing change needed to get the shell-landing fix — it applies to every `dax run` automatically

## 👩‍🔬 How to validate

- Run `dax run` in a project whose `~/.dax.yaml` still has a top-level `features:` list and confirm the warning names the right leftover features and still runs `workdir`/`dotfiles`/`webpreview` regardless
- Run `dax init` on a fresh directory and confirm it prompts for tenant, and that leaving it blank registers the project with no `tenant` key
- Run `dax init` from a subdirectory of an already-registered project and confirm it refuses with the enclosing project's name and root instead of registering a duplicate
- `dax -t run` (dry run) in a registered project and confirm `-w /home/<user>/<project>` appears in the assembled docker command