### PR TITLE
SSH agent forwarding: keyring fast-fail + drop the ssh feature switch

### DIFF
--- a/.dax.yaml.example
+++ b/.dax.yaml.example
@@ -2,7 +2,7 @@ image: dax:latest
 
 # workdir, dotfiles, and webpreview are always on — no top-level features:
 # list needed for them. Everything else (claude, claude_tenant_state, auggie,
-# github, ssh, mounts, substrate, ...) is opt-in per project: add it to that
+# github, mounts, substrate, ...) is opt-in per project: add it to that
 # project's own `features:` list, a cwd-local .dax.yaml, or pass -f. e.g.:
 #
 # projects:
@@ -10,7 +10,11 @@ image: dax:latest
 #     dir: /Users/you/code/myproject
 #     features:
 #       - claude
-#       - ssh
+#
+# SSH agent forwarding is not a feature at all — it turns on purely because a
+# project's `creds:` list resolves to an `ssh`-provider credential (`dax
+# creds add`, provider ssh). No credential, no forwarding; nothing to opt
+# into separately.
 
 claudedir:
   mount: ~/.claude

--- a/dax.py
+++ b/dax.py
@@ -282,39 +282,17 @@ def feature_ovpn(config):
     ]
 
 
-_DOCKER_DESKTOP_SSH_SOCK = '/run/host-services/ssh-auth.sock'
-
-
-def _resolve_ssh_agent_sock(config):
-    """The host SSH agent socket to bridge into the container, or None.
-
-    Ephemeral per-credential agent (started by `cmd_run` when a project's
-    `creds:` resolves an `ssh` credential) wins over the ambient host agent,
-    which wins over Docker Desktop's own bridge socket - the same fallback
-    order `feature_ssh` always used, just pulled out on its own so `cmd_run`
-    can decide whether to start the TCP bridge (see `feature_ssh`) before the
-    feature loop runs.
-    """
-    sock = config.get('_ephemeral_ssh_sock', '')
-    if not sock or not os.path.exists(sock):
-        sock = os.environ.get('SSH_AUTH_SOCK', '')
-    if not sock or not os.path.exists(sock):
-        sock = _DOCKER_DESKTOP_SSH_SOCK
-    if not sock or not os.path.exists(sock):
-        return None
-    return sock
-
-
 def _start_ssh_agent_bridge(agent_sock, port):
-    """TCP-forward a host SSH agent socket into the container's reach.
+    """TCP-forward this run's ephemeral SSH agent socket into the
+    container's reach.
 
-    Bind-mounting the socket directly (the old `feature_ssh`) doesn't survive
-    a Docker Desktop VM restart or a host sleep/wake cycle even when both real
-    endpoints stay up the whole time - the container keeps the mount, but the
-    live connection across the VM boundary can die. Exactly the class of
-    problem `_start_creds_daemon` already solved for OAuth credentials by
-    using TCP over `host.docker.internal` instead of a bind-mounted socket;
-    this is the same fix applied to agent forwarding.
+    Bind-mounting the socket directly doesn't survive a Docker Desktop VM
+    restart or a host sleep/wake cycle even when both real endpoints stay up
+    the whole time - the container keeps the mount, but the live connection
+    across the VM boundary can die. Exactly the class of problem
+    `_start_creds_daemon` already solved for OAuth credentials by using TCP
+    over `host.docker.internal` instead of a bind-mounted socket; this is the
+    same fix applied to agent forwarding.
 
     Runs `dax_creds.ssh_bridge` (asyncio, in-process) rather than shelling out
     to `socat` on the host - `socat` is guaranteed inside the container image
@@ -337,25 +315,6 @@ def _start_ssh_agent_bridge(agent_sock, port):
     dax_print("[+] starting SSH agent bridge (log: {})".format(log_path))
     return subprocess.Popen(cmd, cwd=str(Path(__file__).parent),
                             stdout=log_file, stderr=log_file)
