### PR TITLE
tmux window naming: wrapper rename + opt-in auto_claude feature

### DIFF
--- a/.dax.yaml.example
+++ b/.dax.yaml.example
@@ -2,8 +2,9 @@ image: dax:latest
 
 # workdir, dotfiles, and webpreview are always on — no top-level features:
 # list needed for them. Everything else (claude, claude_tenant_state, auggie,
-# github, mounts, substrate, ...) is opt-in per project: add it to that
-# project's own `features:` list, a cwd-local .dax.yaml, or pass -f. e.g.:
+# github, mounts, substrate, auto_claude, ...) is opt-in per project: add it
+# to that project's own `features:` list, a cwd-local .dax.yaml, or pass -f.
+# e.g.:
 #
 # projects:
 #   myproject:
@@ -15,6 +16,12 @@ image: dax:latest
 # project's `creds:` list resolves to an `ssh`-provider credential (`dax
 # creds add`, provider ssh). No credential, no forwarding; nothing to opt
 # into separately.
+#
+# `auto_claude`: skip the login shell — start tmux, name its one window after
+# the project, and run `claude` directly as that window's command. Exiting
+# claude closes the window, ends the (only) tmux session, ends the
+# container's foreground process, and (docker run --rm) tears the container
+# down. No shell left behind and nothing to reattach to, by design.
 
 claudedir:
   mount: ~/.claude

--- a/dax.py
+++ b/dax.py
@@ -3,6 +3,7 @@
 import argparse
 import hashlib
 import os
+import shlex
 import shutil
 import sys
 import socket as _socket
@@ -337,14 +338,49 @@ def _find_preview_port(cwd, base=8000, spread=1000):
 
 
 def feature_webpreview(config):
+    """Starts dax-preview in the background, then hands off to whatever the
+    container's foreground process should be.
+
+    Sets `config['_shell_cmd_prefix']` rather than building the whole
+    foreground command itself: webpreview is a baseline feature (always
+    on), so it runs before any opt-in feature that might also want a say in
+    what the foreground process is (see `feature_auto_claude`) - `cmd_run`
+    is what actually decides the final `exec` target, composing whatever
+    prefix this sets with it. Baseline features always run first
+    (`_ALWAYS_ON_FEATURES` is prepended unconditionally in `load_config`),
+    so this ordering is reliable, not incidental.
+    """
     port = config.get('webpreview', {}).get('port') or _find_preview_port(config['cwd'])
-    shell = os.environ.get('SHELL', '/bin/zsh')
     container_home = _container_home(config)
     preview_dir = os.path.join(container_home, config['workdir_name'])
     dax_print("[-]   webpreview port: {}".format(port))
-    config['_shell_cmd'] = 'DAX_PREVIEW_PORT={} DAX_PREVIEW_DIR={} dax-preview & exec {}'.format(
-        port, preview_dir, shell)
+    config['_shell_cmd_prefix'] = 'DAX_PREVIEW_PORT={} DAX_PREVIEW_DIR={} dax-preview & '.format(
+        port, preview_dir)
     return ['-p', '{}:{}'.format(port, port)]
+
+
+def feature_auto_claude(config):
+    """Skip the login shell: start tmux, name its one window after the
+    project, and run `claude` directly as that window's command.
+
+    Sets `config['_final_exec']` rather than building `_shell_cmd` outright,
+    so this composes with `feature_webpreview`'s background dax-preview
+    launcher (see `cmd_run`'s shell_cmd assembly) instead of silently
+    dropping it — webpreview is a baseline feature and always runs, so its
+    background launcher must keep running here too.
+
+    Deliberately runs `claude` as the window's own command, not
+    `claude; exec $SHELL`: exiting claude (`/exit` or otherwise) closes the
+    window, which — since it's the session's only window — ends the tmux
+    session, which ends the container's foreground process, which (`docker
+    run --rm`) tears the container down. No shell left behind to fall into
+    and nothing to reattach to, by design: the container itself is gone
+    with it. `shlex.quote` because `workdir_name` can contain spaces or
+    parens (an already-supported case — see feature_workdir's own tests).
+    """
+    window_name = shlex.quote(config['workdir_name'])
+    config['_final_exec'] = 'tmux new-session -n {} claude'.format(window_name)
+    return []
 
 
 def feature_dotfiles(config):