-
-
-def feature_ssh(config):
-    """Point the container at the TCP bridge `cmd_run` already started.
-
-    `cmd_run` resolves the host agent socket (`_resolve_ssh_agent_sock`) and
-    starts `_start_ssh_agent_bridge` before the feature loop runs, stashing
-    its port at `config['_ssh_bridge_port']` - this function only turns that
-    into the env var `dax-entrypoint.sh` reads to start its own end of the
-    bridge (a local Unix socket relayed over TCP to this port, since `ssh`/
-    `git` need a real Unix socket for `SSH_AUTH_SOCK`, not a TCP address).
-    No bridge port means no socket resolved, no `ssh` feature active, or the
-    bridge failed to start - `cmd_run` already reported why, so this stays
-    silent rather than repeating it.
-    """
-    port = config.get('_ssh_bridge_port')
-    if not port:
-        return []
-    return ['-e', 'DAX_SSH_AGENT_TCP_PORT={}'.format(port)]
 
 
 def _is_port_free(port):
@@ -806,6 +765,29 @@ def cmd_run(args):
                     ssh_provider.setup(cred_def, agent_sock=agent_sock)
                 except RuntimeError as e:
                     dax_print(f"[!] failed to load {cred_name}: {e}")
+
+            # Forwarding into the container turns on purely because an `ssh`
+            # credential is configured — no separate `ssh` feature to also
+            # remember (removed 2026-08; see docs/design/2026-08-04-codebase
+            # -review.md). There is only ever one source now: this run's own
+            # ephemeral agent above. No more ambient SSH_AUTH_SOCK or Docker
+            # Desktop bridge-socket fallback — a project with no ssh
+            # credential gets no forwarding, full stop, matching the same
+            # explicit-over-ambient move already made for GitHub.
+            try:
+                port = _find_free_port()
+                ssh_bridge_proc = _start_ssh_agent_bridge(agent_sock, port)
+                if _wait_for_tcp('127.0.0.1', port):
+                    if '--add-host=host.docker.internal:host-gateway' not in cmd:
+                        cmd += ['--add-host=host.docker.internal:host-gateway']
+                    cmd += ['-e', 'DAX_SSH_AGENT_TCP_PORT={}'.format(port)]
+                else:
+                    dax_print("[!] SSH agent bridge did not start — skipping")
+                    ssh_bridge_proc.terminate()
+                    ssh_bridge_proc = None
+            except Exception as e:
+                dax_print(f"[!] SSH agent bridge error: {e}")
+                ssh_bridge_proc = None
         non_ssh_creds = {n: d for n, d in project_creds.items() if d.get('provider') != 'ssh'}
         if non_ssh_creds:
             from dax_creds.init import ensure_project_credentials
@@ -839,30 +821,6 @@ def cmd_run(args):
         dax_print('    Check this env\'s own `features:` list (and any -f flag) '
                   'and drop one of the two.')
         sys.exit(1)
-
-    # Must run before the feature loop: feature_ssh only reads
-    # config['_ssh_bridge_port'], it doesn't resolve or start anything itself.
-    # Wrapped the same way the credential daemon below is - a resolution or
-    # subprocess failure here should be a warning, not a crashed `dax run`.
-    if 'ssh' in features:
-        try:
-            sock = _resolve_ssh_agent_sock(config)
-            if sock:
-                port = _find_free_port()
-                ssh_bridge_proc = _start_ssh_agent_bridge(sock, port)
-                if _wait_for_tcp('127.0.0.1', port):
-                    config['_ssh_bridge_port'] = port
-                    if '--add-host=host.docker.internal:host-gateway' not in cmd:
-                        cmd += ['--add-host=host.docker.internal:host-gateway']
-                else:
-                    dax_print("[!] SSH agent bridge did not start — skipping")
-                    ssh_bridge_proc.terminate()
-                    ssh_bridge_proc = None
-            else:
-                dax_print("[!] No SSH agent socket found. Run ssh-add first.")
-        except Exception as e:
-            dax_print(f"[!] SSH agent bridge error: {e}")
-            ssh_bridge_proc = None
 
     for feature in features:
         cmd.extend(_add_feature(feature, config))

--- a/dax.py
+++ b/dax.py
@@ -658,6 +658,28 @@ def _wait_for_tcp(host, port, timeout=5.0):
     return False
 
 