@@ -855,8 +891,17 @@ def cmd_run(args):
 
     cmd.append(config['image'])
 
-    if '_shell_cmd' in config:
-        cmd += ['/bin/sh', '-c', config['_shell_cmd']]
+    # The composition point for whatever the container's foreground process
+    # should be. `_shell_cmd_prefix` (feature_webpreview's background
+    # dax-preview launcher) and `_final_exec` (feature_auto_claude's tmux+
+    # claude) are independent knobs set by different features that may or
+    # may not both be active - neither overwrites the other outright, so
+    # webpreview's background launcher survives whether or not auto_claude
+    # also wants to replace the login shell with something else.
+    if '_shell_cmd_prefix' in config or '_final_exec' in config:
+        final = config.get('_final_exec') or os.environ.get('SHELL', '/bin/zsh')
+        shell_cmd = config.get('_shell_cmd_prefix', '') + 'exec {}'.format(final)
+        cmd += ['/bin/sh', '-c', shell_cmd]
 
     dax_print("[+] running:\n  " + _format_docker_cmd(cmd))
     try:

--- a/dax_creds/wrappers/claude
+++ b/dax_creds/wrappers/claude
@@ -129,4 +129,16 @@ if [ -n "$SUBSTRATE_ROOT" ]; then
     esac
 fi
 
+# --- tmux window naming ------------------------------------------------------
+#
+# $TMUX is only set when this process is actually running inside a tmux pane
+# — set by the pane's own environment, regardless of whether that pane was
+# started by hand or by auto_claude below — so this is a no-op everywhere
+# else, nothing to gate behind a feature. Renaming on every claude launch
+# (not just the first) keeps the window's name following wherever you've
+# cd'd if you relaunch claude later in the same window.
+if [ -n "$TMUX" ]; then
+    tmux rename-window "$(basename "$PWD")" 2>/dev/null
+fi
+
 exec "${DAX_CLAUDE_REAL:-/usr/bin/claude-real}" "$@"

--- a/tests/test_dax_cmd_run_auto_claude.py
+++ b/tests/test_dax_cmd_run_auto_claude.py
@@ -1,0 +1,66 @@
+"""`auto_claude`: an opt-in feature that skips the login shell entirely,
+starting tmux with `claude` as its one window's command instead. Composes
+with feature_webpreview's background dax-preview launcher (a baseline
+feature, always active) via cmd_run's `_shell_cmd_prefix`/`_final_exec`
+split — neither feature clobbers what the other set.
+"""
+import argparse
+import os
+
+import yaml
+
+from dax import cmd_run
+
+
+def _args():
+    return argparse.Namespace(features=None, ports=None, test_only=True)
+
+
+def _setup(tmp_path, monkeypatch, features=None):
+    home = tmp_path / 'home'
+    home.mkdir()
+    repo = home / 'myproj'
+    repo.mkdir()
+
+    project = {'dir': str(repo), 'creds': []}
+    if features is not None:
+        project['features'] = features
+    with open(home / '.dax.yaml', 'w') as f:
+        yaml.dump({'image': 'test/dax:latest', 'projects': {'myproj': project}}, f)
+
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.chdir(repo)
+
+
+def test_without_auto_claude_the_shell_cmd_is_unchanged(tmp_path, monkeypatch, capsys):
+    _setup(tmp_path, monkeypatch)
+
+    cmd_run(_args())
+
+    out = capsys.readouterr().out
+    assert 'dax-preview &' in out
+    assert 'tmux new-session' not in out
+    assert 'exec {}'.format(os.environ.get('SHELL', '/bin/zsh')) in out
+
+
+def test_auto_claude_runs_tmux_with_claude_as_the_window_command(tmp_path, monkeypatch, capsys):
+    _setup(tmp_path, monkeypatch, features=['auto_claude'])
+
+    cmd_run(_args())
+
+    out = capsys.readouterr().out
+    assert "tmux new-session -n myproj claude" in out
+
+
+def test_auto_claude_does_not_drop_webpreviews_background_launcher(tmp_path, monkeypatch, capsys):
+    """The composition this whole split exists for: webpreview is baseline
+    and always runs, so its `dax-preview &` must survive even though
+    auto_claude — an opt-in feature running after it — also wants to control
+    what happens in the foreground."""
+    _setup(tmp_path, monkeypatch, features=['auto_claude'])
+
+    cmd_run(_args())
+
+    out = capsys.readouterr().out
+    assert 'dax-preview &' in out
+    assert 'exec tmux new-session -n myproj claude' in out