+def _keyring_importable():
+    """Whether `sys.executable` - the same interpreter `_start_creds_daemon`/
+    `_start_login_daemon` spawn as a subprocess - can import `keyring`.
+
+    `dax_creds.daemon`'s `__main__` block constructs `KeyringTokenStore()`
+    unconditionally, with no fallback, so a missing `keyring` crashes the
+    daemon subprocess immediately on an ImportError - one that never reaches
+    the caller's terminal (stdout/stderr are redirected to its log file), so
+    it just looks like "credential daemon did not start" after a silent
+    5-second timeout with no indication why. Checking here, before spawning
+    it, turns that into an immediate, actionable message instead. `keyring`
+    is not declared anywhere in pyproject.toml (host or container extras) -
+    it is only ever an out-of-band `pip install keyring`, which is exactly
+    what's missing when this returns False.
+    """
+    try:
+        import keyring  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
 _DOCKER_TWO_TOKEN_FLAGS = {'--name', '-h', '-v', '--volume', '-e', '-p', '-w', '--group-add', '-c'}
 
 
@@ -846,7 +868,12 @@ def cmd_run(args):
         cmd.extend(_add_feature(feature, config))
 
     try:
-        if project_creds:
+        if project_creds and not _keyring_importable():
+            dax_print("[!] keyring not importable in this Python environment — "
+                      "skipping the credential daemon and launching without "
+                      "credentials.")
+            dax_print("    pip install keyring on whatever host is running `dax`.")
+        elif project_creds:
             port = _find_free_port()
             daemon_proc = _start_creds_daemon(project_creds, port)
             if _wait_for_tcp('127.0.0.1', port):
@@ -1007,6 +1034,17 @@ def cmd_creds_login(cred_name, config):
     provider_cfg = _LOGIN_PROVIDERS.get(provider)
     if not provider_cfg:
         print(f"dax creds login: no login flow defined for provider '{provider}'")
+        sys.exit(1)
+
+    if not _keyring_importable():
+        dax_print('[!] keyring not importable in this Python environment — the '
+                  'credential daemon needs it to reach Keychain, and crashes '
+                  'immediately without it.')
+        dax_print('    If this is inside a dax container: credential logins are '
+                  'host-only — exit and run `dax creds login` from your host '
+                  'terminal instead.')
+        dax_print('    Otherwise: pip install keyring on whatever host is '
+                  'running `dax`.')
         sys.exit(1)
 
     image = config.get('defaults', {}).get('image', 'dax:latest')

--- a/tests/test_dax_cmd_creds_login.py
+++ b/tests/test_dax_cmd_creds_login.py
@@ -11,6 +11,7 @@ import json
 
 import pytest
 
+import dax
 import dax_creds.providers.claude as claude_provider_module
 from dax import _login_credential_def, _post_login_import
 
@@ -85,6 +86,27 @@ def test_login_rejects_a_derived_name_whose_env_has_no_tenant():
 
     with pytest.raises(KeyError):
         _login_credential_def(config, 'claude-personal-fabric')
+
+
+def test_cmd_creds_login_refuses_cleanly_when_keyring_not_importable(monkeypatch, capsys):
+    """Regression test for the 2026-08-06 incident: run from inside a
+    container (or any Python without `keyring`), `dax creds login` spawned a
+    daemon that crashed on an uncaught ImportError, invisible to the caller
+    since stdout/stderr go to a log file — all that surfaced was a silent
+    5-second timeout and "credential daemon did not start", no indication
+    why, and no hint that credential logins are host-only in the first
+    place. This must refuse immediately with both pieces of information
+    instead of ever spawning the daemon.
+    """
+    monkeypatch.setattr(dax, '_keyring_importable', lambda: False)
+    config = {'credentials': {'github-dbfarrow': {'provider': 'github'}}}
+
+    with pytest.raises(SystemExit):
+        dax.cmd_creds_login('github-dbfarrow', config)
+
+    out = capsys.readouterr().out
+    assert 'keyring not importable' in out
+    assert 'host terminal' in out
 
 
 def test_post_login_import_claude_stores_token_from_disk(tmp_path, monkeypatch, capsys):

--- a/tests/test_dax_cmd_run_creds_daemon.py
+++ b/tests/test_dax_cmd_run_creds_daemon.py
@@ -55,6 +55,10 @@ def _setup(tmp_path, monkeypatch):
     # subprocess can't run here — while still recording exactly what
     # cmd_run asked for, and its own terminate()/wait() for the finally block.
     monkeypatch.setattr(dax, '_find_free_port', lambda: 54321)
+    # This sandbox has no `keyring` either — same gap the module docstring
+    # above already documents for the daemon subprocess. cmd_run's own
+    # keyring check runs in-process now, so it needs faking too.
+    monkeypatch.setattr(dax, '_keyring_importable', lambda: True)
 
     class _FakeDaemon:
         def terminate(self):
@@ -87,6 +91,28 @@ def test_creds_daemon_uses_tcp_not_a_bind_mounted_socket(tmp_path, monkeypatch, 
     assert 'DAX_CREDS_GITHUB=test-github' in out
     assert 'dax-creds.sock' not in out
     assert 'dax-state' not in out
+
+
+def test_credential_daemon_skipped_cleanly_when_keyring_not_importable(tmp_path, monkeypatch, capsys):
+    """Regression test for the 2026-08-06 incident: the daemon subprocess
+    crashes on an uncaught ImportError when `keyring` isn't importable in
+    whatever Python spawns it, and that crash was invisible to the caller —
+    stdout/stderr go to a log file, so all `dax run`/`dax creds login` ever
+    showed was a silent 5-second timeout and a generic "did not start". This
+    must be caught before spawning anything, not discovered by a timeout.
+    """
+    home, repo, started = _setup(tmp_path, monkeypatch)
+    monkeypatch.setattr(dax, '_keyring_importable', lambda: False)
+
+    def _fail_if_called(*a, **k):
+        raise AssertionError('_start_creds_daemon should not be called')
+    monkeypatch.setattr(dax, '_start_creds_daemon', _fail_if_called)
+
+    dax.cmd_run(_args())
+
+    out = capsys.readouterr().out
+    assert 'keyring not importable' in out
+    assert 'DAX_CREDS_SOCK' not in out
 
 
 def test_start_creds_daemon_passes_tcp_port_not_a_socket_path(tmp_path, monkeypatch):

--- a/tests/test_dax_cmd_run_ssh_bridge.py
+++ b/tests/test_dax_cmd_run_ssh_bridge.py
@@ -141,6 +141,7 @@ def test_add_host_not_duplicated_when_ssh_and_creds_both_active(tmp_path, monkey
     monkeypatch.setattr(dax, '_find_free_port', lambda: 54321)
     monkeypatch.setattr(dax, '_start_ssh_agent_bridge', _fake_bridge_starter({}))
     monkeypatch.setattr(dax, '_start_creds_daemon', lambda creds, port: _FakeProc())
+    monkeypatch.setattr(dax, '_keyring_importable', lambda: True)
 
     cmd_run(_args())
 

--- a/tests/test_dax_cmd_run_ssh_bridge.py
+++ b/tests/test_dax_cmd_run_ssh_bridge.py
@@ -1,16 +1,23 @@
-"""`dax run`'s SSH agent forwarding must use a TCP bridge, not a bind-mounted
-Unix socket — the same class of Docker Desktop VM-boundary fragility
-`_start_creds_daemon` already fixed for credentials (see
-test_dax_cmd_run_creds_daemon.py). `feature_ssh` alone can't prove this
-anymore: resolving the host socket, starting the bridge, and deciding
-whether `--add-host` is needed all happen in `cmd_run`, before the feature
-loop runs — `feature_ssh` just reads what `cmd_run` already decided.
+"""`dax run`'s SSH agent forwarding turns on purely because a project's
+`creds:` resolves an `ssh`-provider credential — there is no separate `ssh`
+feature to also remember. `feature_ssh`/`_resolve_ssh_agent_sock` and the
+ambient SSH_AUTH_SOCK/Docker-Desktop-bridge-socket fallback chain were
+removed 2026-08: the only source is ever this run's own ephemeral agent,
+folded directly into the credential-resolution flow that already starts it
+(see docs/design/2026-08-04-codebase-review.md). A project with no `ssh`
+credential gets no forwarding at all — no ambient fallback left to catch it.
+
+Bridging over TCP rather than a bind-mounted socket (the Docker Desktop
+VM-boundary fragility this replaced) is covered directly below and in
+test_dax_creds_ssh_bridge.py.
 """
 import argparse
 
+import pytest
 import yaml
 
 import dax
+import dax_creds.providers.ssh as ssh_provider_module
 from dax import cmd_run, _start_ssh_agent_bridge
 
 
@@ -45,27 +52,6 @@ def _args():
     return argparse.Namespace(features=None, ports=None, test_only=True)
 
 
-def _setup(tmp_path, monkeypatch, project_features, creds=None, credentials=None):
-    home = tmp_path / 'home'
-    home.mkdir(exist_ok=True)
-    repo = home / 'myenv'
-    repo.mkdir(exist_ok=True)
-
-    project = {'dir': str(repo), 'creds': creds or [], 'features': project_features}
-    with open(home / '.dax.yaml', 'w') as f:
-        yaml.dump({
-            'image': 'test/dax:latest', 'features': [],
-            'credentials': credentials or {},
-            'projects': {'myenv': project},
-        }, f)
-
-    monkeypatch.setenv('HOME', str(home))
-    monkeypatch.chdir(repo)
-    monkeypatch.setattr('dax_creds.init.ensure_project_credentials', lambda *a, **k: [])
-    monkeypatch.setattr(dax, '_wait_for_tcp', lambda host, port, timeout=5.0: True)
-    return home, repo
-
-
 class _FakeProc:
     def terminate(self):
         pass
@@ -82,12 +68,41 @@ def _fake_bridge_starter(started):
     return _start
 
 
-def test_ssh_bridge_starts_and_sets_container_env(tmp_path, monkeypatch, capsys):
-    _setup(tmp_path, monkeypatch, project_features=['ssh'])
+def _setup(tmp_path, monkeypatch, creds=None, credentials=None, features=None):
+    home = tmp_path / 'home'
+    home.mkdir(exist_ok=True)
+    repo = home / 'myenv'
+    repo.mkdir(exist_ok=True)
 
-    sock = tmp_path / 'agent.sock'
-    sock.touch()
-    monkeypatch.setattr(dax, '_resolve_ssh_agent_sock', lambda config: str(sock))
+    project = {'dir': str(repo), 'creds': creds or []}
+    if features is not None:
+        project['features'] = features
+    with open(home / '.dax.yaml', 'w') as f:
+        yaml.dump({
+            'image': 'test/dax:latest', 'features': [],
+            'credentials': credentials or {},
+            'projects': {'myenv': project},
+        }, f)
+
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr('dax_creds.init.ensure_project_credentials', lambda *a, **k: [])
+    monkeypatch.setattr(dax, '_wait_for_tcp', lambda host, port, timeout=5.0: True)
+    monkeypatch.setattr(dax, '_keyring_importable', lambda: True)
+    # Real ssh-agent/ssh-add are host-only side effects with no place in a
+    # unit test — faked the same way _start_creds_daemon already is.
+    monkeypatch.setattr(ssh_provider_module, 'start_ephemeral_agent',
+                        lambda: ('/tmp/fake-agent.sock', 99999))
+    monkeypatch.setattr(ssh_provider_module, 'stop_ephemeral_agent', lambda pid: None)
+    monkeypatch.setattr(ssh_provider_module.SshProvider, 'setup',
+                        lambda self, cred_def, agent_sock=None: None)
+    return home, repo
+
+
+def test_ssh_bridge_starts_when_an_ssh_credential_is_configured(tmp_path, monkeypatch, capsys):
+    _setup(tmp_path, monkeypatch, creds=['ssh-key'],
+           credentials={'ssh-key': {'provider': 'ssh', 'key': '~/.ssh/id_rsa'}})
+
     monkeypatch.setattr(dax, '_find_free_port', lambda: 54321)
     started = {}
     monkeypatch.setattr(dax, '_start_ssh_agent_bridge', _fake_bridge_starter(started))
@@ -95,22 +110,18 @@ def test_ssh_bridge_starts_and_sets_container_env(tmp_path, monkeypatch, capsys)
     cmd_run(_args())
 
     out = capsys.readouterr().out
-    assert started['sock'] == str(sock)
+    assert started['sock'] == '/tmp/fake-agent.sock'
     assert started['port'] == 54321
     assert 'DAX_SSH_AGENT_TCP_PORT=54321' in out
     assert out.count('--add-host=host.docker.internal:host-gateway') == 1
-    # The old bind-mounted-socket approach is gone — no --volume to a host
-    # ssh-agent socket and no SSH_AUTH_SOCK set directly on the docker cmd.
-    assert 'ssh-agent' not in out
-    assert 'SSH_AUTH_SOCK' not in out
 
 
-def test_no_bridge_and_no_add_host_when_ssh_not_a_feature(tmp_path, monkeypatch, capsys):
-    _setup(tmp_path, monkeypatch, project_features=[])
+def test_no_bridge_when_no_ssh_credential_configured(tmp_path, monkeypatch, capsys):
+    _setup(tmp_path, monkeypatch, creds=[])
 
-    def _fail(config):
-        raise AssertionError('_resolve_ssh_agent_sock should not be called')
-    monkeypatch.setattr(dax, '_resolve_ssh_agent_sock', _fail)
+    def _fail(*a, **k):
+        raise AssertionError('start_ephemeral_agent should not be called')
+    monkeypatch.setattr(ssh_provider_module, 'start_ephemeral_agent', _fail)
 
     cmd_run(_args())
 
@@ -119,29 +130,30 @@ def test_no_bridge_and_no_add_host_when_ssh_not_a_feature(tmp_path, monkeypatch,
     assert 'DAX_SSH_AGENT_TCP_PORT' not in out
 
 
-def test_no_bridge_when_no_socket_resolves(tmp_path, monkeypatch, capsys):
-    _setup(tmp_path, monkeypatch, project_features=['ssh'])
-    monkeypatch.setattr(dax, '_resolve_ssh_agent_sock', lambda config: None)
+def test_ssh_in_features_is_now_an_unknown_feature(tmp_path, monkeypatch, capsys):
+    """The old opt-in switch is gone, not just inert: `_add_feature` treats
+    any unrecognized name as fatal, so a project whose `features:` still
+    lists `ssh` from before this change now hard-refuses to launch at all,
+    rather than silently doing nothing. Migrating off the old two-switch
+    design means actually removing `ssh` from `features:`, not just leaving
+    a now-meaningless entry there."""
+    _setup(tmp_path, monkeypatch, creds=[], features=['ssh'])
 
-    cmd_run(_args())
+    with pytest.raises(SystemExit):
+        cmd_run(_args())
 
-    out = capsys.readouterr().out
-    assert 'No SSH agent socket found' in out
-    assert '--add-host' not in out
-    assert 'DAX_SSH_AGENT_TCP_PORT' not in out
+    assert 'unknown feature: ssh' in capsys.readouterr().out
 
 
-def test_add_host_not_duplicated_when_ssh_and_creds_both_active(tmp_path, monkeypatch, capsys):
-    _setup(tmp_path, monkeypatch, project_features=['ssh'],
-           creds=['test-github'], credentials={'test-github': {'provider': 'github'}})
+def test_add_host_not_duplicated_when_ssh_and_other_creds_both_active(tmp_path, monkeypatch, capsys):
+    _setup(tmp_path, monkeypatch,
+           creds=['ssh-key', 'test-github'],
+           credentials={'ssh-key': {'provider': 'ssh', 'key': '~/.ssh/id_rsa'},
+                        'test-github': {'provider': 'github'}})
 
-    sock = tmp_path / 'agent.sock'
-    sock.touch()
-    monkeypatch.setattr(dax, '_resolve_ssh_agent_sock', lambda config: str(sock))
     monkeypatch.setattr(dax, '_find_free_port', lambda: 54321)
     monkeypatch.setattr(dax, '_start_ssh_agent_bridge', _fake_bridge_starter({}))
     monkeypatch.setattr(dax, '_start_creds_daemon', lambda creds, port: _FakeProc())
-    monkeypatch.setattr(dax, '_keyring_importable', lambda: True)
 
     cmd_run(_args())
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -6,8 +6,6 @@ from dax import (
     feature_workdir,
     feature_optdir,
     feature_aws,
-    feature_ssh,
-    _resolve_ssh_agent_sock,
     feature_dotfiles,
     feature_ports,
     feature_mounts,
@@ -180,51 +178,11 @@ def test_feature_substrate_warns_if_none_configured(capsys):
     assert 'no substrate configured' in capsys.readouterr().out
 
 
-def test_feature_ssh_returns_tcp_bridge_env_var():
-    # feature_ssh no longer resolves or mounts anything itself — cmd_run
-    # already started the bridge and stashed its port before the feature
-    # loop runs (see test_dax_cmd_run_ssh_bridge.py for that wiring).
-    opts = feature_ssh({'_ssh_bridge_port': 54321})
-    assert opts == ['-e', 'DAX_SSH_AGENT_TCP_PORT=54321']
-    assert not any('ssh-agent' in o for o in opts)
-
-
-def test_feature_ssh_returns_nothing_without_a_bridge_port(capsys):
-    # No _ssh_bridge_port means cmd_run either didn't have the `ssh` feature
-    # active, found no socket, or the bridge failed to start — cmd_run
-    # already reported why in each of those cases, so this stays silent
-    # rather than repeating it.
-    opts = feature_ssh({})
-    assert opts == []
-    assert capsys.readouterr().out == ''
-
-
-def test_resolve_ssh_agent_sock_prefers_ephemeral_agent(tmp_path):
-    ephemeral = tmp_path / 'ephemeral.sock'
-    ephemeral.touch()
-    config = {'_ephemeral_ssh_sock': str(ephemeral)}
-    assert _resolve_ssh_agent_sock(config) == str(ephemeral)
-
-
-def test_resolve_ssh_agent_sock_falls_back_to_env(tmp_path, monkeypatch):
-    sock = tmp_path / 'ssh-auth.sock'
-    sock.touch()
-    monkeypatch.setenv('SSH_AUTH_SOCK', str(sock))
-    assert _resolve_ssh_agent_sock({}) == str(sock)
-
-
-def test_resolve_ssh_agent_sock_falls_back_to_docker_desktop_socket(tmp_path, monkeypatch):
-    monkeypatch.delenv('SSH_AUTH_SOCK', raising=False)
-    dd_sock = tmp_path / 'docker-desktop.sock'
-    dd_sock.touch()
-    monkeypatch.setattr('dax._DOCKER_DESKTOP_SSH_SOCK', str(dd_sock))
-    assert _resolve_ssh_agent_sock({}) == str(dd_sock)
-
-
-def test_resolve_ssh_agent_sock_returns_none_when_nothing_found(tmp_path, monkeypatch):
-    monkeypatch.delenv('SSH_AUTH_SOCK', raising=False)
-    monkeypatch.setattr('dax._DOCKER_DESKTOP_SSH_SOCK', str(tmp_path / 'missing.sock'))
-    assert _resolve_ssh_agent_sock({}) is None
+# `ssh` is no longer a feature at all (removed 2026-08): forwarding turns on
+# purely because a project's `creds:` resolves an `ssh`-provider credential,
+# folded directly into cmd_run's existing credential-resolution flow rather
+# than a separate feature_ssh/_resolve_ssh_agent_sock pair. See
+# test_dax_cmd_run_ssh_bridge.py for that behavior.
 
 
 def test_feature_webpreview_uses_explicit_port(monkeypatch):


### PR DESCRIPTION
## Summary
- `dax creds login` used to spawn a credential daemon that crashed with an uncaught `ImportError` whenever `keyring` wasn't importable (e.g. run from inside a dax container) — invisible to the caller since the crash lands in a log file, surfacing only as a silent 5-second timeout and a generic "credential daemon did not start". Both daemon-spawning paths (`cmd_run`, `cmd_creds_login`) now check `keyring` importability up front and fail fast with an actionable message; `cmd_creds_login` specifically calls out the container case.
- SSH agent forwarding used to need two independent switches to agree: an `ssh`-provider credential in a project's `creds:` *and* `ssh` in that project's `features:`. Registering the credential without the feature flag silently loaded a key into an ephemeral agent that was torn down having never reached the container — real, observed waste with no error. Collapsed to one switch: forwarding turns on purely because `creds:` resolves to an `ssh` credential. The ambient `SSH_AUTH_SOCK`/Docker Desktop bridge-socket fallback is gone — no credential, no forwarding, matching the same explicit-over-ambient move already made for GitHub auth.
- `ssh` no longer exists as a feature name. A project still listing it in `features:` from before this change now hard-refuses to launch (`unknown feature: ssh`) rather than silently doing nothing.

## Test plan
- [x] `python3 -m pytest -q` — 524 passed
- [x] Live dry-run (`dax -t run`) against a scratch config with an `ssh`-provider credential and *no* `ssh` in `features:` — confirms the bridge starts and `DAX_SSH_AGENT_TCP_PORT`/`--add-host` land in the assembled docker command purely from `creds:`
- [x] Live dry-run demonstrating the keyring guard's actual message against this sandbox's real missing `keyring`
- [ ] Manual: run on host Mac, confirm `dax creds login` refuses cleanly if ever run from inside a container, and confirm real SSH forwarding still works end-to-end for a project relying on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)