--- a/tests/test_dax_creds_claude_wrapper.py
+++ b/tests/test_dax_creds_claude_wrapper.py
@@ -18,11 +18,16 @@ ENVELOPE = {'claudeAiOauth': {'accessToken': 'sk-ant-oat01-abc',
 ENVELOPE_JSON = json.dumps(ENVELOPE)
 
 
-def _run(tmp_path, dax_creds_stdout, dax_creds_exit=0, env=None):
+def _run(tmp_path, dax_creds_stdout, dax_creds_exit=0, env=None, cwd=None):
     """Run the wrapper with a stubbed dax-creds and a no-op claude-real.
 
     The wrapper is copied and chmod'd the way Dockerfile.tmpl installs it,
     rather than executed in place — it is mode 644 in the repo.
+
+    A stub `tmux` is always on PATH too, logging its own argv to `tmp_path /
+    'tmux.log'` (one line per invocation) rather than doing anything real —
+    the wrapper only ever calls it when $TMUX is set, so its absence from
+    most tests' env means it's simply never invoked.
     """
     bin_dir = tmp_path / 'bin'
     bin_dir.mkdir(exist_ok=True)
@@ -40,6 +45,11 @@ def _run(tmp_path, dax_creds_stdout, dax_creds_exit=0, env=None):
     real.write_text('#!/bin/bash\nexit 0\n')
     real.chmod(0o755)
 
+    tmux_log = tmp_path / 'tmux.log'
+    tmux = bin_dir / 'tmux'
+    tmux.write_text('#!/bin/bash\nprintf "%s\\n" "$*" >> {!r}\nexit 0\n'.format(str(tmux_log)))
+    tmux.chmod(0o755)
+
     home = tmp_path / 'home'
     home.mkdir(exist_ok=True)
 
@@ -54,7 +64,7 @@ def _run(tmp_path, dax_creds_stdout, dax_creds_exit=0, env=None):
         full_env.update(env)
 
     proc = subprocess.run([str(wrapper)], env=full_env, capture_output=True,
-                          text=True, timeout=30)
+                          text=True, timeout=30, cwd=cwd)
     return proc, home / '.claude' / '.credentials.json'
 
 
@@ -106,6 +116,29 @@ def test_no_fetch_attempted_without_credential_name(tmp_path):
     proc, creds = _run(tmp_path, ENVELOPE_JSON, env={'DAX_CREDS_CLAUDE': ''})
     assert not creds.exists()
     assert proc.stderr == ''
+
+
+def test_renames_tmux_window_to_the_current_directory_when_inside_tmux(tmp_path):
+    project_dir = tmp_path / 'myproject'
+    project_dir.mkdir()
+
+    proc, _ = _run(tmp_path, ENVELOPE_JSON, env={'TMUX': '/tmp/fake-tmux-socket,0,0'},
+                   cwd=str(project_dir))
+
+    assert proc.returncode == 0
+    assert (tmp_path / 'tmux.log').read_text() == 'rename-window myproject\n'
+
+
+def test_does_not_touch_tmux_when_not_running_inside_it(tmp_path):
+    proc, _ = _run(tmp_path, ENVELOPE_JSON, env={'TMUX': ''})
+    assert proc.returncode == 0
+    assert not (tmp_path / 'tmux.log').exists()
+
+
+def test_still_execs_claude_after_renaming_the_window(tmp_path):
+    # The rename must never block or replace the actual claude launch.
+    proc, _ = _run(tmp_path, ENVELOPE_JSON, env={'TMUX': '/tmp/fake-tmux-socket,0,0'})
+    assert proc.returncode == 0
 
 
 # --- inject-if-absent ------------------------------------------------------

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -14,6 +14,7 @@ from dax import (
     feature_ovpn,
     feature_X11,
     feature_webpreview,
+    feature_auto_claude,
     _find_preview_port,
     _format_docker_cmd,
 )
@@ -196,8 +197,13 @@ def test_feature_webpreview_uses_explicit_port(monkeypatch):
     opts = feature_webpreview(config)
     assert '-p' in opts
     assert '9000:9000' in opts
-    assert 'DAX_PREVIEW_PORT=9000' in config['_shell_cmd']
-    assert 'DAX_PREVIEW_DIR=/home/user/project' in config['_shell_cmd']
+    assert 'DAX_PREVIEW_PORT=9000' in config['_shell_cmd_prefix']
+    assert 'DAX_PREVIEW_DIR=/home/user/project' in config['_shell_cmd_prefix']
+    # webpreview no longer decides the foreground process itself — that's
+    # cmd_run's job, composing this prefix with whatever _final_exec is (or
+    # the plain shell, by default).
+    assert '_final_exec' not in config
+    assert 'exec' not in config['_shell_cmd_prefix']
 
 
 def test_feature_webpreview_auto_assigns_port(monkeypatch):
@@ -212,7 +218,32 @@ def test_feature_webpreview_auto_assigns_port(monkeypatch):
     port_mapping = next(o for o in opts if ':' in o and o != '-p')
     host_port = int(port_mapping.split(':')[0])
     assert 8000 <= host_port < 9000
-    assert 'DAX_PREVIEW_DIR=/home/user/project' in config['_shell_cmd']
+    assert 'DAX_PREVIEW_DIR=/home/user/project' in config['_shell_cmd_prefix']
+
+
+def test_feature_auto_claude_sets_final_exec_to_tmux_running_claude():
+    config = {'workdir_name': 'myproject'}
+    opts = feature_auto_claude(config)
+    assert opts == []
+    assert config['_final_exec'] == "tmux new-session -n myproject claude"
+
+
+def test_feature_auto_claude_quotes_a_workdir_name_with_spaces():
+    # workdir_name can contain spaces/parens (see feature_workdir's own
+    # tests) — this has to survive being embedded in a single shell string.
+    config = {'workdir_name': 'my.project (copy)'}
+    opts = feature_auto_claude(config)
+    assert config['_final_exec'] == "tmux new-session -n 'my.project (copy)' claude"
+
+
+def test_feature_auto_claude_does_not_clobber_webpreviews_prefix():
+    """Both features run in the same cmd_run pass — webpreview (baseline)
+    always runs first, so this must add to what it already set, not replace
+    the whole shell-command story wholesale."""
+    config = {'workdir_name': 'myproject', '_shell_cmd_prefix': 'dax-preview & '}
+    feature_auto_claude(config)
+    assert config['_shell_cmd_prefix'] == 'dax-preview & '
+    assert config['_final_exec'] == "tmux new-session -n myproject claude"
 
 
 def test_find_preview_port_is_deterministic():


### PR DESCRIPTION
## Summary
- The `claude` wrapper now renames the current tmux window to the current directory's basename whenever it's running inside a tmux pane (`$TMUX` set). No flag needed — it's a no-op outside tmux, and fires on every `claude` launch so the name keeps following you if you `cd` and relaunch in the same window.
- New opt-in feature `auto_claude`: skips the login shell entirely and starts `tmux new-session -n <project> claude` as the container's foreground process instead. Exiting `claude` closes the window, ends the (only) tmux session, ends the container's foreground process, and (`docker run --rm`) tears the container down — no shell left behind, nothing to reattach to, by design.
- Along the way: `feature_webpreview` (baseline, always on) already owned "what does the foreground process do" to launch `dax-preview &` first. Split that into `_shell_cmd_prefix` (background setup) and `_final_exec` (the actual foreground command) so `auto_claude` composes with it instead of silently dropping the background launcher when both are active.

## Test plan
- [x] `python3 -m pytest -q` — 533 passed
- [x] Live dry-run (`dax -t run`) with `features: [auto_claude]` — confirms the assembled docker command carries `-c DAX_PREVIEW_PORT=... dax-preview & exec tmux new-session -n <project> claude`, proving the composition rather than a clobber
- [x] Wrapper tests run the real script via subprocess (existing harness, extended with a `tmux` stub) — confirm the rename fires only when `$TMUX` is set, uses the right directory name, and never blocks the actual `claude` launch
- [ ] Manual, needs an image rebuild first (the wrapper is baked into the image at build time): confirm the rename is visible in a real tmux session, and that a real `auto_claude` container tears itself down cleanly on `claude` exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)